### PR TITLE
Generalise Constructors

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
@@ -37,7 +37,7 @@ public class ArcTan2Vertex extends DoubleBinaryOpVertex {
         double denominator = (Math.pow(b.getValue(), 2) * Math.pow(a.getValue(), 2));
 
         Infinitesimal thisInfA = aDual.getInfinitesimal().multiplyBy(b.getValue() / denominator);
-        Infinitesimal thisInfB = bDual.getInfinitesimal().multiplyBy(- (a.getValue() / denominator));
+        Infinitesimal thisInfB = bDual.getInfinitesimal().multiplyBy(-(a.getValue() / denominator));
         Infinitesimal newInf = thisInfA.add(thisInfB);
         return new DualNumber(op(a.getValue(), b.getValue()), newInf);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
@@ -15,7 +15,7 @@ public class PowerVertex extends DoubleBinaryOpVertex {
     }
 
     public PowerVertex(double a, DoubleVertex b) {
-        this (new ConstantDoubleVertex(a), b);
+        this(new ConstantDoubleVertex(a), b);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.Beta;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
 
 import java.util.Map;
@@ -20,8 +21,32 @@ public class BetaVertex extends ProbabilisticDouble {
         setParents(alpha, beta);
     }
 
+    public BetaVertex(DoubleVertex alpha, double beta, Random random) {
+        this(alpha, new ConstantDoubleVertex(beta), random);
+    }
+
+    public BetaVertex(double alpha, DoubleVertex beta, Random random) {
+        this(new ConstantDoubleVertex(alpha), beta, random);
+    }
+
+    public BetaVertex(double alpha, double beta, Random random) {
+        this(new ConstantDoubleVertex(alpha), beta, random);
+    }
+
     public BetaVertex(DoubleVertex alpha, DoubleVertex beta) {
         this(alpha, beta, new Random());
+    }
+
+    public BetaVertex(DoubleVertex alpha, double beta) {
+        this(alpha, new ConstantDoubleVertex(beta), new Random());
+    }
+
+    public BetaVertex(double alpha, DoubleVertex beta) {
+        this(new ConstantDoubleVertex(alpha), beta, new Random());
+    }
+
+    public BetaVertex(double alpha, double beta) {
+        this(new ConstantDoubleVertex(alpha), beta, new Random());
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -19,6 +19,14 @@ public class ChiSquaredVertex extends ProbabilisticDouble {
         setParents(k);
     }
 
+    public ChiSquaredVertex(IntegerVertex k) {
+        this(k, new Random());
+    }
+
+    public ChiSquaredVertex(int k, Random random) {
+        this(new ConstantIntegerVertex(k), random);
+    }
+
     public ChiSquaredVertex(int k) {
         this(new ConstantIntegerVertex(k), new Random());
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -21,32 +21,32 @@ public class ExponentialVertex extends ProbabilisticDouble {
         setParents(a, b);
     }
 
-    public ExponentialVertex(DoubleVertex a, DoubleVertex b) {
-        this(a, b, new Random());
-    }
-
-    public ExponentialVertex(double a, double b) {
-        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), new Random());
-    }
-
-    public ExponentialVertex(double a, DoubleVertex b) {
-        this(new ConstantDoubleVertex(a), b, new Random());
-    }
-
-    public ExponentialVertex(DoubleVertex a, double b) {
-        this(a, new ConstantDoubleVertex(b), new Random());
-    }
-
-    public ExponentialVertex(double a, double b, Random random) {
-        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), random);
+    public ExponentialVertex(DoubleVertex a, double b, Random random) {
+        this(a, new ConstantDoubleVertex(b), random);
     }
 
     public ExponentialVertex(double a, DoubleVertex b, Random random) {
         this(new ConstantDoubleVertex(a), b, random);
     }
 
-    public ExponentialVertex(DoubleVertex a, double b, Random random) {
-        this(a, new ConstantDoubleVertex(b), random);
+    public ExponentialVertex(double a, double b, Random random) {
+        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), random);
+    }
+
+    public ExponentialVertex(DoubleVertex a, DoubleVertex b) {
+        this(a, b, new Random());
+    }
+
+    public ExponentialVertex(DoubleVertex a, double b) {
+        this(a, new ConstantDoubleVertex(b), new Random());
+    }
+
+    public ExponentialVertex(double a, DoubleVertex b) {
+        this(new ConstantDoubleVertex(a), b, new Random());
+    }
+
+    public ExponentialVertex(double a, double b) {
+        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), new Random());
     }
 
     public DoubleVertex getA() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -29,16 +29,36 @@ public class GammaVertex extends ProbabilisticDouble {
         setParents(a, theta, k);
     }
 
-    public GammaVertex(DoubleVertex a, DoubleVertex theta, DoubleVertex k) {
-        this(a, theta, k, new Random());
+    public GammaVertex(DoubleVertex theta, double k, Random random) {
+        this(new ConstantDoubleVertex(0.0), theta, new ConstantDoubleVertex(k), random);
     }
 
-    public GammaVertex(DoubleVertex theta, DoubleVertex k, Random random) {
-        this(new ConstantDoubleVertex(0.0), theta, k, random);
+    public GammaVertex(double theta, DoubleVertex k, Random random) {
+        this(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(theta), k, random);
+    }
+
+    public GammaVertex(double theta, double k, Random random) {
+        this(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(theta), new ConstantDoubleVertex(k), random);
     }
 
     public GammaVertex(double a, double theta, double k, Random random) {
         this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(theta), new ConstantDoubleVertex(k), random);
+    }
+
+    public GammaVertex(DoubleVertex a, DoubleVertex theta, DoubleVertex k) {
+        this(a, theta, k, new Random());
+    }
+
+    public GammaVertex(DoubleVertex theta, double k) {
+        this(new ConstantDoubleVertex(0.0), theta, new ConstantDoubleVertex(k), new Random());
+    }
+
+    public GammaVertex(double theta, DoubleVertex k) {
+        this(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(theta), k, new Random());
+    }
+
+    public GammaVertex(double theta, double k) {
+        this(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(theta), new ConstantDoubleVertex(k), new Random());
     }
 
     public DoubleVertex getA() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -21,6 +21,18 @@ public class GaussianVertex extends ProbabilisticDouble {
         setParents(mu, sigma);
     }
 
+    public GaussianVertex(DoubleVertex mu, double sigma, Random random) {
+        this(mu, new ConstantDoubleVertex(sigma), random);
+    }
+
+    public GaussianVertex(double mu, DoubleVertex sigma, Random random) {
+        this(new ConstantDoubleVertex(mu), sigma, random);
+    }
+
+    public GaussianVertex(double mu, double sigma, Random random) {
+        this(new ConstantDoubleVertex(mu), new ConstantDoubleVertex(sigma), random);
+    }
+
     public GaussianVertex(DoubleVertex mu, DoubleVertex sigma) {
         this(mu, sigma, new Random());
     }
@@ -37,17 +49,6 @@ public class GaussianVertex extends ProbabilisticDouble {
         this(mu, new ConstantDoubleVertex(sigma), new Random());
     }
 
-    public GaussianVertex(double mu, double sigma, Random random) {
-        this(new ConstantDoubleVertex(mu), new ConstantDoubleVertex(sigma), random);
-    }
-
-    public GaussianVertex(double mu, DoubleVertex sigma, Random random) {
-        this(new ConstantDoubleVertex(mu), sigma, random);
-    }
-
-    public GaussianVertex(DoubleVertex mu, double sigma, Random random) {
-        this(mu, new ConstantDoubleVertex(sigma), random);
-    }
 
     public DoubleVertex getMu() {
         return mu;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -22,20 +22,32 @@ public class InverseGammaVertex extends ProbabilisticDouble {
         setParents(a, b);
     }
 
-    public InverseGammaVertex(DoubleVertex a, DoubleVertex b) {
-        this(a, b, new Random());
-    }
-
-    public InverseGammaVertex(double a, double b, Random random) {
-        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), random);
-    }
-
     public InverseGammaVertex(DoubleVertex a, double b, Random random) {
         this(a, new ConstantDoubleVertex(b), random);
     }
 
     public InverseGammaVertex(double a, DoubleVertex b, Random random) {
         this(new ConstantDoubleVertex(a), b, random);
+    }
+
+    public InverseGammaVertex(double a, double b, Random random) {
+        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), random);
+    }
+
+    public InverseGammaVertex(DoubleVertex a, DoubleVertex b) {
+        this(a, b, new Random());
+    }
+
+    public InverseGammaVertex(DoubleVertex a, double b) {
+        this(a, new ConstantDoubleVertex(b), new Random());
+    }
+
+    public InverseGammaVertex(double a, DoubleVertex b) {
+        this(new ConstantDoubleVertex(a), b, new Random());
+    }
+
+    public InverseGammaVertex(double a, double b) {
+        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), new Random());
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -21,12 +21,28 @@ public class LaplaceVertex extends ProbabilisticDouble {
         setParents(mu, beta);
     }
 
-    public LaplaceVertex(DoubleVertex mu, DoubleVertex beta) {
-        this(mu, beta, new Random());
+    public LaplaceVertex(DoubleVertex mu, double beta, Random random) {
+        this(mu, new ConstantDoubleVertex(beta), random);
+    }
+
+    public LaplaceVertex(double mu, DoubleVertex beta, Random random) {
+        this(new ConstantDoubleVertex(mu), beta, random);
     }
 
     public LaplaceVertex(double mu, double beta, Random random) {
         this(new ConstantDoubleVertex(mu), new ConstantDoubleVertex(beta), random);
+    }
+
+    public LaplaceVertex(DoubleVertex mu, DoubleVertex beta) {
+        this(mu, beta, new Random());
+    }
+
+    public LaplaceVertex(DoubleVertex mu, double beta) {
+        this(mu, new ConstantDoubleVertex(beta), new Random());
+    }
+
+    public LaplaceVertex(double mu, DoubleVertex beta) {
+        this(new ConstantDoubleVertex(mu), beta, new Random());
     }
 
     public LaplaceVertex(double mu, double beta) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -21,32 +21,32 @@ public class LogisticVertex extends ProbabilisticDouble {
         setParents(a, b);
     }
 
-    public LogisticVertex(DoubleVertex a, DoubleVertex b) {
-        this(a, b, new Random());
-    }
-
-    public LogisticVertex(double a, double b) {
-        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), new Random());
-    }
-
-    public LogisticVertex(double a, DoubleVertex b) {
-        this(new ConstantDoubleVertex(a), b, new Random());
-    }
-
-    public LogisticVertex(DoubleVertex a, double b) {
-        this(a, new ConstantDoubleVertex(b), new Random());
-    }
-
-    public LogisticVertex(double a, double b, Random random) {
-        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), random);
+    public LogisticVertex(DoubleVertex a, double b, Random random) {
+        this(a, new ConstantDoubleVertex(b), random);
     }
 
     public LogisticVertex(double a, DoubleVertex b, Random random) {
         this(new ConstantDoubleVertex(a), b, random);
     }
 
-    public LogisticVertex(DoubleVertex a, double b, Random random) {
-        this(a, new ConstantDoubleVertex(b), random);
+    public LogisticVertex(double a, double b, Random random) {
+        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), random);
+    }
+
+    public LogisticVertex(DoubleVertex a, DoubleVertex b) {
+        this(a, b, new Random());
+    }
+
+    public LogisticVertex(DoubleVertex a, double b) {
+        this(a, new ConstantDoubleVertex(b), new Random());
+    }
+
+    public LogisticVertex(double a, DoubleVertex b) {
+        this(new ConstantDoubleVertex(a), b, new Random());
+    }
+
+    public LogisticVertex(double a, double b) {
+        this(new ConstantDoubleVertex(a), new ConstantDoubleVertex(b), new Random());
     }
 
     public DoubleVertex getA() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -26,16 +26,32 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
         setParents(xMin, xMax);
     }
 
-    public SmoothUniformVertex(DoubleVertex xMin, DoubleVertex xMax) {
-        this(xMin, xMax, DEFAULT_EDGE_SHARPNESS, new Random());
+    public SmoothUniformVertex(DoubleVertex xMin, double xMax, Random random) {
+        this(xMin, new ConstantDoubleVertex(xMax), DEFAULT_EDGE_SHARPNESS, random);
+    }
+
+    public SmoothUniformVertex(double xMin, DoubleVertex xMax, Random random) {
+        this(new ConstantDoubleVertex(xMin), xMax, DEFAULT_EDGE_SHARPNESS, random);
     }
 
     public SmoothUniformVertex(double xMin, double xMax, Random random) {
         this(new ConstantDoubleVertex(xMin), new ConstantDoubleVertex(xMax), DEFAULT_EDGE_SHARPNESS, random);
     }
 
+    public SmoothUniformVertex(DoubleVertex xMin, DoubleVertex xMax) {
+        this(xMin, xMax, DEFAULT_EDGE_SHARPNESS, new Random());
+    }
+
+    public SmoothUniformVertex(DoubleVertex xMin, double xMax) {
+        this(xMin, new ConstantDoubleVertex(xMax), DEFAULT_EDGE_SHARPNESS, new Random());
+    }
+
+    public SmoothUniformVertex(double xMin, DoubleVertex xMax) {
+        this(new ConstantDoubleVertex(xMin), xMax, DEFAULT_EDGE_SHARPNESS, new Random());
+    }
+
     public SmoothUniformVertex(double xMin, double xMax) {
-        this(xMin, xMax, new Random());
+        this(new ConstantDoubleVertex(xMin), new ConstantDoubleVertex(xMax), DEFAULT_EDGE_SHARPNESS, new Random());
     }
 
     public DoubleVertex getXMin() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.Triangular;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 
 import java.util.Map;
 import java.util.Random;
@@ -21,8 +22,60 @@ public class TriangularVertex extends ProbabilisticDouble {
         setParents(xMin, xMax, c);
     }
 
-    public TriangularVertex(DoubleVertex xMin, DoubleVertex xMax, DoubleVertex c) {
-        this(xMin, xMax, c, new Random());
+    public TriangularVertex(DoubleVertex xMin, DoubleVertex xMax, double c, Random random) {
+        this(xMin, xMax, new ConstantDoubleVertex(c), random);
+    }
+
+    public TriangularVertex(DoubleVertex xMin, double xMax, DoubleVertex c, Random random) {
+        this(xMin, new ConstantDoubleVertex(xMax), c, random);
+    }
+
+    public TriangularVertex(double xMin, DoubleVertex xMax, DoubleVertex c, Random random) {
+        this(new ConstantDoubleVertex(xMin), xMax, c, random);
+    }
+
+    public TriangularVertex(DoubleVertex xMin, double xMax, double c, Random random) {
+        this(xMin, new ConstantDoubleVertex(xMax), new ConstantDoubleVertex(c), random);
+    }
+
+    public TriangularVertex(double xMin, DoubleVertex xMax, double c, Random random) {
+        this(new ConstantDoubleVertex(xMin), xMax, c, random);
+    }
+
+    public TriangularVertex(double xMin, double xMax, DoubleVertex c, Random random) {
+        this(new ConstantDoubleVertex(xMin), new ConstantDoubleVertex(xMax), c, random);
+    }
+
+    public TriangularVertex(double xMin, double xMax, double c, Random random) {
+        this(new ConstantDoubleVertex(xMin), new ConstantDoubleVertex(xMax), new ConstantDoubleVertex(c), random);
+    }
+
+    public TriangularVertex(DoubleVertex xMin, DoubleVertex xMax, double c) {
+        this(xMin, xMax, new ConstantDoubleVertex(c), new Random());
+    }
+
+    public TriangularVertex(DoubleVertex xMin, double xMax, DoubleVertex c) {
+        this(xMin, new ConstantDoubleVertex(xMax), c, new Random());
+    }
+
+    public TriangularVertex(double xMin, DoubleVertex xMax, DoubleVertex c) {
+        this(new ConstantDoubleVertex(xMin), xMax, c, new Random());
+    }
+
+    public TriangularVertex(DoubleVertex xMin, double xMax, double c) {
+        this(xMin, new ConstantDoubleVertex(xMax), new ConstantDoubleVertex(c), new Random());
+    }
+
+    public TriangularVertex(double xMin, DoubleVertex xMax, double c) {
+        this(new ConstantDoubleVertex(xMin), xMax, c, new Random());
+    }
+
+    public TriangularVertex(double xMin, double xMax, DoubleVertex c) {
+        this(new ConstantDoubleVertex(xMin), new ConstantDoubleVertex(xMax), c, new Random());
+    }
+
+    public TriangularVertex(double xMin, double xMax, double c) {
+        this(new ConstantDoubleVertex(xMin), new ConstantDoubleVertex(xMax), new ConstantDoubleVertex(c), new Random());
     }
 
     public DoubleVertex getXMin() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -22,12 +22,28 @@ public class UniformVertex extends ProbabilisticDouble {
         setParents(xMin, xMax);
     }
 
-    public UniformVertex(DoubleVertex xMin, DoubleVertex xMax) {
-        this(xMin, xMax, new Random());
+    public UniformVertex(DoubleVertex xMin, double xMax, Random random) {
+        this(xMin, new ConstantDoubleVertex(xMax), random);
+    }
+
+    public UniformVertex(double xMin, DoubleVertex xMax, Random random) {
+        this(new ConstantDoubleVertex(xMin), xMax, random);
     }
 
     public UniformVertex(double xMin, double xMax, Random random) {
         this(new ConstantDoubleVertex(xMin), new ConstantDoubleVertex(xMax), random);
+    }
+
+    public UniformVertex(DoubleVertex xMin, DoubleVertex xMax) {
+        this(xMin, xMax, new Random());
+    }
+
+    public UniformVertex(DoubleVertex xMin, double xMax) {
+        this(xMin, xMax, new Random());
+    }
+
+    public UniformVertex(double xMin, DoubleVertex xMax) {
+        this(new ConstantDoubleVertex(xMin), xMax, new Random());
     }
 
     public UniformVertex(double xMin, double xMax) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import io.improbable.keanu.distributions.discrete.Poisson;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 
 import java.util.Map;
@@ -10,9 +11,9 @@ import java.util.Random;
 public class PoissonVertex extends ProbabilisticInteger {
 
     private final Random random;
-    private final Vertex<Double> mu;
+    private final DoubleVertex mu;
 
-    public PoissonVertex(Vertex<Double> mu, Random random) {
+    public PoissonVertex(DoubleVertex mu, Random random) {
         this.mu = mu;
         this.random = random;
         setParents(mu);
@@ -20,6 +21,14 @@ public class PoissonVertex extends ProbabilisticInteger {
 
     public PoissonVertex(double mu, Random random) {
         this(new ConstantDoubleVertex(mu), random);
+    }
+
+    public PoissonVertex(DoubleVertex mu) {
+        this(mu, new Random());
+    }
+
+    public PoissonVertex(double mu) {
+        this(new ConstantDoubleVertex(mu), new Random());
     }
 
     public Vertex<Double> getMu() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -9,26 +9,26 @@ import java.util.Random;
 
 public class UniformIntVertex extends ProbabilisticInteger {
 
-    private IntegerVertex min;
-    private IntegerVertex max;
+    private Vertex<Integer> min;
+    private Vertex<Integer> max;
     private Random random;
 
     /**
      * @param min The inclusive lower bound.
      * @param max The exclusive upper bound.
      */
-    public UniformIntVertex(IntegerVertex min, IntegerVertex max, Random random) {
+    public UniformIntVertex(Vertex<Integer> min, Vertex<Integer> max, Random random) {
         this.min = min;
         this.max = max;
         this.random = random;
         setParents(min, max);
     }
 
-    public UniformIntVertex(IntegerVertex min, int max, Random random) {
+    public UniformIntVertex(Vertex<Integer> min, int max, Random random) {
         this(min, new ConstantIntegerVertex(max), new Random());
     }
 
-    public UniformIntVertex(int min, IntegerVertex max, Random random) {
+    public UniformIntVertex(int min, Vertex<Integer> max, Random random) {
         this(new ConstantIntegerVertex(min), max, new Random());
     }
 
@@ -36,15 +36,15 @@ public class UniformIntVertex extends ProbabilisticInteger {
         this(new ConstantIntegerVertex(min), new ConstantIntegerVertex(max), random);
     }
 
-    public UniformIntVertex(IntegerVertex min, IntegerVertex max) {
+    public UniformIntVertex(Vertex<Integer> min, Vertex<Integer> max) {
         this(min, max, new Random());
     }
 
-    public UniformIntVertex(IntegerVertex min, int max) {
+    public UniformIntVertex(Vertex<Integer> min, int max) {
         this(min, new ConstantIntegerVertex(max), new Random());
     }
 
-    public UniformIntVertex(int min, IntegerVertex max) {
+    public UniformIntVertex(int min, Vertex<Integer> max) {
         this(new ConstantIntegerVertex(min), max, new Random());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 
 import java.util.Map;
@@ -8,33 +9,45 @@ import java.util.Random;
 
 public class UniformIntVertex extends ProbabilisticInteger {
 
-    private Vertex<Integer> min;
-    private Vertex<Integer> max;
+    private IntegerVertex min;
+    private IntegerVertex max;
     private Random random;
 
     /**
      * @param min The inclusive lower bound.
      * @param max The exclusive upper bound.
      */
-    public UniformIntVertex(Vertex<Integer> min, Vertex<Integer> max, Random random) {
+    public UniformIntVertex(IntegerVertex min, IntegerVertex max, Random random) {
         this.min = min;
         this.max = max;
         this.random = random;
         setParents(min, max);
     }
 
-    /**
-     * @param min The inclusive lower max.
-     * @param max The exclusive upper max.
-     */
-    public UniformIntVertex(Vertex<Integer> min, Vertex<Integer> max) {
+    public UniformIntVertex(IntegerVertex min, int max, Random random) {
+        this(min, new ConstantIntegerVertex(max), new Random());
+    }
+
+    public UniformIntVertex(int min, IntegerVertex max, Random random) {
+        this(new ConstantIntegerVertex(min), max, new Random());
+    }
+
+    public UniformIntVertex(int min, int max, Random random) {
+        this(new ConstantIntegerVertex(min), new ConstantIntegerVertex(max), random);
+    }
+
+    public UniformIntVertex(IntegerVertex min, IntegerVertex max) {
         this(min, max, new Random());
     }
 
-    /**
-     * @param min The inclusive lower max.
-     * @param max The exclusive upper max.
-     */
+    public UniformIntVertex(IntegerVertex min, int max) {
+        this(min, new ConstantIntegerVertex(max), new Random());
+    }
+
+    public UniformIntVertex(int min, IntegerVertex max) {
+        this(new ConstantIntegerVertex(min), max, new Random());
+    }
+
     public UniformIntVertex(int min, int max) {
         this(new ConstantIntegerVertex(min), new ConstantIntegerVertex(max));
     }


### PR DESCRIPTION
Alex Sparrow raised the point that there is a large amount of inconsistency across the constructors of Vertices.

Some allow you to pass in only `DoubleVertex's` as arguments, some allow double's, some allow a mix of the two and some allow you to pass in a random and some create a random for you. There's quite a large mix. This is largely my fault as I've been creating them without giving them much thought. 

This seeks to generalise this across the board and hopefully give new Vertices some structure to follow. 