### PR TITLE
Fix javadoc warnings

### DIFF
--- a/keanu-project/build.gradle
+++ b/keanu-project/build.gradle
@@ -123,6 +123,11 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
+//Break build on javadoc warnings
+tasks.withType(Javadoc) {
+    options.addStringOption('Xwerror', '-quiet')
+}
+
 artifacts {
     archives javadocJar, sourcesJar
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -20,10 +20,10 @@ public class MetropolisHastings {
     }
 
     /**
-     * @param bayesNet
+     * @param bayesNet     a bayesian network containing latent vertices
      * @param fromVertices the vertices to include in the returned samples
-     * @param sampleCount
-     * @param random
+     * @param sampleCount  number of samples to take using the algorithm
+     * @param random       the source of randomness
      * @return Samples for each vertex ordered by MCMC iteration
      */
     public static NetworkSamples getPosteriorSamples(final BayesNet bayesNet,
@@ -31,7 +31,7 @@ public class MetropolisHastings {
                                                      final int sampleCount,
                                                      final Random random) {
         checkBayesNetInHealthyState(bayesNet);
-        
+
         Map<String, List<?>> samplesByVertex = new HashMap<>();
         List<? extends Vertex<?>> latentVertices = bayesNet.getLatentVertices();
         Map<Vertex<?>, Set<Vertex<?>>> affectedVerticesCache = getVerticesAffectedByLatents(latentVertices);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SimulatedAnnealing.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SimulatedAnnealing.java
@@ -9,13 +9,10 @@ import java.util.*;
 
 /**
  * Simulated Annealing is a modified version of Metropolis Hastings that causes the MCMC random walk to
- * tend towards the maximum a posteriori (MAP)
+ * tend towards the Maximum A Posteriori (MAP)
  */
 public class SimulatedAnnealing {
 
-    /**
-     * Finds the MAP using the specified annealing schedule.
-     */
     public static NetworkState getMaxAPosteriori(BayesNet bayesNet,
                                                  int sampleCount,
                                                  AnnealingSchedule schedule) {
@@ -29,9 +26,6 @@ public class SimulatedAnnealing {
         return getMaxAPosteriori(bayesNet, sampleCount, schedule, random);
     }
 
-    /**
-     * Finds the MAP using the default annealing schedule, which is an exponential decay schedule.
-     */
     public static NetworkState getMaxAPosteriori(BayesNet bayesNet, int sampleCount) {
 
         AnnealingSchedule schedule = exponentialSchedule(sampleCount, 2, 0.01);
@@ -39,6 +33,15 @@ public class SimulatedAnnealing {
         return getMaxAPosteriori(bayesNet, sampleCount, schedule, new Random());
     }
 
+    /**
+     * Finds the MAP using the default annealing schedule, which is an exponential decay schedule.
+     *
+     * @param bayesNet          a bayesian network containing latent vertices
+     * @param sampleCount       the number of samples to take
+     * @param annealingSchedule the schedule to update T (temperature) as a function of sample number.
+     * @param random            the source of randomness
+     * @return the NetworkState that represents the Max A Posteriori
+     */
     public static NetworkState getMaxAPosteriori(BayesNet bayesNet,
                                                  int sampleCount,
                                                  AnnealingSchedule annealingSchedule,
@@ -84,6 +87,10 @@ public class SimulatedAnnealing {
         ((Map<String, ? super T>) samples).put(vertex.getId(), vertex.getValue());
     }
 
+    /**
+     * An annealing schedule determines how T (temperature) changes as
+     * a function of the current iteration number (i.e. sample number)
+     */
     public interface AnnealingSchedule {
         double getT(int iteration);
     }
@@ -92,6 +99,7 @@ public class SimulatedAnnealing {
      * @param iterations the number of iterations annealing over
      * @param startT     the value of T at iteration 0
      * @param endT       the value of T at the last iteration
+     * @return the annealing schedule
      */
     public static AnnealingSchedule exponentialSchedule(int iterations, double startT, double endT) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/particleFiltering/ParticleFilter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/particleFiltering/ParticleFilter.java
@@ -29,7 +29,7 @@ public class ParticleFilter {
      * @param resamplingProportion the proportion of particles to cull (e.g. the 25% of least probably particles could
      *                             be culled)
      * @param random a random number generator
-     * @return
+     * @return a list of likely
      */
 
     public static List<Particle> getProbableValues(Collection<? extends Vertex<?>> vertices, int numParticles,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/particleFiltering/ParticleFilter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/particleFiltering/ParticleFilter.java
@@ -29,7 +29,7 @@ public class ParticleFilter {
      * @param resamplingProportion the proportion of particles to cull (e.g. the 25% of least probably particles could
      *                             be culled)
      * @param random a random number generator
-     * @return a list of likely
+     * @return a list of particles representing the most probable found values of latent variables
      */
 
     public static List<Particle> getProbableValues(Collection<? extends Vertex<?>> vertices, int numParticles,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
@@ -40,7 +40,7 @@ public class GradientOptimizer {
      * @param maxEvaluations the maximum number of objective function evaluations before throwing an exception
      *                       indicating convergence failure.
      * @param optimizer      apache math optimizer to use for optimization
-     * @return the natural logarithm of the Maximum a posteriori (MAP)
+     * @return the natural logarithm of the Maximum A Posteriori (MAP)
      */
     public double maxAPosteriori(int maxEvaluations, NonLinearConjugateGradientOptimizer optimizer) {
         if (bayesNet.getVerticesThatContributeToMasterP().isEmpty()) {
@@ -52,7 +52,7 @@ public class GradientOptimizer {
     /**
      * @param maxEvaluations the maximum number of objective function evaluations before throwing an exception
      *                       indicating convergence failure.
-     * @return the natural logarithm of the Maximum a posteriori (MAP)
+     * @return the natural logarithm of the Maximum A Posteriori (MAP)
      */
     public double maxAPosteriori(int maxEvaluations) {
         return maxAPosteriori(maxEvaluations, DEFAULT_OPTIMIZER);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
@@ -35,7 +35,11 @@ public class GradientOptimizer {
     }
 
     /**
-     * @param maxEvaluations throws an exception if the optimizer doesn't converge within this many evaluations
+     * This method is here to provide more fine grained control of optimization.
+     *
+     * @param maxEvaluations the maximum number of objective function evaluations before throwing an exception
+     *                       indicating convergence failure.
+     * @param optimizer      apache math optimizer to use for optimization
      * @return the natural logarithm of the Maximum a posteriori (MAP)
      */
     public double maxAPosteriori(int maxEvaluations, NonLinearConjugateGradientOptimizer optimizer) {
@@ -45,12 +49,21 @@ public class GradientOptimizer {
         return optimize(maxEvaluations, bayesNet.getVerticesThatContributeToMasterP(), optimizer);
     }
 
+    /**
+     * @param maxEvaluations the maximum number of objective function evaluations before throwing an exception
+     *                       indicating convergence failure.
+     * @return the natural logarithm of the Maximum a posteriori (MAP)
+     */
     public double maxAPosteriori(int maxEvaluations) {
         return maxAPosteriori(maxEvaluations, DEFAULT_OPTIMIZER);
     }
 
     /**
-     * @param maxEvaluations throws an exception if the optimizer doesn't converge within this many evaluations
+     * This method is here to provide more fine grained control of optimization.
+     *
+     * @param maxEvaluations the maximum number of objective function evaluations before throwing an exception
+     *                       indicating convergence failure.
+     * @param optimizer      apache math optimizer to use for optimization
      * @return the natural logarithm of the maximum likelihood
      */
     public double maxLikelihood(int maxEvaluations, NonLinearConjugateGradientOptimizer optimizer) {
@@ -60,6 +73,11 @@ public class GradientOptimizer {
         return optimize(maxEvaluations, bayesNet.getObservedVertices(), optimizer);
     }
 
+    /**
+     * @param maxEvaluations the maximum number of objective function evaluations before throwing an exception
+     *                       indicating convergence failure.
+     * @return the natural logarithm of the maximum likelihood
+     */
     public double maxLikelihood(int maxEvaluations) {
         return maxLikelihood(maxEvaluations, DEFAULT_OPTIMIZER);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/NonGradientOptimizer.java
@@ -64,6 +64,7 @@ public class NonGradientOptimizer {
 
     /**
      * @param maxEvaluations throws an exception if the optimizer doesn't converge within this many evaluations
+     * @param boundsRange    bounding box around starting point
      * @return the natural logarithm of the Maximum a posteriori (MAP)
      */
     public double maxAPosteriori(int maxEvaluations, double boundsRange) {
@@ -72,6 +73,7 @@ public class NonGradientOptimizer {
 
     /**
      * @param maxEvaluations throws an exception if the optimizer doesn't converge within this many evaluations
+     * @param boundsRange    bounding box around starting point
      * @return the natural logarithm of the maximum likelihood
      */
     public double maxLikelihood(int maxEvaluations, double boundsRange) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -7,14 +7,14 @@ import static java.lang.Math.log;
 import static java.lang.Math.pow;
 import static org.apache.commons.math3.special.Gamma.*;
 
+/**
+ * Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.2 page 14
+ */
 public class Beta {
 
-    /**
-     * Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.2 page 14
-     */
     public static double sample(double alpha, double beta, double xMin, double xMax, Random random) {
         double y1 = Gamma.sample(0.0, 1.0, alpha, random);
         double y2 = Gamma.sample(0.0, 1.0, beta, random);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -2,14 +2,14 @@ package io.improbable.keanu.distributions.continuous;
 
 import java.util.Random;
 
+/**
+ * Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.8 page 20
+ */
 public class Exponential {
 
-    /**
-     * Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.8 page 20
-     */
     public static double sample(double a, double b, Random random) {
         assert (b > 0.0);
         return a - b * Math.log(random.nextDouble());

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -6,21 +6,21 @@ import static java.lang.Math.*;
 import static org.apache.commons.math3.special.Gamma.digamma;
 import static org.apache.commons.math3.special.Gamma.gamma;
 
+/**
+ * Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.8 page 33
+ */
 public class Gamma {
 
-    /**
-     * Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.8 page 33
-     */
     public static final double M_E = 0.577215664901532860606512090082;
 
     /**
      * @param a      location
      * @param theta  scale
      * @param k      shape
-     * @param random
+     * @param random source of randomness
      * @return a random number from the Gamma distribution
      */
     public static double sample(double a, double theta, double k, Random random) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -2,14 +2,14 @@ package io.improbable.keanu.distributions.continuous;
 
 import java.util.Random;
 
+/**
+ * Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.8 page 25
+ */
 public class Laplace {
 
-    /**
-     * Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.8 page 25
-     */
     public static double sample(double mu, double beta, Random random) {
         assert (beta > 0.);
         if (random.nextDouble() > 0.5) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -13,8 +13,8 @@ public class Logistic {
     /**
      * @param a      location parameter (any real number)
      * @param b      scale parameter (b grater than 0)
-     * @param random
-     * @return
+     * @param random source for sampling
+     * @return a sample from the distribution
      */
     public static double sample(double a, double b, Random random) {
         assert (b > 0.0);
@@ -24,8 +24,8 @@ public class Logistic {
     /**
      * @param a location parameter (any real number)
      * @param b scale parameter (b greater than 0)
-     * @param x
-     * @return
+     * @param x at value
+     * @return the density at x
      */
     public static double pdf(double a, double b, double x) {
         double exponential = Math.exp((x - a) / b);
@@ -41,8 +41,8 @@ public class Logistic {
     /**
      * @param a location parameter (any real number)
      * @param b scale parameter (b greater than 0)
-     * @param x
-     * @return
+     * @param x at value
+     * @return the partial derivatives at x
      */
     public static Diff dPdf(double a, double b, double x) {
         double expAOverB = Math.exp(a / b);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -13,7 +13,7 @@ public class Logistic {
     /**
      * @param a      location parameter (any real number)
      * @param b      scale parameter (b grater than 0)
-     * @param random source for sampling
+     * @param random source or randomness
      * @return a sample from the distribution
      */
     public static double sample(double a, double b, Random random) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniformDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniformDistribution.java
@@ -39,7 +39,7 @@ public class SmoothUniformDistribution {
 
     /**
      * Will return samples between xMin and xMax as well as samples from the left and right shoulder.
-     * The width of the shoulder is determined by the edgeSharpness as a percentage of the body with,
+     * The width of the shoulder is determined by the edgeSharpness as a percentage of the body width,
      * which is (xMax - xMin).
      *
      * @param xMin min value from body

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniformDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniformDistribution.java
@@ -39,7 +39,13 @@ public class SmoothUniformDistribution {
 
     /**
      * Will return samples between xMin and xMax as well as samples from the left and right shoulder.
+     * The width of the shoulder is determined by the edgeSharpness as a percentage of the body with,
+     * which is (xMax - xMin).
      *
+     * @param xMin min value from body
+     * @param xMax max value from body
+     * @param edgeSharpness sharpness as a percentage of the body width
+     * @param random source of randomness
      * @return a uniform random number between xMin and xMax
      */
     public static double sample(double xMin, double xMax, final double edgeSharpness, Random random) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
@@ -2,14 +2,13 @@ package io.improbable.keanu.distributions.continuous;
 
 import java.util.Random;
 
+/**
+ * Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.24 page 37
+ */
 public class Triangular {
-
-    /**
-     * Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.24 page 37
-     */
 
     public static double sample(double xMin, double xMax, double c, Random random) {
         assert (xMin <= xMax && xMin <= c && c <= xMax);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
@@ -2,14 +2,13 @@ package io.improbable.keanu.distributions.continuous;
 
 import java.util.Random;
 
+/**
+ * Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.8 page 48
+ */
 public class Uniform {
-
-    /**
-     * Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.8 page 48
-     */
 
     public static double sample(double xMin, double xMax, Random random) {
         return random.nextDouble() * (xMax - xMin) + xMin;
@@ -22,5 +21,4 @@ public class Uniform {
             return 0.;
         }
     }
-
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -4,6 +4,12 @@ import java.util.Random;
 
 import static org.apache.commons.math3.util.CombinatoricsUtils.factorial;
 
+/**
+ * Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.2.8 page 49
+ */
 public class Poisson {
     private final double mu;
     private final Random random;
@@ -17,12 +23,6 @@ public class Poisson {
         return poisson(mu, random);
     }
 
-    /**
-     * Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.2.8 page 49
-     */
     public static int poisson(double mu, Random random) {
         assert (mu > 0.);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/kotlin/ArithmeticDouble.kt
+++ b/keanu-project/src/main/java/io/improbable/keanu/kotlin/ArithmeticDouble.kt
@@ -6,12 +6,12 @@ class ArithmeticDouble(val value: Double) : DoubleOperators<ArithmeticDouble> {
         return ArithmeticDouble(Math.exp(this.value))
     }
 
-    override fun pow(that: ArithmeticDouble): ArithmeticDouble {
-        return ArithmeticDouble(Math.pow(this.value, that.value))
+    override fun pow(exponent: ArithmeticDouble): ArithmeticDouble {
+        return ArithmeticDouble(Math.pow(this.value, exponent.value))
     }
 
-    override fun pow(value: Double): ArithmeticDouble {
-        return ArithmeticDouble(Math.pow(this.value, value))
+    override fun pow(exponent: Double): ArithmeticDouble {
+        return ArithmeticDouble(Math.pow(this.value, exponent))
     }
 
     override fun log(): ArithmeticDouble {

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesNet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesNet.java
@@ -92,6 +92,7 @@ public class BayesNet {
     /**
      * Attempt to find a non-zero master probability
      * by naively sampling vertices in order of data dependency
+     * @param attempts sampling attempts to get non-zero probability
      */
     public void probeForNonZeroMasterP(int attempts) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/plating/PlateBuilder.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/plating/PlateBuilder.java
@@ -31,7 +31,7 @@ public class PlateBuilder<T> {
     /**
      * Build a fixed number of plates without additional data
      *
-     * @param count
+     * @param count count
      * @return A builder with count set
      */
     public FromCount count(int count) {
@@ -41,7 +41,7 @@ public class PlateBuilder<T> {
     /**
      * Build an unspecified number of plates with data from an iterator
      *
-     * @param iterator
+     * @param iterator iterator
      * @return A builder with data set
      */
     public FromIterator fromIterator(Iterator<T> iterator) {
@@ -51,7 +51,7 @@ public class PlateBuilder<T> {
     /**
      * Build a number of plates with data from an iterator
      *
-     * @param iterator
+     * @param iterator iterator
      * @param sizeHint A hint of the iterator cardinality. Does not need to be exact
      * @return A builder with data set
      */
@@ -76,7 +76,7 @@ public class PlateBuilder<T> {
         /**
          * Set the Plate factory method, taking no additional data
          *
-         * @param factory
+         * @param factory a plate factory
          * @return A builder with count and plate factory set
          */
         public FromCountFactory withFactory(Consumer<Plate> factory) {
@@ -103,7 +103,7 @@ public class PlateBuilder<T> {
         /**
          * Set the Plate factory method, taking additional data
          *
-         * @param factory
+         * @param factory a plate factory
          * @return A builder with data and plate factory set
          */
         public FromDataFactory withFactory(BiConsumer<Plate, T> factory) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Constant.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Constant.java
@@ -3,7 +3,7 @@ package io.improbable.keanu.vertices;
 /**
  * This interface is used to identify vertices that are constants.
  *
- * @param <T>
+ * @param <T> constant type
  */
 public interface Constant<T> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -34,14 +34,14 @@ public abstract class Vertex<T> implements Identifiable {
 
     /**
      * @param value The supplied value.
-     * @return The value of the natural log of the probability density at the supplied value
+     * @return The natural log of the probability density at the supplied value
      */
     public double logDensity(T value) {
         return Math.log(density(value));
     }
 
     /**
-     * @return the log of the density at the vertex's value
+     * @return the natural log of the density at the vertex's value
      */
     public double logDensityAtValue() {
         return logDensity(getValue());

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -26,24 +26,22 @@ public abstract class Vertex<T> implements Identifiable {
     public abstract double density(T value);
 
     /**
-     * Just a helper method for a common function
+     * @return the density at the vertex's current value
      */
     public double densityAtValue() {
         return density(getValue());
     }
 
     /**
-     * This is the value of the natural log of the probability density at the supplied value.
-     *
      * @param value The supplied value.
-     * @return The probability.
+     * @return The value of the natural log of the probability density at the supplied value
      */
     public double logDensity(T value) {
         return Math.log(density(value));
     }
 
     /**
-     * Just a helper method for a common function
+     * @return the log of the density at the vertex's value
      */
     public double logDensityAtValue() {
         return logDensity(getValue());
@@ -63,6 +61,8 @@ public abstract class Vertex<T> implements Identifiable {
      * chain rule is used to calculate the derivative of the log of the density.
      * <p>
      * dlog(P)/dx = (dP/dx)*(1/P(x))
+     *
+     * @return the partial derivatives of the log density
      */
     public Map<String, Double> dlnDensityAtValue() {
 
@@ -127,9 +127,10 @@ public abstract class Vertex<T> implements Identifiable {
     }
 
     /**
-     * A probabilistic vertex is defined as a vertex whose value is not
-     * derived from it's parents. However, the probability of the vertex's
-     * value may be dependent on it's parents values.
+     * @return True if the vertex is probabilistic, false otherwise.
+     * A probabilistic vertex is defined as a vertex whose value is
+     * not derived from it's parents. However, the probability of the
+     * vertex's value may be dependent on it's parents values.
      */
     public abstract boolean isProbabilistic();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/NumericalEqualsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/NumericalEqualsVertex.java
@@ -3,15 +3,15 @@ package io.improbable.keanu.vertices.bool.nonprobabilistic.operators;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.NonProbabilisticBool;
 
+/**
+ * Returns true if a vertex value is equal to another vertex value within an epsilon.
+ */
 public class NumericalEqualsVertex extends NonProbabilisticBool {
 
     protected Vertex<Number> a;
     protected Vertex<Number> b;
     private Vertex<Number> epsilon;
 
-    /**
-     * Returns true if a is within epsilon of b
-     */
     public NumericalEqualsVertex(Vertex<Number> a, Vertex<Number> b, Vertex<Number> epsilon) {
         this.a = a;
         this.b = b;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
@@ -9,7 +9,7 @@ import java.util.Map;
 public class LogProbGradient {
 
     /**
-     * @param probabilisticVertices
+     * @param probabilisticVertices vertices to use in LogProb calc
      * @return the partial derivatives with respect to any latents upstream
      */
     public static Map<String, Double> getJointLogProbGradientWrtLatents(List<Vertex<?>> probabilisticVertices) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -19,7 +19,7 @@ public class GammaVertex extends ProbabilisticDouble {
      * @param a      location
      * @param theta  scale
      * @param k      shape
-     * @param random
+     * @param random source for sampling
      */
     public GammaVertex(DoubleVertex a, DoubleVertex theta, DoubleVertex k, Random random) {
         this.a = a;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
@@ -15,8 +15,8 @@ import static org.apache.commons.math3.special.Erf.erf;
 /**
  * Takes a double and casts it to an integer with a user definable level of fuzziness over the value cast to. The range
  * of potential integer values cast to is specified with a min and max (inclusive). The probability of casting to a
- * given integer is represented as a Gaussian distribution centred on the input value, with a use specifiable sigma.
- * E.n., a sigma value of 0 will guarantee casting ot the nearest integer value with half up rounding.
+ * given integer is represented as a Gaussian distribution centred on the input value, with a user specifiable sigma.
+ * e.g. a sigma value of 0 will guarantee casting to the nearest integer value with half up rounding.
  */
 public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
 
@@ -31,7 +31,7 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
      * @param fuzzinessSigma fuzziness is represented as a Gaussian distribution with mu of the input value and this sigma.
      * @param min            inclusive
      * @param max            inclusive
-     * @param random         source for sampling
+     * @param random         source for randomness
      */
     public FuzzyCastToIntegerVertex(DoubleVertex input,
                                     DoubleVertex fuzzinessSigma,

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
@@ -12,6 +12,12 @@ import java.util.Random;
 
 import static org.apache.commons.math3.special.Erf.erf;
 
+/**
+ * Takes a double and casts it to an integer with a user definable level of fuzziness over the value cast to. The range
+ * of potential integer values cast to is specified with a min and max (inclusive). The probability of casting to a
+ * given integer is represented as a Gaussian distribution centred on the input value, with a use specifiable sigma.
+ * E.n., a sigma value of 0 will guarantee casting ot the nearest integer value with half up rounding.
+ */
 public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
 
     private DoubleVertex input;
@@ -21,19 +27,17 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
     private Random random;
 
     /**
-     * Takes a double and casts it to an integer with a user definable level of fuzziness over the value cast to. The range
-     * of potential integer values cast to is specified with a min and max (inclusive). The probability of casting to a
-     * given integer is represented as a Gaussian distribution centred on the input value, with a use specifiable sigma.
-     * E.n., a sigma value of 0 will guarantee casting ot the nearest integer value with half up rounding.
-     *
-     * @param input
+     * @param input          vertex intended for casting
      * @param fuzzinessSigma fuzziness is represented as a Gaussian distribution with mu of the input value and this sigma.
      * @param min            inclusive
      * @param max            inclusive
-     * @param random
+     * @param random         source for sampling
      */
-    public FuzzyCastToIntegerVertex(DoubleVertex input, DoubleVertex fuzzinessSigma,
-                                    Vertex<Integer> min, Vertex<Integer> max, Random random) {
+    public FuzzyCastToIntegerVertex(DoubleVertex input,
+                                    DoubleVertex fuzzinessSigma,
+                                    Vertex<Integer> min,
+                                    Vertex<Integer> max,
+                                    Random random) {
 
         this.input = input;
         this.fuzzinessSigma = fuzzinessSigma;
@@ -43,9 +47,17 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
         setParents(input, fuzzinessSigma, min, max);
     }
 
-    public FuzzyCastToIntegerVertex(DoubleVertex input, double fuzzinessSigma, int min, int max, Random random) {
-        this(input, new ConstantDoubleVertex(fuzzinessSigma), new ConstantIntegerVertex(min),
-                new ConstantIntegerVertex(max), random);
+    public FuzzyCastToIntegerVertex(DoubleVertex input,
+                                    double fuzzinessSigma,
+                                    int min,
+                                    int max,
+                                    Random random) {
+        this(input,
+                new ConstantDoubleVertex(fuzzinessSigma),
+                new ConstantIntegerVertex(min),
+                new ConstantIntegerVertex(max),
+                random
+        );
     }
 
     public DoubleVertex getInput() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -16,7 +16,7 @@ public class UniformIntVertex extends ProbabilisticInteger {
     /**
      * @param min The inclusive lower bound.
      * @param max The exclusive upper bound.
-     * @param random source for sampling
+     * @param random source of randomness
      */
     public UniformIntVertex(Vertex<Integer> min, Vertex<Integer> max, Random random) {
         this.min = min;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -16,6 +16,7 @@ public class UniformIntVertex extends ProbabilisticInteger {
     /**
      * @param min The inclusive lower bound.
      * @param max The exclusive upper bound.
+     * @param random source for sampling
      */
     public UniformIntVertex(Vertex<Integer> min, Vertex<Integer> max, Random random) {
         this.min = min;


### PR DESCRIPTION
There are several javadoc warnings that are printed on build. This PR addresses all of the warnings and adds some build config to break the build on a javadoc warning.