### PR TITLE
Use seeded random in infer from samples tests

### DIFF
--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -168,8 +168,8 @@ public class BetaVertexTest {
         alphaBeta.add(new ConstantDoubleVertex(trueBeta));
 
         List<DoubleVertex> latentAlphaBeta = new ArrayList<>();
-        latentAlphaBeta.add(new SmoothUniformVertex(0.01, 10.0));
-        latentAlphaBeta.add(new SmoothUniformVertex(0.01, 10.0));
+        latentAlphaBeta.add(new SmoothUniformVertex(0.01, 10.0, random));
+        latentAlphaBeta.add(new SmoothUniformVertex(0.01, 10.0, random));
 
         VertexVariationalMAPTest.inferHyperParamsFromSamples(
                 hyperParams -> new BetaVertex(hyperParams.get(0), hyperParams.get(1), random),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -151,7 +151,7 @@ public class ExponentialVertexTest {
 
         List<DoubleVertex> latentAB = new ArrayList<>();
         latentAB.add(A);
-        latentAB.add(new SmoothUniformVertex(0.01, 10.0));
+        latentAB.add(new SmoothUniformVertex(0.01, 10.0, random));
 
         VertexVariationalMAPTest.inferHyperParamsFromSamples(
                 hyperParams -> new ExponentialVertex(hyperParams.get(0), hyperParams.get(1), random),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -223,8 +223,8 @@ public class GammaVertexTest {
 
         List<DoubleVertex> latentAThetaK = new ArrayList<>();
         latentAThetaK.add(a);
-        latentAThetaK.add(new SmoothUniformVertex(0.01, 10.0));
-        latentAThetaK.add(new SmoothUniformVertex(0.01, 10.0));
+        latentAThetaK.add(new SmoothUniformVertex(0.01, 10.0, random));
+        latentAThetaK.add(new SmoothUniformVertex(0.01, 10.0, random));
 
         VertexVariationalMAPTest.inferHyperParamsFromSamples(
                 hyperParams -> new GammaVertex(hyperParams.get(0), hyperParams.get(1), hyperParams.get(2), random),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -164,8 +164,8 @@ public class GaussianVertexTest {
         muSigma.add(new ConstantDoubleVertex(trueSigma));
 
         List<DoubleVertex> latentMuSigma = new ArrayList<>();
-        latentMuSigma.add(new SmoothUniformVertex(0.01, 10.0));
-        latentMuSigma.add(new SmoothUniformVertex(0.01, 10.0));
+        latentMuSigma.add(new SmoothUniformVertex(0.01, 10.0, random));
+        latentMuSigma.add(new SmoothUniformVertex(0.01, 10.0, random));
 
         VertexVariationalMAPTest.inferHyperParamsFromSamples(
                 hyperParams -> new GaussianVertex(hyperParams.get(0), hyperParams.get(1), random),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -165,8 +165,8 @@ public class LogisticVertexTest {
         AB.add(new ConstantDoubleVertex(trueB));
 
         List<DoubleVertex> latentAB = new ArrayList<>();
-        latentAB.add(new SmoothUniformVertex(0.01, 10.0));
-        latentAB.add(new SmoothUniformVertex(0.01, 10.0));
+        latentAB.add(new SmoothUniformVertex(0.01, 10.0, random));
+        latentAB.add(new SmoothUniformVertex(0.01, 10.0, random));
 
         VertexVariationalMAPTest.inferHyperParamsFromSamples(
                 hyperParams -> new LogisticVertex(hyperParams.get(0), hyperParams.get(1), random),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformTest.java
@@ -28,7 +28,7 @@ public class SmoothUniformTest {
     public void optimizerMovesAwayFromLeftShoulder() {
 
         A = new SmoothUniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1000.), 0.05, random);
-        B = new SmoothUniformVertex(0, 1000);
+        B = new SmoothUniformVertex(0, 1000, random);
         C = A.plus(B);
         CObserved = new GaussianVertex(C, 0.2);
 


### PR DESCRIPTION
This PR locks down the infer from samples such that they always return the same result.