### PR TITLE
Dual Number performance fix

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 
 public abstract class DoubleVertex extends Vertex<Double> implements DoubleOperators<DoubleVertex> {
 
-    public abstract DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap);
+    public abstract DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap);
 
     public DualNumber getDualNumber() {
         Map<Vertex, DualNumber> dualNumbers = new HashMap();
@@ -33,18 +33,20 @@ public abstract class DoubleVertex extends Vertex<Double> implements DoubleOpera
             DoubleVertex head = stack.peek();
             Set<Vertex<?>> parentsThatAreNotYetCalculated = parentsThatAreNotCalculated(dualNumbers, head.getParents());
 
-            //if parents have their dual numbers calculated
             if (parentsThatAreNotYetCalculated.isEmpty()) {
-                //calculate dual number based on parents dual
+
                 DoubleVertex top = stack.pop();
-                DualNumber dual = top.calcDualNumber(dualNumbers);
+                DualNumber dual = top.calculateDualNumber(dualNumbers);
                 dualNumbers.put(top, dual);
 
             } else {
 
                 for (Vertex<?> vertex : parentsThatAreNotYetCalculated) {
-                    //Throw error if not DoubleVertex
-                    stack.push((DoubleVertex) vertex);
+                    if (vertex instanceof DoubleVertex) {
+                        stack.push((DoubleVertex) vertex);
+                    } else {
+                        throw new RuntimeException("Can only calculate Dual Numbers on a graph made of Double's");
+                    }
                 }
 
             }
@@ -113,7 +115,7 @@ public abstract class DoubleVertex extends Vertex<Double> implements DoubleOpera
         return new AbsVertex(this);
     }
 
-    public DoubleVertex lambda(Function<Double, Double> op, Supplier<DualNumber> dualNumberSupplier) {
+    public DoubleVertex lambda(Function<Double, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier) {
         return new DoubleUnaryOpLambda<>(this, op, dualNumberSupplier);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -17,7 +17,6 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleU
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public abstract class DoubleVertex extends Vertex<Double> implements DoubleOperators<DoubleVertex> {
 
@@ -37,9 +36,9 @@ public abstract class DoubleVertex extends Vertex<Double> implements DoubleOpera
         while (!stack.isEmpty()) {
 
             DoubleVertex head = stack.peek();
-            Set<Vertex<?>> parentsThatAreNotYetCalculated = parentsThatAreNotCalculated(dualNumbers, head.getParents());
+            Set<Vertex<?>> parentsThatDualNumberIsNotCalculated = parentsThatDualNumberIsNotCalculated(dualNumbers, head.getParents());
 
-            if (parentsThatAreNotYetCalculated.isEmpty()) {
+            if (parentsThatDualNumberIsNotCalculated.isEmpty()) {
 
                 DoubleVertex top = stack.pop();
                 DualNumber dual = top.calculateDualNumber(dualNumbers);
@@ -47,7 +46,7 @@ public abstract class DoubleVertex extends Vertex<Double> implements DoubleOpera
 
             } else {
 
-                for (Vertex<?> vertex : parentsThatAreNotYetCalculated) {
+                for (Vertex<?> vertex : parentsThatDualNumberIsNotCalculated) {
                     if (vertex instanceof DoubleVertex) {
                         stack.push((DoubleVertex) vertex);
                     } else {
@@ -172,7 +171,7 @@ public abstract class DoubleVertex extends Vertex<Double> implements DoubleOpera
         return new ArcCosVertex(this);
     }
 
-    private Set<Vertex<?>> parentsThatAreNotCalculated(Map<Vertex, DualNumber> dualNumbers, Set<Vertex<?>> parents) {
+    private Set<Vertex<?>> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, Set<Vertex<?>> parents) {
         Set<Vertex<?>> notCalculatedParents = new HashSet<>();
         for (Vertex<?> next : parents) {
             if (!dualNumbers.containsKey(next)){

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 
 public abstract class DoubleVertex extends Vertex<Double> implements DoubleOperators<DoubleVertex> {
 
-    public abstract DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap);
+    public abstract DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers);
 
     public DualNumber getDualNumber() {
         Map<Vertex, DualNumber> dualNumbers = new HashMap();
@@ -45,7 +45,7 @@ public abstract class DoubleVertex extends Vertex<Double> implements DoubleOpera
                     if (vertex instanceof DoubleVertex) {
                         stack.push((DoubleVertex) vertex);
                     } else {
-                        throw new RuntimeException("Can only calculate Dual Numbers on a graph made of Double's");
+                        throw new RuntimeException("Can only calculate Dual Numbers on a graph made of Doubles");
                     }
                 }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -21,6 +21,12 @@ import java.util.function.Supplier;
 
 public abstract class DoubleVertex extends Vertex<Double> implements DoubleOperators<DoubleVertex> {
 
+    /**
+     * Calculate the Dual Number of a DoubleVertex.
+     *
+     * @param dualNumbers A Map that is guaranteed to contain the Dual Numbers of the parent of the vertex.
+     * @return The Dual Number of the vertex.
+     */
     public abstract DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers);
 
     public DualNumber getDualNumber() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -115,8 +115,8 @@ public abstract class DoubleVertex extends Vertex<Double> implements DoubleOpera
         return new AbsVertex(this);
     }
 
-    public DoubleVertex lambda(Function<Double, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier) {
-        return new DoubleUnaryOpLambda<>(this, op, dualNumberSupplier);
+    public DoubleVertex lambda(Function<Double, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberCalculation) {
+        return new DoubleUnaryOpLambda<>(this, op, dualNumberCalculation);
     }
 
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -25,7 +25,7 @@ public class CastDoubleVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException("CastDoubleVertex is non-differentiable");
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -25,7 +25,7 @@ public class CastDoubleVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         throw new UnsupportedOperationException("CastDoubleVertex is non-differentiable");
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -3,6 +3,8 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 
+import java.util.Map;
+
 public class CastDoubleVertex extends NonProbabilisticDouble {
 
     private final Vertex<? extends Number> inputVertex;
@@ -23,7 +25,7 @@ public class CastDoubleVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         throw new UnsupportedOperationException("CastDoubleVertex is non-differentiable");
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
@@ -14,7 +14,7 @@ public class ConstantDoubleVertex extends NonProbabilisticDouble implements Cons
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return new DualNumber(getValue(), Collections.emptyMap());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
@@ -1,9 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
 import io.improbable.keanu.vertices.Constant;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 
 import java.util.Collections;
+import java.util.Map;
 
 public class ConstantDoubleVertex extends NonProbabilisticDouble implements Constant<Double> {
 
@@ -12,7 +14,7 @@ public class ConstantDoubleVertex extends NonProbabilisticDouble implements Cons
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return new DualNumber(getValue(), Collections.emptyMap());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
@@ -14,7 +14,7 @@ public class ConstantDoubleVertex extends NonProbabilisticDouble implements Cons
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return new DualNumber(getValue(), Collections.emptyMap());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertex.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 public class AdditionVertex extends DoubleBinaryOpVertex {
 
@@ -10,9 +13,9 @@ public class AdditionVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        final DualNumber aDual = a.getDualNumber();
-        final DualNumber bDual = b.getDualNumber();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        final DualNumber aDual = dualNumberMap.get(a);
+        final DualNumber bDual = dualNumberMap.get(b);
         return aDual.add(bDual);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertex.java
@@ -13,7 +13,7 @@ public class AdditionVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         final DualNumber aDual = dualNumberMap.get(a);
         final DualNumber bDual = dualNumberMap.get(b);
         return aDual.add(bDual);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertex.java
@@ -13,9 +13,9 @@ public class AdditionVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        final DualNumber aDual = dualNumberMap.get(a);
-        final DualNumber bDual = dualNumberMap.get(b);
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        final DualNumber aDual = dualNumbers.get(a);
+        final DualNumber bDual = dualNumbers.get(b);
         return aDual.add(bDual);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
@@ -1,10 +1,13 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpVertex;
+
+import java.util.Map;
 
 public class ArcTan2Vertex extends DoubleBinaryOpVertex {
 
@@ -30,9 +33,9 @@ public class ArcTan2Vertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        DualNumber aDual = a.getDualNumber();
-        DualNumber bDual = b.getDualNumber();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        DualNumber aDual = dualNumberMap.get(a);
+        DualNumber bDual = dualNumberMap.get(b);
 
         double denominator = (Math.pow(b.getValue(), 2) * Math.pow(a.getValue(), 2));
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
@@ -33,9 +33,9 @@ public class ArcTan2Vertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        DualNumber aDual = dualNumberMap.get(a);
-        DualNumber bDual = dualNumberMap.get(b);
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        DualNumber aDual = dualNumbers.get(a);
+        DualNumber bDual = dualNumbers.get(b);
 
         double denominator = (Math.pow(b.getValue(), 2) * Math.pow(a.getValue(), 2));
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
@@ -33,7 +33,7 @@ public class ArcTan2Vertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         DualNumber aDual = dualNumberMap.get(a);
         DualNumber bDual = dualNumberMap.get(b);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DifferenceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DifferenceVertex.java
@@ -13,9 +13,9 @@ public class DifferenceVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        final DualNumber aDual = dualNumberMap.get(a);
-        final DualNumber bDual = dualNumberMap.get(b);
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        final DualNumber aDual = dualNumbers.get(a);
+        final DualNumber bDual = dualNumbers.get(b);
         return aDual.subtract(bDual);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DifferenceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DifferenceVertex.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 public class DifferenceVertex extends DoubleBinaryOpVertex {
 
@@ -10,9 +13,9 @@ public class DifferenceVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        final DualNumber aDual = a.getDualNumber();
-        final DualNumber bDual = b.getDualNumber();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        final DualNumber aDual = dualNumberMap.get(a);
+        final DualNumber bDual = dualNumberMap.get(b);
         return aDual.subtract(bDual);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DifferenceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DifferenceVertex.java
@@ -13,7 +13,7 @@ public class DifferenceVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         final DualNumber aDual = dualNumberMap.get(a);
         final DualNumber bDual = dualNumberMap.get(b);
         return aDual.subtract(bDual);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
@@ -14,7 +14,7 @@ public class DivisionVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         DualNumber aDual = dualNumberMap.get(a);
         DualNumber bDual = dualNumberMap.get(b);
         return aDual.divideBy(bDual);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
@@ -14,9 +14,9 @@ public class DivisionVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        DualNumber aDual = dualNumberMap.get(a);
-        DualNumber bDual = dualNumberMap.get(b);
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        DualNumber aDual = dualNumbers.get(a);
+        DualNumber bDual = dualNumbers.get(b);
         return aDual.divideBy(bDual);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 
 public class DivisionVertex extends DoubleBinaryOpVertex {
@@ -11,9 +14,9 @@ public class DivisionVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        DualNumber aDual = a.getDualNumber();
-        DualNumber bDual = b.getDualNumber();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        DualNumber aDual = dualNumberMap.get(a);
+        DualNumber bDual = dualNumberMap.get(b);
         return aDual.divideBy(bDual);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -14,13 +14,13 @@ public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
     protected final Vertex<A> a;
     protected final Vertex<B> b;
     protected final BiFunction<A, B, Double> op;
-    protected final Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier;
+    protected final Function<Map<Vertex, DualNumber>, DualNumber> dualNumberCalculation;
 
     public DoubleBinaryOpLambda(Vertex<A> a, Vertex<B> b, BiFunction<A, B, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberCalculation) {
         this.a = a;
         this.b = b;
         this.op = op;
-        this.dualNumberSupplier = dualNumberCalculation;
+        this.dualNumberCalculation = dualNumberCalculation;
         setParents(a, b);
     }
 
@@ -40,8 +40,8 @@ public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
 
     @Override
     public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
-        if (dualNumberSupplier != null) {
-            return dualNumberSupplier.apply(dualNumbers);
+        if (dualNumberCalculation != null) {
+            return dualNumberCalculation.apply(dualNumbers);
         }
 
         throw new UnsupportedOperationException();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -39,9 +39,9 @@ public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         if (dualNumberSupplier != null) {
-            return dualNumberSupplier.apply(dualNumberMap);
+            return dualNumberSupplier.apply(dualNumbers);
         }
 
         throw new UnsupportedOperationException();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
@@ -13,9 +14,9 @@ public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
     protected final Vertex<A> a;
     protected final Vertex<B> b;
     protected final BiFunction<A, B, Double> op;
-    protected final Supplier<DualNumber> dualNumberSupplier;
+    protected final Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier;
 
-    public DoubleBinaryOpLambda(Vertex<A> a, Vertex<B> b, BiFunction<A, B, Double> op, Supplier<DualNumber> dualNumberSupplier) {
+    public DoubleBinaryOpLambda(Vertex<A> a, Vertex<B> b, BiFunction<A, B, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier) {
         this.a = a;
         this.b = b;
         this.op = op;
@@ -38,9 +39,9 @@ public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         if (dualNumberSupplier != null) {
-            return dualNumberSupplier.get();
+            return dualNumberSupplier.apply(dualNumberMap);
         }
 
         throw new UnsupportedOperationException();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.NonProbabilisticDouble;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -37,7 +38,7 @@ public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         if (dualNumberSupplier != null) {
             return dualNumberSupplier.get();
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -16,11 +16,11 @@ public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
     protected final BiFunction<A, B, Double> op;
     protected final Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier;
 
-    public DoubleBinaryOpLambda(Vertex<A> a, Vertex<B> b, BiFunction<A, B, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier) {
+    public DoubleBinaryOpLambda(Vertex<A> a, Vertex<B> b, BiFunction<A, B, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberCalculation) {
         this.a = a;
         this.b = b;
         this.op = op;
-        this.dualNumberSupplier = dualNumberSupplier;
+        this.dualNumberSupplier = dualNumberCalculation;
         setParents(a, b);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
@@ -14,9 +14,9 @@ public class MultiplicationVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        DualNumber aDual = dualNumberMap.get(a);
-        DualNumber bDual = dualNumberMap.get(b);
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        DualNumber aDual = dualNumbers.get(a);
+        DualNumber bDual = dualNumbers.get(b);
         return aDual.multiplyBy(bDual);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
@@ -14,7 +14,7 @@ public class MultiplicationVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         DualNumber aDual = dualNumberMap.get(a);
         DualNumber bDual = dualNumberMap.get(b);
         return aDual.multiplyBy(bDual);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 
 public class MultiplicationVertex extends DoubleBinaryOpVertex {
@@ -11,9 +14,9 @@ public class MultiplicationVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        DualNumber aDual = a.getDualNumber();
-        DualNumber bDual = b.getDualNumber();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        DualNumber aDual = dualNumberMap.get(a);
+        DualNumber bDual = dualNumberMap.get(b);
         return aDual.multiplyBy(bDual);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
@@ -27,9 +27,9 @@ public class PowerVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        DualNumber aDual = dualNumberMap.get(a);
-        DualNumber bDual = dualNumberMap.get(b);
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        DualNumber aDual = dualNumbers.get(a);
+        DualNumber bDual = dualNumbers.get(b);
         return aDual.pow(bDual);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
@@ -1,8 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 public class PowerVertex extends DoubleBinaryOpVertex {
 
@@ -24,9 +27,9 @@ public class PowerVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        DualNumber aDual = a.getDualNumber();
-        DualNumber bDual = b.getDualNumber();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        DualNumber aDual = dualNumberMap.get(a);
+        DualNumber bDual = dualNumberMap.get(b);
         return aDual.pow(bDual);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
@@ -27,7 +27,7 @@ public class PowerVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         DualNumber aDual = dualNumberMap.get(a);
         DualNumber bDual = dualNumberMap.get(b);
         return aDual.pow(bDual);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/DoubleReduceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/DoubleReduceVertex.java
@@ -62,7 +62,7 @@ public class DoubleReduceVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         if (dualNumberSupplier != null) {
             return dualNumberSupplier.get();
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/DoubleReduceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/DoubleReduceVertex.java
@@ -62,7 +62,7 @@ public class DoubleReduceVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         if (dualNumberSupplier != null) {
             return dualNumberSupplier.get();
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/DoubleReduceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/DoubleReduceVertex.java
@@ -62,7 +62,7 @@ public class DoubleReduceVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         if (dualNumberSupplier != null) {
             return dualNumberSupplier.get();
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
@@ -19,7 +19,7 @@ public class AbsVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
@@ -19,7 +19,7 @@ public class AbsVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
@@ -1,8 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 public class AbsVertex extends DoubleUnaryOpVertex {
 
@@ -16,7 +19,7 @@ public class AbsVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
@@ -24,7 +24,7 @@ public class ArcCosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return dualNumberMap.get(inputVertex).acos();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
@@ -1,9 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
+
+import java.util.Map;
 
 public class ArcCosVertex extends DoubleUnaryOpVertex {
 
@@ -21,7 +24,7 @@ public class ArcCosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        return inputVertex.getDualNumber().acos();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        return dualNumberMap.get(inputVertex).acos();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
@@ -24,7 +24,7 @@ public class ArcCosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        return dualNumberMap.get(inputVertex).acos();
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        return dualNumbers.get(inputVertex).acos();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
@@ -24,7 +24,7 @@ public class ArcSinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        return dualNumberMap.get(inputVertex).asin();
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        return dualNumbers.get(inputVertex).asin();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
@@ -1,9 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
+
+import java.util.Map;
 
 public class ArcSinVertex extends DoubleUnaryOpVertex {
 
@@ -21,7 +24,7 @@ public class ArcSinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        return inputVertex.getDualNumber().asin();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        return dualNumberMap.get(inputVertex).asin();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
@@ -24,7 +24,7 @@ public class ArcSinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return dualNumberMap.get(inputVertex).asin();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
@@ -24,7 +24,7 @@ public class ArcTanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         DualNumber inputDualNumber = dualNumberMap.get(inputVertex);
         double dArcTan = 1 / (1 + Math.pow(inputVertex.getValue(), 2));
         Infinitesimal outputInfinitesimal = inputDualNumber.getInfinitesimal().multiplyBy(dArcTan);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
@@ -1,9 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
+
+import java.util.Map;
 
 public class ArcTanVertex extends DoubleUnaryOpVertex {
 
@@ -21,8 +24,8 @@ public class ArcTanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        DualNumber inputDualNumber = inputVertex.getDualNumber();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        DualNumber inputDualNumber = dualNumberMap.get(inputVertex);
         double dArcTan = 1 / (1 + Math.pow(inputVertex.getValue(), 2));
         Infinitesimal outputInfinitesimal = inputDualNumber.getInfinitesimal().multiplyBy(dArcTan);
         return new DualNumber(op(inputVertex.getValue()), outputInfinitesimal);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
@@ -24,8 +24,8 @@ public class ArcTanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        DualNumber inputDualNumber = dualNumberMap.get(inputVertex);
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        DualNumber inputDualNumber = dualNumbers.get(inputVertex);
         double dArcTan = 1 / (1 + Math.pow(inputVertex.getValue(), 2));
         Infinitesimal outputInfinitesimal = inputDualNumber.getInfinitesimal().multiplyBy(dArcTan);
         return new DualNumber(op(inputVertex.getValue()), outputInfinitesimal);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
@@ -23,7 +23,7 @@ public class CeilVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
@@ -23,7 +23,7 @@ public class CeilVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
@@ -1,8 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 public class CeilVertex extends DoubleUnaryOpVertex {
 
@@ -20,7 +23,7 @@ public class CeilVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
@@ -1,9 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
+
+import java.util.Map;
 
 public class CosVertex extends DoubleUnaryOpVertex {
 
@@ -21,7 +24,7 @@ public class CosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        return inputVertex.getDualNumber().cos();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        return dualNumberMap.get(inputVertex).cos();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
@@ -24,7 +24,7 @@ public class CosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        return dualNumberMap.get(inputVertex).cos();
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        return dualNumbers.get(inputVertex).cos();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
@@ -24,7 +24,7 @@ public class CosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return dualNumberMap.get(inputVertex).cos();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.NonProbabilisticDouble;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -35,7 +36,7 @@ public class DoubleUnaryOpLambda<IN> extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         if (dualNumberSupplier != null) {
             return dualNumberSupplier.get();
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
@@ -36,9 +36,9 @@ public class DoubleUnaryOpLambda<IN> extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         if (dualNumberSupplier != null) {
-            return dualNumberSupplier.apply(dualNumberMap);
+            return dualNumberSupplier.apply(dualNumbers);
         }
 
         throw new UnsupportedOperationException();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
@@ -14,10 +14,10 @@ public class DoubleUnaryOpLambda<IN> extends NonProbabilisticDouble {
     protected final Function<IN, Double> op;
     protected final Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier;
 
-    public DoubleUnaryOpLambda(Vertex<IN> inputVertex, Function<IN, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier) {
+    public DoubleUnaryOpLambda(Vertex<IN> inputVertex, Function<IN, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberCalculation) {
         this.inputVertex = inputVertex;
         this.op = op;
-        this.dualNumberSupplier = dualNumberSupplier;
+        this.dualNumberSupplier = dualNumberCalculation;
         setParents(inputVertex);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
@@ -12,9 +12,9 @@ public class DoubleUnaryOpLambda<IN> extends NonProbabilisticDouble {
 
     protected final Vertex<IN> inputVertex;
     protected final Function<IN, Double> op;
-    protected final Supplier<DualNumber> dualNumberSupplier;
+    protected final Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier;
 
-    public DoubleUnaryOpLambda(Vertex<IN> inputVertex, Function<IN, Double> op, Supplier<DualNumber> dualNumberSupplier) {
+    public DoubleUnaryOpLambda(Vertex<IN> inputVertex, Function<IN, Double> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberSupplier) {
         this.inputVertex = inputVertex;
         this.op = op;
         this.dualNumberSupplier = dualNumberSupplier;
@@ -36,9 +36,9 @@ public class DoubleUnaryOpLambda<IN> extends NonProbabilisticDouble {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         if (dualNumberSupplier != null) {
-            return dualNumberSupplier.get();
+            return dualNumberSupplier.apply(dualNumberMap);
         }
 
         throw new UnsupportedOperationException();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
@@ -24,7 +24,7 @@ public class ExpVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return dualNumberMap.get(inputVertex).exp();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
@@ -24,8 +24,8 @@ public class ExpVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        return dualNumberMap.get(inputVertex).exp();
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        return dualNumbers.get(inputVertex).exp();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
@@ -1,9 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
+
+import java.util.Map;
 
 public class ExpVertex extends DoubleUnaryOpVertex {
 
@@ -21,8 +24,8 @@ public class ExpVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        return inputVertex.getDualNumber().exp();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        return dualNumberMap.get(inputVertex).exp();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
@@ -23,7 +23,7 @@ public class FloorVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
@@ -23,7 +23,7 @@ public class FloorVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
@@ -1,8 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 public class FloorVertex extends DoubleUnaryOpVertex {
 
@@ -20,7 +23,7 @@ public class FloorVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
@@ -20,7 +20,7 @@ public class LogVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return dualNumberMap.get(inputVertex).log();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
@@ -1,8 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
+
+import java.util.Map;
 
 public class LogVertex extends DoubleUnaryOpVertex {
 
@@ -17,8 +20,8 @@ public class LogVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        return inputVertex.getDualNumber().log();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        return dualNumberMap.get(inputVertex).log();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
@@ -20,8 +20,8 @@ public class LogVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        return dualNumberMap.get(inputVertex).log();
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        return dualNumbers.get(inputVertex).log();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
@@ -1,9 +1,13 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
+
+import java.util.Map;
+import java.util.function.Consumer;
 
 public class SinVertex extends DoubleUnaryOpVertex {
 
@@ -21,7 +25,8 @@ public class SinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        return inputVertex.getDualNumber().sin();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        return dualNumberMap.get(inputVertex).sin();
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
@@ -25,8 +25,8 @@ public class SinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        return dualNumberMap.get(inputVertex).sin();
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        return dualNumbers.get(inputVertex).sin();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
@@ -25,7 +25,7 @@ public class SinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return dualNumberMap.get(inputVertex).sin();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
@@ -1,9 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.Infinitesimal;
+
+import java.util.Map;
 
 public class TanVertex extends DoubleUnaryOpVertex {
 
@@ -21,8 +24,8 @@ public class TanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
-        DualNumber inputDualNumber = inputVertex.getDualNumber();
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+        DualNumber inputDualNumber = dualNumberMap.get(inputVertex);
         double dTan = 1 / Math.pow(Math.cos(inputVertex.getValue()), 2);
         Infinitesimal outputInfinitesimal = inputDualNumber.getInfinitesimal().multiplyBy(dTan);
         return new DualNumber(op(inputVertex.getValue()), outputInfinitesimal);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
@@ -24,7 +24,7 @@ public class TanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         DualNumber inputDualNumber = dualNumberMap.get(inputVertex);
         double dTan = 1 / Math.pow(Math.cos(inputVertex.getValue()), 2);
         Infinitesimal outputInfinitesimal = inputDualNumber.getInfinitesimal().multiplyBy(dTan);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
@@ -24,8 +24,8 @@ public class TanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
-        DualNumber inputDualNumber = dualNumberMap.get(inputVertex);
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        DualNumber inputDualNumber = dualNumbers.get(inputVertex);
         double dTan = 1 / Math.pow(Math.cos(inputVertex.getValue()), 2);
         Infinitesimal outputInfinitesimal = inputDualNumber.getInfinitesimal().multiplyBy(dTan);
         return new DualNumber(op(inputVertex.getValue()), outputInfinitesimal);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -27,7 +27,7 @@ public abstract class ProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return new DualNumber(getValue(), getId());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Map;
 
 public abstract class ProbabilisticDouble extends DoubleVertex {
 
@@ -24,7 +27,7 @@ public abstract class ProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public DualNumber getDualNumber() {
+    public DualNumber calcDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
         return new DualNumber(getValue(), getId());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -27,7 +27,7 @@ public abstract class ProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumberMap) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return new DualNumber(getValue(), getId());
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/DualNumberPropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/DualNumberPropagationTest.java
@@ -20,48 +20,16 @@ public class DualNumberPropagationTest {
     @Test
     public void doesNotPerformUnneccesaryDualNumberCalculations() {
         AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger m = new AtomicInteger(0);
         DoubleVertex start = new SinVertex(Math.PI / 3);
 
         int links = 20;
-        DoubleVertex end = addLinks(start, n, links);
+        DoubleVertex end = TestGraphGenerator.addLinks(start, n, m, links);
 
         end.getDualNumber();
 
         //Does the right amount of work
-        assertEquals(3 * links, n.get());
-    }
-
-    private DoubleVertex addLinks(DoubleVertex end, AtomicInteger n, int links) {
-
-        for (int i = 0; i < links; i++) {
-            DoubleVertex left = passThroughVertex(end, n, id -> log.info("OP on id:" + id));
-            DoubleVertex right = passThroughVertex(end, n, id -> log.info("OP on id:" + id));
-            end = sumVertex(left, right, n, id -> log.info("OP on id:" + id));
-        }
-
-        return end;
-    }
-
-    private DoubleVertex passThroughVertex(DoubleVertex from, AtomicInteger n, Consumer<Long> onOp) {
-        final long id = Vertex.idGenerator.get();
-        return new DoubleUnaryOpLambda<>(from, (a) -> {
-            onOp.accept(id);
-            return a;
-        }, (a) -> {
-            n.incrementAndGet();
-            return a.get(from);
-        });
-    }
-
-    private DoubleVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger n, Consumer<Long> onOp) {
-        final long id = Vertex.idGenerator.get();
-        return new DoubleBinaryOpLambda<>(left, right, (a, b) -> {
-            onOp.accept(id);
-            return a + b;
-        }, (a) -> {
-            n.incrementAndGet();
-            return a.get(left).add(a.get(right));
-        } );
+        assertEquals(3 * links, m.get());
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/DualNumberPropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/DualNumberPropagationTest.java
@@ -1,0 +1,61 @@
+package io.improbable.keanu.vertices;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DoubleBinaryOpLambda;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.PowerVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpLambda;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+public class DualNumberPropagationTest {
+
+    private final Logger log = LoggerFactory.getLogger(DualNumberPropagationTest.class);
+
+    @Test
+    public void doesNotPerformUnneccesaryDualNumberCalculations() {
+        ConstantDoubleVertex x = new ConstantDoubleVertex(5.0);
+        PowerVertex xPow = new PowerVertex(x, 2.0);
+        PowerVertex yPow = new PowerVertex(x, 3.0);
+        MultiplicationVertex multiplicationVertex = new MultiplicationVertex(xPow, yPow);
+        PowerVertex xPow2 = new PowerVertex(multiplicationVertex, 2.0);
+        PowerVertex yPow2 = new PowerVertex(multiplicationVertex, 3.0);
+        MultiplicationVertex multiplicationVertex1 = new MultiplicationVertex(xPow2, yPow2);
+        multiplicationVertex1.getDualNumber();
+    }
+
+    private DoubleVertex addLinks(DoubleVertex end, AtomicInteger n, int links) {
+
+        for (int i = 0; i < links; i++) {
+            DoubleVertex left = passThroughVertex(end, n, id -> log.info("OP on id:" + id));
+            DoubleVertex right = passThroughVertex(end, n, id -> log.info("OP on id:" + id));
+            end = sumVertex(left, right, n, id -> log.info("OP on id:" + id));
+        }
+
+        return end;
+    }
+
+    private DoubleVertex passThroughVertex(DoubleVertex from, AtomicInteger n, Consumer<Long> onOp) {
+        final long id = Vertex.idGenerator.get();
+        return new DoubleUnaryOpLambda<>(from, (a) -> {
+            n.incrementAndGet();
+            onOp.accept(id);
+            return a;
+        });
+    }
+
+    private DoubleVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger n, Consumer<Long> onOp) {
+        final long id = Vertex.idGenerator.get();
+        return new DoubleBinaryOpLambda<>(left, right, (a, b) -> {
+            n.incrementAndGet();
+            onOp.accept(id);
+            return a + b;
+        });
+    }
+
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/DualNumberPropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/DualNumberPropagationTest.java
@@ -1,12 +1,8 @@
 package io.improbable.keanu.vertices;
 
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DoubleBinaryOpLambda;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.PowerVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpLambda;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.FloorVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SinVertex;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
@@ -13,37 +13,37 @@ public class TestGraphGenerator {
 
     private static final Logger log = LoggerFactory.getLogger(TestGraphGenerator.class);
 
-    static DoubleVertex addLinks(DoubleVertex end, AtomicInteger n, AtomicInteger m, int links) {
+    static DoubleVertex addLinks(DoubleVertex end, AtomicInteger opCount, AtomicInteger dualNumberCount, int links) {
 
         for (int i = 0; i < links; i++) {
-            DoubleVertex left = passThroughVertex(end, n, m, id -> log.info("OP on id:" + id));
-            DoubleVertex right = passThroughVertex(end, n, m, id -> log.info("OP on id:" + id));
-            end = sumVertex(left, right, n, m, id -> log.info("OP on id:" + id));
+            DoubleVertex left = passThroughVertex(end, opCount, dualNumberCount, id -> log.info("OP on id:" + id));
+            DoubleVertex right = passThroughVertex(end, opCount, dualNumberCount, id -> log.info("OP on id:" + id));
+            end = sumVertex(left, right, opCount, dualNumberCount, id -> log.info("OP on id:" + id));
         }
 
         return end;
     }
 
-    static DoubleVertex passThroughVertex(DoubleVertex from, AtomicInteger n, AtomicInteger m, Consumer<Long> onOp) {
+    static DoubleVertex passThroughVertex(DoubleVertex from, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<Long> onOp) {
         final long id = Vertex.idGenerator.get();
         return new DoubleUnaryOpLambda<>(from, (a) -> {
-            n.incrementAndGet();
+            opCount.incrementAndGet();
             onOp.accept(id);
             return a;
         }, (a) -> {
-            m.incrementAndGet();
+            dualNumberCount.incrementAndGet();
             return a.get(from);
         });
     }
 
-    static DoubleVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger n, AtomicInteger m, Consumer<Long> onOp) {
+    static DoubleVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<Long> onOp) {
         final long id = Vertex.idGenerator.get();
         return new DoubleBinaryOpLambda<>(left, right, (a, b) -> {
-            n.incrementAndGet();
+            opCount.incrementAndGet();
             onOp.accept(id);
             return a + b;
         }, (a) -> {
-            m.incrementAndGet();
+            dualNumberCount.incrementAndGet();
             return a.get(left).add(a.get(right));
         } );
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/VertexValuePropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/VertexValuePropagationTest.java
@@ -14,6 +14,9 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import static io.improbable.keanu.vertices.TestGraphGenerator.addLinks;
+import static io.improbable.keanu.vertices.TestGraphGenerator.passThroughVertex;
+import static io.improbable.keanu.vertices.TestGraphGenerator.sumVertex;
 import static org.junit.Assert.assertEquals;
 
 public class VertexValuePropagationTest {
@@ -31,10 +34,11 @@ public class VertexValuePropagationTest {
     public void doesNotDoUnnecessaryOperations() {
 
         AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger m = new AtomicInteger(0);
         DoubleVertex start = new GaussianVertex(0, 1, random);
 
         int links = 20;
-        DoubleVertex end = addLinks(start, n, links);
+        DoubleVertex end = addLinks(start, n, m, links);
 
         start.setAndCascade(2.0);
 
@@ -48,13 +52,14 @@ public class VertexValuePropagationTest {
     @Test
     public void doesNotPropagateThroughProbabilisticVertices() {
         AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger m = new AtomicInteger(0);
         DoubleVertex start = new GaussianVertex(0, 1, random);
 
-        DoubleVertex end = addLinks(start, n, 1);
+        DoubleVertex end = addLinks(start, n, m, 1);
 
         DoubleVertex nextLayerStart = new GaussianVertex(end, 1, random);
 
-        DoubleVertex secondLayerEnd = addLinks(nextLayerStart, n, 1);
+        DoubleVertex secondLayerEnd = addLinks(nextLayerStart, n, m, 1);
 
         start.setAndCascade(3.0);
 
@@ -68,15 +73,16 @@ public class VertexValuePropagationTest {
     @Test
     public void doesPropagateAroundProbabilisticVertices() {
         AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger m = new AtomicInteger(0);
         DoubleVertex firstLayerStart = new GaussianVertex(0, 1, random);
 
-        DoubleVertex firstLayerEnd = addLinks(firstLayerStart, n, 1);
+        DoubleVertex firstLayerEnd = addLinks(firstLayerStart, n, m, 1);
 
         DoubleVertex secondLayerStart = new GaussianVertex(firstLayerEnd, 1, random);
 
-        DoubleVertex secondLayerLeft = sumVertex(secondLayerStart, firstLayerEnd, n, id -> log.info("OP on id: " + id));
-        DoubleVertex secondLayerRight = passThroughVertex(secondLayerStart, n, id -> log.info("OP on id: " + id));
-        DoubleVertex secondLayerEnd = sumVertex(secondLayerLeft, secondLayerRight, n, id -> log.info("OP on id: " + id));
+        DoubleVertex secondLayerLeft = sumVertex(secondLayerStart, firstLayerEnd, n, m,id -> log.info("OP on id: " + id));
+        DoubleVertex secondLayerRight = passThroughVertex(secondLayerStart, n, m, id -> log.info("OP on id: " + id));
+        DoubleVertex secondLayerEnd = sumVertex(secondLayerLeft, secondLayerRight, n, m, id -> log.info("OP on id: " + id));
 
         secondLayerStart.setValue(2.0);
         firstLayerStart.setValue(3.0);
@@ -90,32 +96,4 @@ public class VertexValuePropagationTest {
         assertEquals(6, n.get());
     }
 
-    private DoubleVertex addLinks(DoubleVertex end, AtomicInteger n, int links) {
-
-        for (int i = 0; i < links; i++) {
-            DoubleVertex left = passThroughVertex(end, n, id -> log.info("OP on id: " + id));
-            DoubleVertex right = passThroughVertex(end, n, id -> log.info("OP on id: " + id));
-            end = sumVertex(left, right, n, id -> log.info("OP on id:" + id));
-        }
-
-        return end;
-    }
-
-    private DoubleVertex passThroughVertex(DoubleVertex from, AtomicInteger n, Consumer<Long> onOp) {
-        final long id = Vertex.idGenerator.get();
-        return new DoubleUnaryOpLambda<>(from, (a) -> {
-            n.incrementAndGet();
-            onOp.accept(id);
-            return a;
-        });
-    }
-
-    private DoubleVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger n, Consumer<Long> onOp) {
-        final long id = Vertex.idGenerator.get();
-        return new DoubleBinaryOpLambda<>(left, right, (a, b) -> {
-            n.incrementAndGet();
-            onOp.accept(id);
-            return a + b;
-        });
-    }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
@@ -59,7 +59,7 @@ public class DoubleVertexTest {
 
         Function<Double, Double> op = val -> val + 5;
 
-        DoubleVertex v3 = v1.lambda(op, () -> {
+        DoubleVertex v3 = v1.lambda(op, (a) -> {
             DualNumber v1Dual = v1.getDualNumber();
             return new DualNumber(op.apply(v1Dual.getValue()), v1Dual.getInfinitesimal());
         });


### PR DESCRIPTION
A performance fix for Dual Numbers. 

Ensures that when calculating Dual Numbers, a vertex's Dual Number is never calculated more than once.