### PR TITLE
Allow casting of any Number to a DoubleVertex

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -5,27 +5,27 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 
 public class CastDoubleVertex extends NonProbabilisticDouble {
 
-    private final Vertex<Double> inputVertex;
+    private final Vertex<? extends Number> inputVertex;
 
-    public CastDoubleVertex(Vertex<Double> inputVertex) {
+    public CastDoubleVertex(Vertex<? extends Number> inputVertex) {
         this.inputVertex = inputVertex;
         setParents(inputVertex);
     }
 
     @Override
     public Double sample() {
-        return inputVertex.sample();
+        return inputVertex.sample().doubleValue();
     }
 
     @Override
     public Double lazyEval() {
-        setValue(inputVertex.lazyEval());
+        setValue(inputVertex.lazyEval().doubleValue());
         return getValue();
     }
 
     @Override
     public Double getDerivedValue() {
-        return inputVertex.getValue();
+        return inputVertex.getValue().doubleValue();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -30,6 +30,6 @@ public class CastDoubleVertex extends NonProbabilisticDouble {
 
     @Override
     public DualNumber getDualNumber() {
-        return new DualNumber(inputVertex.getValue(), inputVertex.getId());
+        throw new UnsupportedOperationException("CastDoubleVertex is non-differentiable");
     }
 }


### PR DESCRIPTION
This PR relaxes the requirements for DoubleVertex casting. Any Number can now be casted to an DoubleVertex. However, this operation is non-differentiable and throws an exception is a dual number calculation is requested.