### PR TITLE
Improve error message when using MCMC

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -36,6 +36,7 @@ public class MetropolisHastings {
 
         Map<String, List<?>> samplesByVertex = new HashMap<>();
         List<? extends Vertex<?>> latentVertices = bayesNet.getLatentVertices();
+        assert (latentVertices.size() > 0) : "Error: Cannot sample from a completely deterministic graph.";
         Map<Vertex<?>, Set<Vertex<?>>> affectedVerticesCache = getVerticesAffectedByLatents(latentVertices);
 
         Map<String, Map<String, Long>> setAndCascadeCache = new HashMap<>();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -30,13 +30,10 @@ public class MetropolisHastings {
                                                      final List<? extends Vertex<?>> fromVertices,
                                                      final int sampleCount,
                                                      final Random random) {
-        if (bayesNet.isInImpossibleState()) {
-            throw new RuntimeException("Cannot start optimizer on zero probability network");
-        }
-
+        checkBayesNetInHealthyState(bayesNet);
         Map<String, List<?>> samplesByVertex = new HashMap<>();
         List<? extends Vertex<?>> latentVertices = bayesNet.getLatentVertices();
-        assert (latentVertices.size() > 0) : "Error: Cannot sample from a completely deterministic graph.";
+
         Map<Vertex<?>, Set<Vertex<?>>> affectedVerticesCache = getVerticesAffectedByLatents(latentVertices);
 
         Map<String, Map<String, Long>> setAndCascadeCache = new HashMap<>();
@@ -114,6 +111,14 @@ public class MetropolisHastings {
     private static <T> void addSampleForVertex(Vertex<T> vertex, Map<String, List<?>> samples) {
         List<T> samplesForVertex = (List<T>) samples.computeIfAbsent(vertex.getId(), v -> new ArrayList<T>());
         samplesForVertex.add(vertex.getValue());
+    }
+
+    private static void checkBayesNetInHealthyState(BayesNet bayesNet) {
+        if (bayesNet.getVerticesThatContributeToMasterP().size() == 0) {
+            throw new IllegalArgumentException("Cannot sample from a completely deterministic BayesNet");
+        } else if (bayesNet.isInImpossibleState()) {
+            throw new RuntimeException("Cannot start optimizer on zero probability network");
+        }
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -31,9 +31,9 @@ public class MetropolisHastings {
                                                      final int sampleCount,
                                                      final Random random) {
         checkBayesNetInHealthyState(bayesNet);
+        
         Map<String, List<?>> samplesByVertex = new HashMap<>();
         List<? extends Vertex<?>> latentVertices = bayesNet.getLatentVertices();
-
         Map<Vertex<?>, Set<Vertex<?>>> affectedVerticesCache = getVerticesAffectedByLatents(latentVertices);
 
         Map<String, Map<String, Long>> setAndCascadeCache = new HashMap<>();


### PR DESCRIPTION
The current error message experienced when trying to sample with MCMC from a graph that does not have any probabilistic vertices is a cryptic enigma wrapped in a mystery: `Exception in thread "main" java.lang.ArithmeticException: / by zero`.

Let's make this a bit more clear.