### PR TITLE
Remove non log based density methods

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -70,8 +70,8 @@ public class MetropolisHastings {
 
         final double logPNew = logPOld - affectedVerticesLogPOld + affectedVerticesLogPNew;
 
-        final double pqxOld = chosenVertex.logDensity(oldValue);
-        final double pqxNew = chosenVertex.logDensity(proposedValue);
+        final double pqxOld = chosenVertex.logProb(oldValue);
+        final double pqxNew = chosenVertex.logProb(proposedValue);
 
         final double logr = (logPNew * (1.0 / T) + pqxOld) - (logPOld * (1.0 / T) + pqxNew);
         final double r = Math.exp(logr);
@@ -100,7 +100,7 @@ public class MetropolisHastings {
 
     static double sumLogP(Set<Vertex<?>> vertices) {
         return vertices.stream()
-                .mapToDouble(Vertex::logDensityAtValue)
+                .mapToDouble(Vertex::logProbAtValue)
                 .sum();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/particleFiltering/ParticleFilter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/particleFiltering/ParticleFilter.java
@@ -184,7 +184,7 @@ public class ParticleFilter {
         }
 
         private double sumLogP(Collection<Vertex<?>> vertices) {
-            return vertices.stream().mapToDouble(Vertex::logDensityAtValue).sum();
+            return vertices.stream().mapToDouble(Vertex::logProbAtValue).sum();
         }
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
@@ -55,7 +55,7 @@ public class RejectionSampler {
 
     private static boolean matchesObservation(List<Vertex<?>> observedVertices) {
         return observedVertices.stream()
-                .allMatch(v -> v.densityAtValue() != 0.0);
+                .allMatch(v -> v.logDensityAtValue() != Double.NEGATIVE_INFINITY);
     }
 
     private static void takeSamples(Map<String, List<?>> samples, List<? extends Vertex<?>> fromVertices) {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
@@ -55,7 +55,7 @@ public class RejectionSampler {
 
     private static boolean matchesObservation(List<Vertex<?>> observedVertices) {
         return observedVertices.stream()
-                .allMatch(v -> v.logDensityAtValue() != Double.NEGATIVE_INFINITY);
+                .allMatch(v -> v.logProbAtValue() != Double.NEGATIVE_INFINITY);
     }
 
     private static void takeSamples(Map<String, List<?>> samples, List<? extends Vertex<?>> fromVertices) {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/FitnessFunction.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/FitnessFunction.java
@@ -38,7 +38,7 @@ public class FitnessFunction {
     protected double logOfTotalProbability() {
         double sum = 0.0;
         for (Vertex<?> vertex : probabilisticVertices) {
-            sum += vertex.logDensityAtValue();
+            sum += vertex.logProbAtValue();
         }
 
         return sum;

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -37,7 +37,7 @@ public class Poisson {
         return i - 1;
     }
 
-    public static double pdf(double mu, int k) {
+    public static double pmf(double mu, int k) {
         if (k >= 0 && k < 20) {
             return (Math.pow(mu, k) / factorial(k)) * Math.exp(-mu);
         } else if (k >= 20) {

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesNet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesNet.java
@@ -84,7 +84,7 @@ public class BayesNet {
     public double getLogOfMasterP() {
         double sum = 0.0;
         for (Vertex<?> vertex : verticesThatContributeToMasterP) {
-            sum += vertex.logDensityAtValue();
+            sum += vertex.logProbAtValue();
         }
         return sum;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/ContinuousVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/ContinuousVertex.java
@@ -1,0 +1,21 @@
+package io.improbable.keanu.vertices;
+
+import java.util.Map;
+
+public abstract class ContinuousVertex<T> extends Vertex<T> {
+
+    @Override
+    public final double logProb(T value) {
+        return logPdf(value);
+    }
+
+    @Override
+    public final Map<String, Double> dLogProb(T value) {
+        return dLogPdf(value);
+    }
+
+    public abstract double logPdf(T value);
+
+    public abstract Map<String, Double> dLogPdf(T value);
+
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/DiscreteVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/DiscreteVertex.java
@@ -1,0 +1,21 @@
+package io.improbable.keanu.vertices;
+
+import java.util.Map;
+
+public abstract class DiscreteVertex<T> extends Vertex<T> {
+
+    @Override
+    public final double logProb(T value) {
+        return logPmf(value);
+    }
+
+    @Override
+    public final Map<String, Double> dLogProb(T value) {
+        return dLogPmf(value);
+    }
+
+    public abstract double logPmf(T value);
+
+    public abstract Map<String, Double> dLogPmf(T value);
+
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -18,62 +18,26 @@ public abstract class Vertex<T> implements Identifiable {
     private boolean observed;
 
     /**
-     * This is the value of the probability density at the supplied value.
-     *
-     * @param value The supplied value.
-     * @return The probability.
-     */
-    public abstract double density(T value);
-
-    /**
-     * Just a helper method for a common function
-     */
-    public double densityAtValue() {
-        return density(getValue());
-    }
-
-    /**
      * This is the value of the natural log of the probability density at the supplied value.
      *
      * @param value The supplied value.
-     * @return The probability.
+     * @return The log probability.
      */
-    public double logDensity(T value) {
-        return Math.log(density(value));
-    }
+    public abstract double logDensity(T value);
 
-    /**
-     * Just a helper method for a common function
-     */
     public double logDensityAtValue() {
         return logDensity(getValue());
     }
 
     /**
-     * This returns the derivative of the density function with respect to
-     * any dependent vertices.
+     * The partial derivatives of the natural log density.
      *
-     * @return a Map containing { dependent vertex Id -&gt; density slope w.r.t. dependent vertex}
+     * @param value at a given value
      */
-    public abstract Map<String, Double> dDensityAtValue();
+    public abstract Map<String, Double> dLogDensity(T value);
 
-    /**
-     * This is the same as dDensityAtValue except for the log of the density. For numerical
-     * stability a vertex may chose to override this method but if not overridden, the
-     * chain rule is used to calculate the derivative of the log of the density.
-     * <p>
-     * dlog(P)/dx = (dP/dx)*(1/P(x))
-     */
-    public Map<String, Double> dlnDensityAtValue() {
-
-        final double density = densityAtValue();
-        Map<String, Double> dDensityAtValue = dDensityAtValue();
-        Map<String, Double> dLnDensity = new HashMap<>();
-        for (String vertexId : dDensityAtValue.keySet()) {
-            dLnDensity.put(vertexId, dDensityAtValue.get(vertexId) / density);
-        }
-
-        return dLnDensity;
+    public Map<String, Double> dLogDensityAtValue() {
+        return dLogDensity(getValue());
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -18,7 +18,7 @@ public abstract class Vertex<T> implements Identifiable {
     private boolean observed;
 
     /**
-     * This is the value of the natural log probability at the supplied value. In the
+     * This is the natural log of the probability at the supplied value. In the
      * case of continuous vertices, this is actually the log of the density, which
      * will differ from the probability by a constant.
      *

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -18,26 +18,28 @@ public abstract class Vertex<T> implements Identifiable {
     private boolean observed;
 
     /**
-     * This is the value of the natural log of the probability density at the supplied value.
+     * This is the value of the natural log probability at the supplied value. In the
+     * case of continuous vertices, this is actually the log of the density, which
+     * will differ from the probability by a constant.
      *
      * @param value The supplied value.
-     * @return The log probability.
+     * @return The log prob.
      */
-    public abstract double logDensity(T value);
+    public abstract double logProb(T value);
 
-    public double logDensityAtValue() {
-        return logDensity(getValue());
+    public double logProbAtValue() {
+        return logProb(getValue());
     }
 
     /**
-     * The partial derivatives of the natural log density.
+     * The partial derivatives of the natural log prob.
      *
      * @param value at a given value
      */
-    public abstract Map<String, Double> dLogDensity(T value);
+    public abstract Map<String, Double> dLogProb(T value);
 
-    public Map<String, Double> dLogDensityAtValue() {
-        return dLogDensity(getValue());
+    public Map<String, Double> dLogProbAtValue() {
+        return dLogProb(getValue());
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.bool;
 
+import io.improbable.keanu.vertices.DiscreteVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.AndBinaryVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.OrBinaryVertex;
@@ -12,7 +13,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-public abstract class BoolVertex extends Vertex<Boolean> {
+public abstract class BoolVertex extends DiscreteVertex<Boolean> {
 
     public static final ConstantVertex<Boolean> TRUE = new ConstantVertex<>(true);
     public static final ConstantVertex<Boolean> FALSE = new ConstantVertex<>(false);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NonProbabilisticBool.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NonProbabilisticBool.java
@@ -7,12 +7,12 @@ import java.util.Map;
 public abstract class NonProbabilisticBool extends BoolVertex {
 
     @Override
-    public double density(Boolean value) {
-        return this.getDerivedValue().equals(value) ? 1.0 : 0.0;
+    public double logDensity(Boolean value) {
+        return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Boolean value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NonProbabilisticBool.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NonProbabilisticBool.java
@@ -7,12 +7,12 @@ import java.util.Map;
 public abstract class NonProbabilisticBool extends BoolVertex {
 
     @Override
-    public double logDensity(Boolean value) {
+    public double logProb(Boolean value) {
         return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Boolean value) {
+    public Map<String, Double> dLogProb(Boolean value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NonProbabilisticBool.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NonProbabilisticBool.java
@@ -7,12 +7,12 @@ import java.util.Map;
 public abstract class NonProbabilisticBool extends BoolVertex {
 
     @Override
-    public double logProb(Boolean value) {
+    public double logPmf(Boolean value) {
         return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dLogProb(Boolean value) {
+    public Map<String, Double> dLogPmf(Boolean value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/Flip.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/Flip.java
@@ -8,42 +8,42 @@ import java.util.Random;
 
 public class Flip extends ProbabilisticBool {
 
-    private final Vertex<Double> probabilityTrue;
+    private final Vertex<Double> probTrue;
     private final Random random;
 
-    public Flip(Vertex<Double> probabilityTrue, Random random) {
-        this.probabilityTrue = probabilityTrue;
+    public Flip(Vertex<Double> probTrue, Random random) {
+        this.probTrue = probTrue;
         this.random = random;
         setValue(false);
-        setParents(probabilityTrue);
+        setParents(probTrue);
     }
 
-    public Flip(double probabilityTrue, Random random) {
-        this(new ConstantDoubleVertex(probabilityTrue), random);
+    public Flip(double probTrue, Random random) {
+        this(new ConstantDoubleVertex(probTrue), random);
     }
 
-    public Flip(double probabilityTrue) {
-        this(new ConstantDoubleVertex(probabilityTrue), new Random());
+    public Flip(double probTrue) {
+        this(new ConstantDoubleVertex(probTrue), new Random());
     }
 
-    public Vertex<Double> getProbabilityTrue() {
-        return probabilityTrue;
+    public Vertex<Double> getProbTrue() {
+        return probTrue;
     }
 
     @Override
-    public double logProb(Boolean value) {
-        final double probability = value ? probabilityTrue.getValue() : 1 - probabilityTrue.getValue();
+    public double logPmf(Boolean value) {
+        final double probability = value ? probTrue.getValue() : 1 - probTrue.getValue();
         return Math.log(probability);
     }
 
     @Override
-    public Map<String, Double> dLogProb(Boolean value) {
+    public Map<String, Double> dLogPmf(Boolean value) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Boolean sample() {
-        return random.nextDouble() < probabilityTrue.getValue();
+        return random.nextDouble() < probTrue.getValue();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/Flip.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/Flip.java
@@ -8,42 +8,42 @@ import java.util.Random;
 
 public class Flip extends ProbabilisticBool {
 
-    private final Vertex<Double> probTrue;
+    private final Vertex<Double> probabilityTrue;
     private final Random random;
 
-    public Flip(Vertex<Double> probTrue, Random random) {
-        this.probTrue = probTrue;
+    public Flip(Vertex<Double> probabilityTrue, Random random) {
+        this.probabilityTrue = probabilityTrue;
         this.random = random;
         setValue(false);
-        setParents(probTrue);
+        setParents(probabilityTrue);
     }
 
-    public Flip(double probTrue, Random random) {
-        this(new ConstantDoubleVertex(probTrue), random);
+    public Flip(double probabilityTrue, Random random) {
+        this(new ConstantDoubleVertex(probabilityTrue), random);
     }
 
-    public Flip(double probTrue) {
-        this(new ConstantDoubleVertex(probTrue), new Random());
+    public Flip(double probabilityTrue) {
+        this(new ConstantDoubleVertex(probabilityTrue), new Random());
     }
 
-    public Vertex<Double> getProbTrue() {
-        return probTrue;
-    }
-
-    @Override
-    public double logDensity(Boolean value) {
-        final double density = value ? probTrue.getValue() : 1 - probTrue.getValue();
-        return Math.log(density);
+    public Vertex<Double> getProbabilityTrue() {
+        return probabilityTrue;
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Boolean value) {
+    public double logProb(Boolean value) {
+        final double probability = value ? probabilityTrue.getValue() : 1 - probabilityTrue.getValue();
+        return Math.log(probability);
+    }
+
+    @Override
+    public Map<String, Double> dLogProb(Boolean value) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Boolean sample() {
-        return random.nextDouble() < probTrue.getValue();
+        return random.nextDouble() < probabilityTrue.getValue();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/Flip.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/Flip.java
@@ -31,12 +31,13 @@ public class Flip extends ProbabilisticBool {
     }
 
     @Override
-    public double density(Boolean value) {
-        return value ? probTrue.getValue() : 1 - probTrue.getValue();
+    public double logDensity(Boolean value) {
+        final double density = value ? probTrue.getValue() : 1 - probTrue.getValue();
+        return Math.log(density);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Boolean value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -2,23 +2,18 @@ package io.improbable.keanu.vertices.dbl;
 
 
 import io.improbable.keanu.kotlin.DoubleOperators;
+import io.improbable.keanu.vertices.ContinuousVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.CastDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.AdditionVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DifferenceVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DivisionVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.*;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.*;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.PowerVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.AbsVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpLambda;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public abstract class DoubleVertex extends Vertex<Double> implements DoubleOperators<DoubleVertex> {
+public abstract class DoubleVertex extends ContinuousVertex<Double> implements DoubleOperators<DoubleVertex> {
 
     public abstract DualNumber getDualNumber();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
@@ -22,12 +22,12 @@ public abstract class NonProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return this.getDerivedValue().equals(value) ? 1.0 : 0.0;
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
@@ -22,12 +22,12 @@ public abstract class NonProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public double density(Double value) {
+    public double logDensity(Double value) {
         return this.getDerivedValue().equals(value) ? 1.0 : 0.0;
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
@@ -22,12 +22,12 @@ public abstract class NonProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
@@ -23,7 +23,7 @@ public abstract class NonProbabilisticDouble extends DoubleVertex {
 
     @Override
     public double logProb(Double value) {
-        return this.getDerivedValue().equals(value) ? 1.0 : 0.0;
+        return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
@@ -23,28 +23,28 @@ public class LogProbGradient {
     }
 
     public static Map<String, Double> getLogProbGradientWrtLatents(final Vertex<?> probabilisticVertex,
-                                                                   final Map<String, Double> diffOfLogWrt) {
+                                                                   final Map<String, Double> diffOfLogProbWrt) {
         //Non-probabilistic vertices are non-differentiable
         if (!probabilisticVertex.isProbabilistic()) {
-            return diffOfLogWrt;
+            return diffOfLogProbWrt;
         }
 
-        //dlnDensityForProbabilisticVertex is the partial differentials of the natural
-        //log of the fitness vertex's density w.r.t latent vertices. The key of the
+        //dlogProbForProbabilisticVertex is the partial differentials of the natural
+        //log of the fitness vertex's probability w.r.t latent vertices. The key of the
         //map is the latent vertex's id.
-        final Map<String, Double> dlnDensityForProbabilisticVertex = probabilisticVertex.dLogDensityAtValue();
+        final Map<String, Double> dlogProbForProbabilisticVertex = probabilisticVertex.dLogProbAtValue();
 
-        for (Map.Entry<String, Double> partialDiffLogPWrt : dlnDensityForProbabilisticVertex.entrySet()) {
+        for (Map.Entry<String, Double> partialDiffLogPWrt : dlogProbForProbabilisticVertex.entrySet()) {
             final String wrtLatentVertexId = partialDiffLogPWrt.getKey();
-            final double partialDiffLogPContribution = partialDiffLogPWrt.getValue();
+            final double partialDiffLogProbContribution = partialDiffLogPWrt.getValue();
 
-            //partialDiffLogPContribution is the contribution to the rate of change of
+            //partialDiffLogProbContribution is the contribution to the rate of change of
             //the natural log of the fitness vertex due to wrtLatentVertexId.
-            final double accumulatedDiffOfLogPWrtLatent = diffOfLogWrt.getOrDefault(wrtLatentVertexId, 0.0);
-            diffOfLogWrt.put(wrtLatentVertexId, accumulatedDiffOfLogPWrtLatent + partialDiffLogPContribution);
+            final double accumulatedDiffOfLogPWrtLatent = diffOfLogProbWrt.getOrDefault(wrtLatentVertexId, 0.0);
+            diffOfLogProbWrt.put(wrtLatentVertexId, accumulatedDiffOfLogPWrtLatent + partialDiffLogProbContribution);
         }
 
-        return diffOfLogWrt;
+        return diffOfLogProbWrt;
     }
 
     public static Map<String, Double> getLogProbGradientWrtLatents(final Vertex<?> probabilisticVertex) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
@@ -32,7 +32,7 @@ public class LogProbGradient {
         //dlnDensityForProbabilisticVertex is the partial differentials of the natural
         //log of the fitness vertex's density w.r.t latent vertices. The key of the
         //map is the latent vertex's id.
-        final Map<String, Double> dlnDensityForProbabilisticVertex = probabilisticVertex.dlnDensityAtValue();
+        final Map<String, Double> dlnDensityForProbabilisticVertex = probabilisticVertex.dLogDensityAtValue();
 
         for (Map.Entry<String, Double> partialDiffLogPWrt : dlnDensityForProbabilisticVertex.entrySet()) {
             final String wrtLatentVertexId = partialDiffLogPWrt.getKey();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -50,11 +50,6 @@ public class BetaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return Beta.pdf(alpha.getValue(), beta.getValue(), value);
-    }
-
-    @Override
     public double logDensity(Double value) {
         return Beta.logPdf(alpha.getValue(), beta.getValue(), value);
     }
@@ -68,14 +63,8 @@ public class BetaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
-        Beta.Diff dPdf = Beta.dPdf(alpha.getValue(), beta.getValue(), getValue());
-        return convertDualNumbersToDiff(dPdf.dPdAlpha, dPdf.dPdBeta, dPdf.dPdx);
-    }
-
-    @Override
-    public Map<String, Double> dlnDensityAtValue() {
-        Beta.Diff dlnPdf = Beta.dlnPdf(alpha.getValue(), beta.getValue(), getValue());
+    public Map<String, Double> dLogDensity(Double value) {
+        Beta.Diff dlnPdf = Beta.dlnPdf(alpha.getValue(), beta.getValue(), value);
         return convertDualNumbersToDiff(dlnPdf.dPdAlpha, dlnPdf.dPdBeta, dlnPdf.dPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -50,7 +50,7 @@ public class BetaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return Beta.logPdf(alpha.getValue(), beta.getValue(), value);
     }
 
@@ -63,7 +63,7 @@ public class BetaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         Beta.Diff dlnPdf = Beta.dlnPdf(alpha.getValue(), beta.getValue(), value);
         return convertDualNumbersToDiff(dlnPdf.dPdAlpha, dlnPdf.dPdBeta, dlnPdf.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -50,7 +50,7 @@ public class BetaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return Beta.logPdf(alpha.getValue(), beta.getValue(), value);
     }
 
@@ -63,7 +63,7 @@ public class BetaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         Beta.Diff dlnPdf = Beta.dlnPdf(alpha.getValue(), beta.getValue(), value);
         return convertDualNumbersToDiff(dlnPdf.dPdAlpha, dlnPdf.dPdBeta, dlnPdf.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -37,16 +37,12 @@ public class ChiSquaredVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return ChiSquared.pdf(k.getValue(), value);
-    }
-
     public double logDensity(Double value) {
         return ChiSquared.logPdf(k.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -37,12 +37,12 @@ public class ChiSquaredVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return ChiSquared.logPdf(k.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -37,12 +37,12 @@ public class ChiSquaredVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return ChiSquared.logPdf(k.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -58,12 +58,12 @@ public class ExponentialVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return Exponential.logPdf(a.getValue(), b.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         Exponential.Diff dP = Exponential.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -58,12 +58,12 @@ public class ExponentialVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return Exponential.logPdf(a.getValue(), b.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         Exponential.Diff dP = Exponential.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -58,23 +58,13 @@ public class ExponentialVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return Exponential.pdf(a.getValue(), b.getValue(), value);
-    }
-
     public double logDensity(Double value) {
         return Exponential.logPdf(a.getValue(), b.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
-        Exponential.Diff dP = Exponential.dPdf(a.getValue(), b.getValue(), getValue());
-        return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
-    }
-
-    @Override
-    public Map<String, Double> dlnDensityAtValue() {
-        Exponential.Diff dP = Exponential.dlnPdf(a.getValue(), b.getValue(), getValue());
+    public Map<String, Double> dLogDensity(Double value) {
+        Exponential.Diff dP = Exponential.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -74,12 +74,12 @@ public class GammaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return Gamma.logPdf(a.getValue(), theta.getValue(), k.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         Gamma.Diff diff = Gamma.dlnPdf(a.getValue(), theta.getValue(), k.getValue(), value);
         return convertDualNumbersToDiff(diff.dPda, diff.dPdtheta, diff.dPdk, diff.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -74,12 +74,12 @@ public class GammaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return Gamma.logPdf(a.getValue(), theta.getValue(), k.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         Gamma.Diff diff = Gamma.dlnPdf(a.getValue(), theta.getValue(), k.getValue(), value);
         return convertDualNumbersToDiff(diff.dPda, diff.dPdtheta, diff.dPdk, diff.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -74,23 +74,13 @@ public class GammaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return Gamma.pdf(a.getValue(), theta.getValue(), k.getValue(), value);
-    }
-
     public double logDensity(Double value) {
         return Gamma.logPdf(a.getValue(), theta.getValue(), k.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
-        Gamma.Diff diff = Gamma.dPdf(a.getValue(), theta.getValue(), k.getValue(), getValue());
-        return convertDualNumbersToDiff(diff.dPda, diff.dPdtheta, diff.dPdk, diff.dPdx);
-    }
-
-    @Override
-    public Map<String, Double> dlnDensityAtValue() {
-        Gamma.Diff diff = Gamma.dlnPdf(a.getValue(), theta.getValue(), k.getValue(), getValue());
+    public Map<String, Double> dLogDensity(Double value) {
+        Gamma.Diff diff = Gamma.dlnPdf(a.getValue(), theta.getValue(), k.getValue(), value);
         return convertDualNumbersToDiff(diff.dPda, diff.dPdtheta, diff.dPdk, diff.dPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -59,12 +59,12 @@ public class GaussianVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return Gaussian.logPdf(mu.getValue(), sigma.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         Gaussian.Diff dlnP = Gaussian.dlnPdf(mu.getValue(), sigma.getValue(), value);
         return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPdsigma, dlnP.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -59,23 +59,13 @@ public class GaussianVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return Gaussian.pdf(mu.getValue(), sigma.getValue(), value);
-    }
-
     public double logDensity(Double value) {
         return Gaussian.logPdf(mu.getValue(), sigma.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
-        Gaussian.Diff dP = Gaussian.dPdf(mu.getValue(), sigma.getValue(), getValue());
-        return convertDualNumbersToDiff(dP.dPdmu, dP.dPdsigma, dP.dPdx);
-    }
-
-    @Override
-    public Map<String, Double> dlnDensityAtValue() {
-        Gaussian.Diff dlnP = Gaussian.dlnPdf(mu.getValue(), sigma.getValue(), getValue());
+    public Map<String, Double> dLogDensity(Double value) {
+        Gaussian.Diff dlnP = Gaussian.dlnPdf(mu.getValue(), sigma.getValue(), value);
         return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPdsigma, dlnP.dPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -59,12 +59,12 @@ public class GaussianVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return Gaussian.logPdf(mu.getValue(), sigma.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         Gaussian.Diff dlnP = Gaussian.dlnPdf(mu.getValue(), sigma.getValue(), value);
         return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPdsigma, dlnP.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -56,11 +56,11 @@ public class InverseGammaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return InverseGamma.logPdf(a.getValue(), b.getValue(), value);
     }
 
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         InverseGamma.Diff dP = InverseGamma.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -56,22 +56,12 @@ public class InverseGammaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return InverseGamma.pdf(a.getValue(), b.getValue(), value);
-    }
-
     public double logDensity(Double value) {
         return InverseGamma.logPdf(a.getValue(), b.getValue(), value);
     }
 
-    @Override
-    public Map<String, Double> dDensityAtValue() {
-        InverseGamma.Diff dP = InverseGamma.dPdf(a.getValue(), b.getValue(), getValue());
-        return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
-    }
-
-    public Map<String, Double> dlnDensityAtValue() {
-        InverseGamma.Diff dP = InverseGamma.dlnPdf(a.getValue(), b.getValue(), getValue());
+    public Map<String, Double> dLogDensity(Double value) {
+        InverseGamma.Diff dP = InverseGamma.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -56,11 +56,11 @@ public class InverseGammaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return InverseGamma.logPdf(a.getValue(), b.getValue(), value);
     }
 
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         InverseGamma.Diff dP = InverseGamma.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -50,12 +50,12 @@ public class LaplaceVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return Laplace.logPdf(mu.getValue(), beta.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         Laplace.Diff diff = Laplace.dlnPdf(mu.getValue(), beta.getValue(), value);
         return convertDualNumbersToDiff(diff.dPdmu, diff.dPdbeta, diff.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -50,23 +50,13 @@ public class LaplaceVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return Laplace.pdf(mu.getValue(), beta.getValue(), value);
-    }
-
     public double logDensity(Double value) {
         return Laplace.logPdf(mu.getValue(), beta.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
-        Laplace.Diff diff = Laplace.dPdf(mu.getValue(), beta.getValue(), getValue());
-        return convertDualNumbersToDiff(diff.dPdmu, diff.dPdbeta, diff.dPdx);
-    }
-
-    @Override
-    public Map<String, Double> dlnDensityAtValue() {
-        Laplace.Diff diff = Laplace.dlnPdf(mu.getValue(), beta.getValue(), getValue());
+    public Map<String, Double> dLogDensity(Double value) {
+        Laplace.Diff diff = Laplace.dlnPdf(mu.getValue(), beta.getValue(), value);
         return convertDualNumbersToDiff(diff.dPdmu, diff.dPdbeta, diff.dPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -50,12 +50,12 @@ public class LaplaceVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return Laplace.logPdf(mu.getValue(), beta.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         Laplace.Diff diff = Laplace.dlnPdf(mu.getValue(), beta.getValue(), value);
         return convertDualNumbersToDiff(diff.dPdmu, diff.dPdbeta, diff.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -58,12 +58,12 @@ public class LogisticVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return Logistic.logPdf(a.getValue(), b.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         Logistic.Diff diff = Logistic.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(diff.dPda, diff.dPdb, diff.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -58,23 +58,13 @@ public class LogisticVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return Logistic.pdf(a.getValue(), b.getValue(), value);
-    }
-
     public double logDensity(Double value) {
         return Logistic.logPdf(a.getValue(), b.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
-        Logistic.Diff diff = Logistic.dPdf(a.getValue(), b.getValue(), getValue());
-        return convertDualNumbersToDiff(diff.dPda, diff.dPdb, diff.dPdx);
-    }
-
-    @Override
-    public Map<String, Double> dlnDensityAtValue() {
-        Logistic.Diff diff = Logistic.dlnPdf(a.getValue(), b.getValue(), getValue());
+    public Map<String, Double> dLogDensity(Double value) {
+        Logistic.Diff diff = Logistic.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(diff.dPda, diff.dPdb, diff.dPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -58,12 +58,12 @@ public class LogisticVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return Logistic.logPdf(a.getValue(), b.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         Logistic.Diff diff = Logistic.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(diff.dPda, diff.dPdb, diff.dPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -67,21 +67,24 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
+    public double logDensity(Double value) {
         final double min = xMin.getValue();
         final double max = xMax.getValue();
         final double shoulderWidth = this.edgeSharpness * (max - min);
-        return SmoothUniformDistribution.pdf(min, max, shoulderWidth, value);
+        final double density = SmoothUniformDistribution.pdf(min, max, shoulderWidth, value);
+        return Math.log(density);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Double value) {
         final double min = xMin.getValue();
         final double max = xMax.getValue();
         final double shoulderWidth = this.edgeSharpness * (max - min);
-        final double dPdfdx = SmoothUniformDistribution.dPdfdx(min, max, shoulderWidth, this.getValue());
+        final double dPdfdx = SmoothUniformDistribution.dPdfdx(min, max, shoulderWidth, value);
+        final double density = SmoothUniformDistribution.pdf(min, max, shoulderWidth, value);
+        final double dlogPdfdx = dPdfdx / density;
 
-        return singletonMap(getId(), dPdfdx);
+        return singletonMap(getId(), dlogPdfdx);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -67,7 +67,7 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         final double min = xMin.getValue();
         final double max = xMax.getValue();
         final double shoulderWidth = this.edgeSharpness * (max - min);
@@ -76,7 +76,7 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         final double min = xMin.getValue();
         final double max = xMax.getValue();
         final double shoulderWidth = this.edgeSharpness * (max - min);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -67,7 +67,7 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         final double min = xMin.getValue();
         final double max = xMax.getValue();
         final double shoulderWidth = this.edgeSharpness * (max - min);
@@ -76,7 +76,7 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         final double min = xMin.getValue();
         final double max = xMax.getValue();
         final double shoulderWidth = this.edgeSharpness * (max - min);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -86,13 +86,17 @@ public class TriangularVertex extends ProbabilisticDouble {
         return xMax;
     }
 
-    @Override
-    public double density(Double value) {
+    private double density(Double value) {
         return Triangular.pdf(xMin.getValue(), xMax.getValue(), c.getValue(), value);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public double logDensity(Double value) {
+        return Math.log(density(value));
+    }
+
+    @Override
+    public Map<String, Double> dLogDensity(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -91,12 +91,12 @@ public class TriangularVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return Math.log(density(value));
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -86,17 +86,17 @@ public class TriangularVertex extends ProbabilisticDouble {
         return xMax;
     }
 
-    private double density(Double value) {
+    private double pdf(Double value) {
         return Triangular.pdf(xMin.getValue(), xMax.getValue(), c.getValue(), value);
     }
 
     @Override
-    public double logProb(Double value) {
-        return Math.log(density(value));
+    public double logPdf(Double value) {
+        return Math.log(pdf(value));
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -59,12 +59,12 @@ public class UniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double density(Double value) {
-        return Uniform.pdf(xMin.getValue(), xMax.getValue(), value);
+    public double logDensity(Double value) {
+        return Math.log(Uniform.pdf(xMin.getValue(), xMax.getValue(), value));
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Double value) {
         double min = this.xMin.getValue();
         double max = this.xMax.getValue();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -59,12 +59,12 @@ public class UniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logProb(Double value) {
+    public double logPdf(Double value) {
         return Math.log(Uniform.pdf(xMin.getValue(), xMax.getValue(), value));
     }
 
     @Override
-    public Map<String, Double> dLogProb(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         double min = this.xMin.getValue();
         double max = this.xMax.getValue();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -59,12 +59,12 @@ public class UniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public double logDensity(Double value) {
+    public double logProb(Double value) {
         return Math.log(Uniform.pdf(xMin.getValue(), xMax.getValue(), value));
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Double value) {
+    public Map<String, Double> dLogProb(Double value) {
         double min = this.xMin.getValue();
         double max = this.xMax.getValue();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/NonProbabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/NonProbabilistic.java
@@ -7,12 +7,12 @@ import java.util.Map;
 public abstract class NonProbabilistic<T> extends Vertex<T> {
 
     @Override
-    public double logDensity(T value) {
+    public double logProb(T value) {
         return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dLogDensity(T value) {
+    public Map<String, Double> dLogProb(T value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/NonProbabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/NonProbabilistic.java
@@ -7,12 +7,12 @@ import java.util.Map;
 public abstract class NonProbabilistic<T> extends Vertex<T> {
 
     @Override
-    public double density(T value) {
-        return this.getDerivedValue().equals(value) ? 1.0 : 0.0;
+    public double logDensity(T value) {
+        return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(T value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/SelectVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/SelectVertex.java
@@ -49,13 +49,13 @@ public class SelectVertex<T> extends Probabilistic<T> {
     }
 
     @Override
-    public double logDensity(T value) {
-        final double density = selectableValues.get(value).getValue() / getSumOfProbabilities();
-        return Math.log(density);
+    public double logProb(T value) {
+        final double probability = selectableValues.get(value).getValue() / getSumOfProbabilities();
+        return Math.log(probability);
     }
 
     @Override
-    public Map<String, Double> dLogDensity(T value) {
+    public Map<String, Double> dLogProb(T value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/SelectVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/SelectVertex.java
@@ -28,13 +28,13 @@ public class SelectVertex<T> extends Probabilistic<T> {
 
     @Override
     public T sample() {
-        double sumP = sumProbabilities();
+        double sumOfProbabilities = getSumOfProbabilities();
         double p = random.nextDouble();
         double sum = 0;
 
         T value = null;
         for (Map.Entry<T, DoubleVertex> entry : selectableValues.entrySet()) {
-            sum += entry.getValue().getValue() / sumP;
+            sum += entry.getValue().getValue() / sumOfProbabilities;
             if (p < sum) {
                 value = entry.getKey();
                 break;
@@ -49,16 +49,17 @@ public class SelectVertex<T> extends Probabilistic<T> {
     }
 
     @Override
-    public double density(T value) {
-        return selectableValues.get(value).getValue() / sumProbabilities();
+    public double logDensity(T value) {
+        final double density = selectableValues.get(value).getValue() / getSumOfProbabilities();
+        return Math.log(density);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(T value) {
         throw new UnsupportedOperationException();
     }
 
-    private double sumProbabilities() {
+    private double getSumOfProbabilities() {
         double sumP = 0.0;
         for (DoubleVertex p : selectableValues.values()) {
             sumP += p.getValue();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.intgr;
 
 
 import io.improbable.keanu.kotlin.IntegerOperators;
+import io.improbable.keanu.vertices.DiscreteVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.CastIntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
@@ -14,7 +15,7 @@ import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.Integ
 
 import java.util.function.Function;
 
-public abstract class IntegerVertex extends Vertex<Integer> implements IntegerOperators<IntegerVertex> {
+public abstract class IntegerVertex extends DiscreteVertex<Integer> implements IntegerOperators<IntegerVertex> {
 
     public IntegerVertex minus(IntegerVertex that) {
         return new IntegerDifferenceVertex(this, that);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/NonProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/NonProbabilisticInteger.java
@@ -22,12 +22,12 @@ public abstract class NonProbabilisticInteger extends IntegerVertex {
     }
 
     @Override
-    public double logDensity(Integer value) {
+    public double logProb(Integer value) {
         return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Integer value) {
+    public Map<String, Double> dLogProb(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/NonProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/NonProbabilisticInteger.java
@@ -22,12 +22,12 @@ public abstract class NonProbabilisticInteger extends IntegerVertex {
     }
 
     @Override
-    public double density(Integer value) {
-        return this.getDerivedValue().equals(value) ? 1 : 0;
+    public double logDensity(Integer value) {
+        return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/NonProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/NonProbabilisticInteger.java
@@ -22,12 +22,12 @@ public abstract class NonProbabilisticInteger extends IntegerVertex {
     }
 
     @Override
-    public double logProb(Integer value) {
+    public double logPmf(Integer value) {
         return this.getDerivedValue().equals(value) ? 0.0 : Double.NEGATIVE_INFINITY;
     }
 
     @Override
-    public Map<String, Double> dLogProb(Integer value) {
+    public Map<String, Double> dLogPmf(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
@@ -87,12 +87,12 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public double logProb(Integer value) {
+    public double logPmf(Integer value) {
         return Math.log(density(value));
     }
 
     @Override
-    public Map<String, Double> dLogProb(Integer value) {
+    public Map<String, Double> dLogPmf(Integer value) {
         int i = getValue();
         double x = input.getValue();
         double clampedX = getClampedInput();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
@@ -64,8 +64,7 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
         return max;
     }
 
-    @Override
-    public double density(Integer value) {
+    private double density(Integer value) {
         double i = value;
         double x = getClampedInput();
         double sigma = fuzzinessSigma.getValue();
@@ -76,20 +75,12 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
-        int i = getValue();
-        double x = input.getValue();
-        double clampedX = getClampedInput();
-        double sigma = fuzzinessSigma.getValue();
-
-        double dPdInput = clampedX == x ? dPdx(x, i, sigma) : 0.0;
-        double dPdSigma = dPdSigma(clampedX, i, sigma);
-
-        return convertDualNumbersToDiff(dPdInput, dPdSigma);
+    public double logDensity(Integer value) {
+        return Math.log(density(value));
     }
 
     @Override
-    public Map<String, Double> dlnDensityAtValue() {
+    public Map<String, Double> dLogDensity(Integer value) {
         int i = getValue();
         double x = input.getValue();
         double clampedX = getClampedInput();
@@ -98,7 +89,7 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
         double dPdInput = clampedX == x ? dPdx(x, i, sigma) : 0.0;
         double dPdSigma = dPdSigma(clampedX, i, sigma);
 
-        double p = densityAtValue();
+        double p = density(value);
         double dlnPdInput = dPdInput / p;
         double dlnPdSigma = dPdSigma / p;
 
@@ -172,10 +163,6 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
     }
 
     private double N(double mu, double sigma) {
-        return n(mu, sigma) / Math.sqrt(2 * Math.PI * sigma * sigma);
-    }
-
-    private double n(double mu, double sigma) {
-        return Math.exp(-(mu * mu) / (2.0 * sigma * sigma));
+        return Gaussian.pdf(mu, sigma, 0);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
@@ -75,12 +75,12 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public double logDensity(Integer value) {
+    public double logProb(Integer value) {
         return Math.log(density(value));
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Integer value) {
+    public Map<String, Double> dLogProb(Integer value) {
         int i = getValue();
         double x = input.getValue();
         double clampedX = getClampedInput();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -36,12 +36,12 @@ public class PoissonVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public double density(Integer value) {
-        return Poisson.pdf(mu.getValue(), value);
+    public double logDensity(Integer value) {
+        return Math.log(Poisson.pdf(mu.getValue(), value));
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -36,12 +36,12 @@ public class PoissonVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public double logDensity(Integer value) {
+    public double logProb(Integer value) {
         return Math.log(Poisson.pdf(mu.getValue(), value));
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Integer value) {
+    public Map<String, Double> dLogProb(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -36,12 +36,12 @@ public class PoissonVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public double logProb(Integer value) {
-        return Math.log(Poisson.pdf(mu.getValue(), value));
+    public double logPmf(Integer value) {
+        return Math.log(Poisson.pmf(mu.getValue(), value));
     }
 
     @Override
-    public Map<String, Double> dLogProb(Integer value) {
+    public Map<String, Double> dLogPmf(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 
 import java.util.Map;
@@ -61,12 +60,13 @@ public class UniformIntVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public double density(Integer value) {
-        return 1.0 / (max.getValue() - min.getValue());
+    public double logDensity(Integer value) {
+        final double density = 1.0 / (max.getValue() - min.getValue());
+        return Math.log(density);
     }
 
     @Override
-    public Map<String, Double> dDensityAtValue() {
+    public Map<String, Double> dLogDensity(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -60,13 +60,13 @@ public class UniformIntVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public double logDensity(Integer value) {
-        final double density = 1.0 / (max.getValue() - min.getValue());
-        return Math.log(density);
+    public double logProb(Integer value) {
+        final double probability = 1.0 / (max.getValue() - min.getValue());
+        return Math.log(probability);
     }
 
     @Override
-    public Map<String, Double> dLogDensity(Integer value) {
+    public Map<String, Double> dLogProb(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -61,13 +61,13 @@ public class UniformIntVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public double logProb(Integer value) {
+    public double logPmf(Integer value) {
         final double probability = 1.0 / (max.getValue() - min.getValue());
         return Math.log(probability);
     }
 
     @Override
-    public Map<String, Double> dLogProb(Integer value) {
+    public Map<String, Double> dLogPmf(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/rocket/RocketTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/rocket/RocketTest.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Random;
 
-import static io.improbable.keanu.vertices.bool.BoolVertexTest.priorProbTrue;
+import static io.improbable.keanu.vertices.bool.BoolVertexTest.priorProbabilityTrue;
 import static org.junit.Assert.assertEquals;
 
 public class RocketTest {
@@ -43,7 +43,7 @@ public class RocketTest {
                 .or(overHeatDueToResidualFuel)
                 .or(overHeatDueToBoth);
 
-        double probOfOverheat = priorProbTrue(overHeated, 10000);
+        double probOfOverheat = priorProbabilityTrue(overHeated, 10000);
         log.info("Prior Probability rocket overheats: " + probOfOverheat);
 
         Flip alarm1NotFalseNegative = new Flip(0.99, r);
@@ -54,10 +54,10 @@ public class RocketTest {
         Flip alarm2FalsePositive = new Flip(0.1, r);
         BoolVertex alarm2 = overHeated.and(alarm2NotFalseNegative).or(alarm2FalsePositive);
 
-        double probOfAlarm1 = priorProbTrue(alarm1, 10000);
+        double probOfAlarm1 = priorProbabilityTrue(alarm1, 10000);
         log.info("Prior Probability alarm1 sounds: " + probOfAlarm1);
 
-        double probOfAlarm2 = priorProbTrue(alarm2, 10000);
+        double probOfAlarm2 = priorProbabilityTrue(alarm2, 10000);
         log.info("Prior Probability alarm2 sounds: " + probOfAlarm2);
 
         alarm1.observe(true);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/BoolVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/BoolVertexTest.java
@@ -53,34 +53,34 @@ public class BoolVertexTest {
     }
 
     @Test
-    public void orDensityIsCorrect() {
+    public void orProbabilityIsCorrect() {
         BoolVertex v3 = v1.or(v2);
 
-        double pV3True = orDensity(pV1, pV2);
+        double pV3True = orProbability(pV1, pV2);
 
-        assertEquals(priorProbTrue(v3, 10000), pV3True, 0.01);
+        assertEquals(priorProbabilityTrue(v3, 10000), pV3True, 0.01);
     }
 
     @Test
-    public void andDensityIsCorrect() {
+    public void andProbabilityIsCorrect() {
         BoolVertex v3 = v1.and(v2);
 
-        double pV3True = andDensity(pV1, pV2);
+        double pV3True = andProbability(pV1, pV2);
 
-        assertEquals(priorProbTrue(v3, 10000), pV3True, 0.01);
+        assertEquals(priorProbabilityTrue(v3, 10000), pV3True, 0.01);
     }
 
     @Test
-    public void ifDensityIsCorrect() {
+    public void ifProbabilityIsCorrect() {
 
         double pV3 = 0.1;
         Flip v3 = new Flip(pV3, random);
 
         Vertex<Boolean> v4 = If(v1, v2, v3);
 
-        double pV4True = ifDensity(pV1, pV2, pV3);
+        double pV4True = ifProbability(pV1, pV2, pV3);
 
-        assertEquals(priorProbTrue(v4, 10000), pV4True, 0.01);
+        assertEquals(priorProbabilityTrue(v4, 10000), pV4True, 0.01);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class BoolVertexTest {
 
         CastBoolVertex a = new CastBoolVertex(f);
 
-        assertEquals(priorProbTrue(a, 10000), p, 0.01);
+        assertEquals(priorProbabilityTrue(a, 10000), p, 0.01);
     }
 
     @Test
@@ -104,26 +104,26 @@ public class BoolVertexTest {
 
         BoolVertex a = f.and(tru).or(fal);
 
-        assertEquals(priorProbTrue(a, 10000), p, 0.01);
+        assertEquals(priorProbabilityTrue(a, 10000), p, 0.01);
     }
 
 
-    private double andDensity(double pA, double pB) {
+    private double andProbability(double pA, double pB) {
         return pA * pB;
     }
 
-    private double orDensity(double pA, double pB) {
+    private double orProbability(double pA, double pB) {
         return pA + pB - (pA * pB);
     }
 
-    private double ifDensity(double pThn, double pThnIsValue, double pElsIsValue) {
+    private double ifProbability(double pThn, double pThnIsValue, double pElsIsValue) {
         double pThnAndThnIsValue = pThn * pThnIsValue;
         double pElsAndElsIsValue = (1 - pThn) * pElsIsValue;
 
         return pThnAndThnIsValue + pElsAndElsIsValue;
     }
 
-    public static double priorProbTrue(Vertex<Boolean> vertex, int sampleCount) {
+    public static double priorProbabilityTrue(Vertex<Boolean> vertex, int sampleCount) {
         BayesNet net = new BayesNet(vertex.getConnectedGraph());
 
         NetworkSamples samples = Prior.sample(net, Collections.singletonList(vertex), sampleCount);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -44,7 +44,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dLogDensityAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(0, gradient, 0);
     }
@@ -54,7 +54,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.25;
         b.setValue(value);
-        double gradient = b.dLogDensityAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(1, Math.signum(gradient), 0);
     }
@@ -64,7 +64,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.75;
         b.setValue(value);
-        double gradient = b.dLogDensityAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(-1, Math.signum(gradient), 0);
     }
@@ -74,7 +74,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(1.5), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dLogDensityAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(1, Math.signum(gradient), 0);
     }
@@ -84,16 +84,16 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(1.5), new ConstantDoubleVertex(3.0), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dLogDensityAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(-1, Math.signum(gradient), 0);
     }
 
     @Test
-    public void sampleMatchesDensity() {
+    public void sampleMatchesLogProb() {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(2.0), new ConstantDoubleVertex(2.0), random);
 
-        ProbabilisticDoubleContract.sampleMethodMatchesDensityMethod(
+        ProbabilisticDoubleContract.sampleMethodMatchesLogProbMethod(
                 b,
                 1000000,
                 0.1,
@@ -104,7 +104,7 @@ public class BetaVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPda() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPda() {
         UniformVertex uniformA = new UniformVertex(new ConstantDoubleVertex(1.5), new ConstantDoubleVertex(3.0));
         BetaVertex beta = new BetaVertex(uniformA, new ConstantDoubleVertex(3.0), random);
 
@@ -130,7 +130,7 @@ public class BetaVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdb() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdb() {
         UniformVertex uniformA = new UniformVertex(new ConstantDoubleVertex(1.5), new ConstantDoubleVertex(3.0));
         BetaVertex beta = new BetaVertex(new ConstantDoubleVertex(1.0), uniformA, random);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -44,7 +44,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dDensityAtValue().get(b.getId());
+        double gradient = b.dLogDensityAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(0, gradient, 0);
     }
@@ -54,7 +54,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.25;
         b.setValue(value);
-        double gradient = b.dDensityAtValue().get(b.getId());
+        double gradient = b.dLogDensityAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(1, Math.signum(gradient), 0);
     }
@@ -64,7 +64,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.75;
         b.setValue(value);
-        double gradient = b.dDensityAtValue().get(b.getId());
+        double gradient = b.dLogDensityAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(-1, Math.signum(gradient), 0);
     }
@@ -74,7 +74,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(1.5), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dDensityAtValue().get(b.getId());
+        double gradient = b.dLogDensityAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(1, Math.signum(gradient), 0);
     }
@@ -84,24 +84,9 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(1.5), new ConstantDoubleVertex(3.0), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dDensityAtValue().get(b.getId());
+        double gradient = b.dLogDensityAtValue().get(b.getId());
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(-1, Math.signum(gradient), 0);
-    }
-
-    @Test
-    public void logDensityIsSameAsLogOfDensity() {
-        BetaVertex b = new BetaVertex(new ConstantDoubleVertex(2.0), new ConstantDoubleVertex(2.0), random);
-        double atValue = 0.5;
-        double logOfDensity = Math.log(b.density(atValue));
-        double logDensity = b.logDensity(atValue);
-        assertEquals(logDensity, logOfDensity, 0.01);
-    }
-
-    @Test
-    public void diffLnDensityIsSameAsLogOfDiffDensity() {
-        BetaVertex b = new BetaVertex(new ConstantDoubleVertex(1.5), new ConstantDoubleVertex(3.0), random);
-        ProbabilisticDoubleContract.diffLnDensityIsSameAsLogOfDiffDensity(b, 0.75, 0.0001);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertexTest.java
@@ -66,14 +66,4 @@ public class ChiSquaredVertexTest {
         ProbabilisticDoubleContract.sampleMethodMatchesDensityMethod(vertex, sampleCount, from, to, bucketSize, 1e-2);
     }
 
-    @Test
-    public void testLogDensityEqualsLogOfDensity() {
-        ChiSquaredVertex chi = new ChiSquaredVertex(1);
-        chi.setValue(0.0);
-        double density = chi.density(0.1);
-        double logDensity = chi.logDensity(0.1);
-
-        Assert.assertEquals(Math.log(density), logDensity, 0.001);
-    }
-
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertexTest.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -52,7 +51,7 @@ public class ChiSquaredVertexTest {
     }
 
     @Test
-    public void chiSampleMethodMatchesDensityMethod() {
+    public void chiSampleMethodMatchesLogProbMethod() {
         Vertex<Double> vertex = new ChiSquaredVertex(
                 new ConstantIntegerVertex(2),
                 random
@@ -63,7 +62,7 @@ public class ChiSquaredVertexTest {
         double bucketSize = 0.05;
         long sampleCount = 100000;
 
-        ProbabilisticDoubleContract.sampleMethodMatchesDensityMethod(vertex, sampleCount, from, to, bucketSize, 1e-2);
+        ProbabilisticDoubleContract.sampleMethodMatchesLogProbMethod(vertex, sampleCount, from, to, bucketSize, 1e-2);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -45,46 +45,14 @@ public class ExponentialVertexTest {
     }
 
     @Test
-    public void logDensityIsSameAsLogOfDensity() {
-        ExponentialVertex e = new ExponentialVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(2.0));
-        double atValue = 0.5;
-        double logOfDensity = Math.log(e.density(atValue));
-        double logDensity = e.logDensity(atValue);
-        assertEquals(logOfDensity, logDensity, 0.01);
-    }
-
-    @Test
-    public void diffLnDensityIsSameAsLogOfDiffDensity() {
-        ExponentialVertex e = new ExponentialVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0));
-        ProbabilisticDoubleContract.diffLnDensityIsSameAsLogOfDiffDensity(e, 0.5, 0.001);
-    }
-
-    @Test
     public void gradientAtAIsMinusOne() {
         double a = 0.0;
         double b = 1.0;
         ExponentialVertex e = new ExponentialVertex(a, b, new Random(1));
         e.setValue(a);
-        double gradient = e.dDensityAtValue().get(e.getId());
+        double gradient = e.dLogDensityAtValue().get(e.getId());
         log.info("Gradient at a: " + gradient);
         assertEquals(-1, gradient, 0);
-    }
-
-    @Test
-    public void gradientContinuesToIncreaseAsValueIncreases() {
-        ExponentialVertex exponentialVertex = new ExponentialVertex(0, 1, new Random(1));
-        int n = 100;
-        double value = 0.0;
-        double step = 0.1;
-        exponentialVertex.setValue(value);
-        double initialGradient = exponentialVertex.dDensityAtValue().get(exponentialVertex.getId());
-
-        for (int i = 0; i < n; i++) {
-            exponentialVertex.setValue(value += step);
-            double gradient = exponentialVertex.dDensityAtValue().get(exponentialVertex.getId());
-            assertTrue(gradient > initialGradient);
-            initialGradient = gradient;
-        }
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -50,13 +50,13 @@ public class ExponentialVertexTest {
         double b = 1.0;
         ExponentialVertex e = new ExponentialVertex(a, b, new Random(1));
         e.setValue(a);
-        double gradient = e.dLogDensityAtValue().get(e.getId());
+        double gradient = e.dLogProbAtValue().get(e.getId());
         log.info("Gradient at a: " + gradient);
         assertEquals(-1, gradient, 0);
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPda() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPda() {
         UniformVertex uniformA = new UniformVertex(new ConstantDoubleVertex(0.), new ConstantDoubleVertex(1.));
         ExponentialVertex exp = new ExponentialVertex(uniformA, new ConstantDoubleVertex(1.0));
 
@@ -76,7 +76,7 @@ public class ExponentialVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdb() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdb() {
         UniformVertex uniformB = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.));
         ExponentialVertex exp = new ExponentialVertex(new ConstantDoubleVertex(0.0), uniformB);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -71,7 +71,7 @@ public class GammaVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPda() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPda() {
         UniformVertex a = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         GammaVertex g = new GammaVertex(a, new ConstantDoubleVertex(0.5), new ConstantDoubleVertex(1.0), random);
 
@@ -91,7 +91,7 @@ public class GammaVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdtheta() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdtheta() {
         UniformVertex t = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         GammaVertex g = new GammaVertex(new ConstantDoubleVertex(0.5), t, new ConstantDoubleVertex(1.0), random);
 
@@ -111,7 +111,7 @@ public class GammaVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdk() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdk() {
         UniformVertex k = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         GammaVertex g = new GammaVertex(new ConstantDoubleVertex(0.5), new ConstantDoubleVertex(1.0), k, random);
 
@@ -143,7 +143,7 @@ public class GammaVertexTest {
 
         for (double x = 0.1; x <= 1.0; x += 0.1) {
             double expected = Math.log(apache.density(x));
-            double density = g.logDensity(x);
+            double density = g.logProb(x);
             assertThat("   Density at " + x + " = " + density + " (expected = " + expected + ")",
                     expected, closeTo(density, 0.0001)
             );
@@ -161,9 +161,9 @@ public class GammaVertexTest {
         log.info("k = " + k + ", theta = " + theta + ":");
 
         for (double x = 0.01; x <= 1.0; x += 0.1) {
-            double approxExpected = (g.logDensity(x + DELTA) - g.logDensity(x - DELTA)) / (2 * DELTA);
+            double approxExpected = (g.logProb(x + DELTA) - g.logProb(x - DELTA)) / (2 * DELTA);
             g.setValue(x);
-            double actual = g.dLogDensityAtValue().get(g.getId());
+            double actual = g.dLogProbAtValue().get(g.getId());
             assertThat("   Gradient at " + x + " = " + actual + " (approx expected = " + approxExpected + ")",
                     approxExpected, closeTo(actual, 0.1)
             );
@@ -171,7 +171,7 @@ public class GammaVertexTest {
     }
 
     @Test
-    public void samplingMatchesPdf() {
+    public void samplingMatchesLogProb() {
         GammaVertex gamma = new GammaVertex(
                 new ConstantDoubleVertex(0.0),
                 new ConstantDoubleVertex(2.0),
@@ -179,7 +179,7 @@ public class GammaVertexTest {
                 random
         );
 
-        ProbabilisticDoubleContract.sampleMethodMatchesDensityMethod(
+        ProbabilisticDoubleContract.sampleMethodMatchesLogProbMethod(
                 gamma,
                 100000,
                 2.0,

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -10,11 +10,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.IsCloseTo.closeTo;
 
 public class GammaVertexTest {
     private final Logger log = LoggerFactory.getLogger(GammaVertexTest.class);
@@ -130,29 +130,6 @@ public class GammaVertexTest {
                 DELTA);
     }
 
-    @Test
-    public void diffLnDensityIsSameAsLogOfDiffDensity() {
-        GammaVertex g = new GammaVertex(
-                new ConstantDoubleVertex(0.0),
-                new ConstantDoubleVertex(2.0),
-                new ConstantDoubleVertex(1.0),
-                random
-        );
-
-        double atValue = 0.5;
-        g.setAndCascade(atValue);
-
-        Map<String, Double> dP = g.dDensityAtValue();
-        Map<String, Double> dlnP = g.dlnDensityAtValue();
-
-        final double density = g.densityAtValue();
-        for (String vertexId : dP.keySet()) {
-            dP.put(vertexId, dP.get(vertexId) / density);
-        }
-
-        assertEquals(dP.get(g.getId()), dlnP.get(g.getId()), 0.01);
-    }
-
     private void testPdfAtPercentiles(double theta, double k) {
         GammaVertex g = new GammaVertex(
                 new ConstantDoubleVertex(0.0),
@@ -164,11 +141,12 @@ public class GammaVertexTest {
         GammaDistribution apache = new GammaDistribution(k, theta);
         log.info("k = " + k + ", theta = " + theta + ":");
 
-        for (double x = 0.0; x <= 1.0; x += 0.1) {
-            double expected = apache.density(x);
-            double density = g.density(x);
-            log.info("   Density at " + x + " = " + density + " (expected = " + expected + ")");
-            assertEquals(expected, density, 0.0001);
+        for (double x = 0.1; x <= 1.0; x += 0.1) {
+            double expected = Math.log(apache.density(x));
+            double density = g.logDensity(x);
+            assertThat("   Density at " + x + " = " + density + " (expected = " + expected + ")",
+                    expected, closeTo(density, 0.0001)
+            );
         }
     }
 
@@ -183,27 +161,13 @@ public class GammaVertexTest {
         log.info("k = " + k + ", theta = " + theta + ":");
 
         for (double x = 0.01; x <= 1.0; x += 0.1) {
-            double approxExpected = (g.density(x + DELTA) - g.density(x - DELTA)) / (2 * DELTA);
+            double approxExpected = (g.logDensity(x + DELTA) - g.logDensity(x - DELTA)) / (2 * DELTA);
             g.setValue(x);
-            double actual = g.dDensityAtValue().get(g.getId());
-            log.info("   Gradient at " + x + " = " + actual + " (approx expected = " + approxExpected + ")");
-            assertEquals(approxExpected, actual, 0.1);
+            double actual = g.dLogDensityAtValue().get(g.getId());
+            assertThat("   Gradient at " + x + " = " + actual + " (approx expected = " + approxExpected + ")",
+                    approxExpected, closeTo(actual, 0.1)
+            );
         }
-    }
-
-    @Test
-    public void logDensityIsSameAsLogOfDensity() {
-        GammaVertex g = new GammaVertex(
-                new ConstantDoubleVertex(0.0),
-                new ConstantDoubleVertex(2.0),
-                new ConstantDoubleVertex(1.0),
-                random
-        );
-
-        double atValue = 0.5;
-        double logOfDensity = Math.log(g.density(atValue));
-        double logDensity = g.logDensity(atValue);
-        assertEquals(logDensity, logOfDensity, 0.01);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -41,7 +41,7 @@ public class GaussianVertexTest {
     public void gradientAtMuIsZero() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(0.0);
-        double gradient = g.dDensityAtValue().get(g.getId());
+        double gradient = g.dLogDensityAtValue().get(g.getId());
         log.info("Gradient at mu: " + gradient);
         assertEquals(0, gradient, 0);
     }
@@ -50,7 +50,7 @@ public class GaussianVertexTest {
     public void gradientBeforeMuIsPositive() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(-1.0);
-        double gradient = g.dDensityAtValue().get(g.getId());
+        double gradient = g.dLogDensityAtValue().get(g.getId());
         log.info("Gradient after mu: " + gradient);
         assertTrue(gradient > 0);
     }
@@ -59,24 +59,9 @@ public class GaussianVertexTest {
     public void gradientAfterMuIsNegative() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(1.0);
-        double gradient = g.dDensityAtValue().get(g.getId());
+        double gradient = g.dLogDensityAtValue().get(g.getId());
         log.info("Gradient after mu: " + gradient);
         assertTrue(gradient < 0);
-    }
-
-    @Test
-    public void logDensityIsSameAsLogOfDensity() {
-        GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(2.0), random);
-        double atValue = 0.5;
-        double logOfDensity = Math.log(g.density(atValue));
-        double logDensity = g.logDensity(atValue);
-        assertEquals(logDensity, logOfDensity, 0.01);
-    }
-
-    @Test
-    public void diffLnDensityIsSameAsLogOfDiffDensity() {
-        GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
-        ProbabilisticDoubleContract.diffLnDensityIsSameAsLogOfDiffDensity(g, 0.5, 0.001);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -41,7 +41,7 @@ public class GaussianVertexTest {
     public void gradientAtMuIsZero() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(0.0);
-        double gradient = g.dLogDensityAtValue().get(g.getId());
+        double gradient = g.dLogProbAtValue().get(g.getId());
         log.info("Gradient at mu: " + gradient);
         assertEquals(0, gradient, 0);
     }
@@ -50,7 +50,7 @@ public class GaussianVertexTest {
     public void gradientBeforeMuIsPositive() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(-1.0);
-        double gradient = g.dLogDensityAtValue().get(g.getId());
+        double gradient = g.dLogProbAtValue().get(g.getId());
         log.info("Gradient after mu: " + gradient);
         assertTrue(gradient > 0);
     }
@@ -59,13 +59,13 @@ public class GaussianVertexTest {
     public void gradientAfterMuIsNegative() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(1.0);
-        double gradient = g.dLogDensityAtValue().get(g.getId());
+        double gradient = g.dLogProbAtValue().get(g.getId());
         log.info("Gradient after mu: " + gradient);
         assertTrue(gradient < 0);
     }
 
     @Test
-    public void gaussianSampleMethodMatchesDensityMethod() {
+    public void gaussianSampleMethodMatchesLogProbMethod() {
 
         Random random = new Random(1);
 
@@ -80,11 +80,11 @@ public class GaussianVertexTest {
         double bucketSize = 0.05;
         long sampleCount = 1000000;
 
-        ProbabilisticDoubleContract.sampleMethodMatchesDensityMethod(vertex, sampleCount, from, to, bucketSize, 1e-2);
+        ProbabilisticDoubleContract.sampleMethodMatchesLogProbMethod(vertex, sampleCount, from, to, bucketSize, 1e-2);
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdmu() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdmu() {
         UniformVertex uniformA = new UniformVertex(new ConstantDoubleVertex(1.5), new ConstantDoubleVertex(3.0), random);
         GaussianVertex gaussian = new GaussianVertex(uniformA, new ConstantDoubleVertex(3.0), random);
 
@@ -104,7 +104,7 @@ public class GaussianVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdsigma() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdsigma() {
         UniformVertex uniformA = new UniformVertex(new ConstantDoubleVertex(1.5), new ConstantDoubleVertex(3.0), random);
         GaussianVertex gaussian = new GaussianVertex(new ConstantDoubleVertex(3.0), uniformA, random);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
@@ -47,14 +47,14 @@ public class InverseGammaVertexTest {
     }
 
     @Test
-    public void samplingMatchesPdf() {
+    public void samplingMatchesLogProb() {
         InverseGammaVertex gamma = new InverseGammaVertex(
                 new ConstantDoubleVertex(2.0),
                 new ConstantDoubleVertex(3.0),
                 random
         );
 
-        ProbabilisticDoubleContract.sampleMethodMatchesDensityMethod(
+        ProbabilisticDoubleContract.sampleMethodMatchesLogProbMethod(
                 gamma,
                 100000,
                 2.0,
@@ -64,7 +64,7 @@ public class InverseGammaVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPda() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPda() {
         UniformVertex uniformA = new UniformVertex(
                 new ConstantDoubleVertex(1.0),
                 new ConstantDoubleVertex(4.0),
@@ -91,7 +91,7 @@ public class InverseGammaVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdb() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdb() {
         UniformVertex uniformB = new UniformVertex(
                 new ConstantDoubleVertex(1.0),
                 new ConstantDoubleVertex(3.0),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
@@ -64,27 +64,6 @@ public class InverseGammaVertexTest {
     }
 
     @Test
-    public void logDensityIsSameAsLogOfDensity() {
-        InverseGammaVertex inverted = new InverseGammaVertex(
-                new ConstantDoubleVertex(3.0),
-                new ConstantDoubleVertex(0.5),
-                random);
-        double atValue = 0.5;
-        double logOfDensity = Math.log(inverted.density(atValue));
-        double logDensity = inverted.logDensity(atValue);
-        assertEquals(logDensity, logOfDensity, 0.01);
-    }
-
-    @Test
-    public void diffLnDensityIsSameAsLogOfDiffDensity() {
-        InverseGammaVertex inverted = new InverseGammaVertex(
-                new ConstantDoubleVertex(3.0),
-                new ConstantDoubleVertex(0.5),
-                random);
-        ProbabilisticDoubleContract.diffLnDensityIsSameAsLogOfDiffDensity(inverted, 0.5, 0.001);
-    }
-
-    @Test
     public void dDensityMatchesFiniteDifferenceCalculationFordPda() {
         UniformVertex uniformA = new UniformVertex(
                 new ConstantDoubleVertex(1.0),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
@@ -40,14 +40,14 @@ public class LaplaceVertexTest {
     }
 
     @Test
-    public void samplingMatchesPdf() {
+    public void samplingMatchesLogProb() {
         LaplaceVertex laplace = new LaplaceVertex(
                 new ConstantDoubleVertex(0.0),
                 new ConstantDoubleVertex(1.0),
                 random
         );
 
-        ProbabilisticDoubleContract.sampleMethodMatchesDensityMethod(
+        ProbabilisticDoubleContract.sampleMethodMatchesLogProbMethod(
                 laplace,
                 100000,
                 2.0,
@@ -57,7 +57,7 @@ public class LaplaceVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdmu() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdmu() {
         UniformVertex uniform = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(3.0), random);
         LaplaceVertex laplace = new LaplaceVertex(uniform, new ConstantDoubleVertex(1.0), random);
 
@@ -77,7 +77,7 @@ public class LaplaceVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdbeta() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdbeta() {
         UniformVertex uniform = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(3.0), random);
         LaplaceVertex laplace = new LaplaceVertex(new ConstantDoubleVertex(0.0), uniform, random);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
@@ -57,15 +57,6 @@ public class LaplaceVertexTest {
     }
 
     @Test
-    public void logDensityIsSameAsLogOfDensity() {
-        LaplaceVertex l = new LaplaceVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
-        double atValue = 0.5;
-        double logOfDensity = Math.log(l.density(atValue));
-        double logDensity = l.logDensity(atValue);
-        assertEquals(logDensity, logOfDensity, 0.01);
-    }
-
-    @Test
     public void dDensityMatchesFiniteDifferenceCalculationFordPdmu() {
         UniformVertex uniform = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(3.0), random);
         LaplaceVertex laplace = new LaplaceVertex(uniform, new ConstantDoubleVertex(1.0), random);
@@ -104,13 +95,6 @@ public class LaplaceVertexTest {
                 vertexIncrement,
                 DELTA);
     }
-
-    @Test
-    public void diffLnDensityIsSameAsLogOfDiffDensity() {
-        LaplaceVertex l = new LaplaceVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
-        ProbabilisticDoubleContract.diffLnDensityIsSameAsLogOfDiffDensity(l, 0.5, 0.001);
-    }
-
 
     @Test
     public void inferHyperParamsFromSamples() {

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -44,37 +44,12 @@ public class LogisticVertexTest {
     }
 
     @Test
-    public void logDensityIsSameAsLogOfDensity() {
-        LogisticVertex l = new LogisticVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(2.0));
-        double atValue = 0.5;
-        double logOfDensity = Math.log(l.density(atValue));
-        double logDensity = l.logDensity(atValue);
-        assertEquals(logOfDensity, logDensity, 0.01);
-    }
-
-    @Test
-    public void diffLnDensityIsSameAsLogOfDiffDensity() {
-        LogisticVertex l = new LogisticVertex(new ConstantDoubleVertex(0.1), new ConstantDoubleVertex(1.0));
-        double atValue = 0.5;
-        l.setAndCascade(atValue);
-
-        Map<String, Double> dP = l.dDensityAtValue();
-        Map<String, Double> dlnP = l.dlnDensityAtValue();
-
-        final double density = l.densityAtValue();
-        for (String vertexId : dP.keySet()) {
-            dP.put(vertexId, dP.get(vertexId) / density);
-        }
-        assertEquals(dP.get(l.getId()), dlnP.get(l.getId()), 0.01);
-    }
-
-    @Test
     public void gradientAtAIsZero() {
         double a = 0.0;
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a);
-        double gradient = l.dDensityAtValue().get(l.getId());
+        double gradient = l.dLogDensityAtValue().get(l.getId());
         log.info("Gradient at a: " + gradient);
         assertEquals(gradient, 0, 0);
     }
@@ -85,7 +60,7 @@ public class LogisticVertexTest {
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a - 1.0);
-        double gradient = l.dDensityAtValue().get(l.getId());
+        double gradient = l.dLogDensityAtValue().get(l.getId());
         log.info("Gradient at x < a: " + gradient);
         assertTrue(gradient > 0);
     }
@@ -96,7 +71,7 @@ public class LogisticVertexTest {
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a + 1.0);
-        double gradient = l.dDensityAtValue().get(l.getId());
+        double gradient = l.dLogDensityAtValue().get(l.getId());
         log.info("Gradient at x > a: " + gradient);
         assertTrue(gradient < 0);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
@@ -49,7 +48,7 @@ public class LogisticVertexTest {
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a);
-        double gradient = l.dLogDensityAtValue().get(l.getId());
+        double gradient = l.dLogProbAtValue().get(l.getId());
         log.info("Gradient at a: " + gradient);
         assertEquals(gradient, 0, 0);
     }
@@ -60,7 +59,7 @@ public class LogisticVertexTest {
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a - 1.0);
-        double gradient = l.dLogDensityAtValue().get(l.getId());
+        double gradient = l.dLogProbAtValue().get(l.getId());
         log.info("Gradient at x < a: " + gradient);
         assertTrue(gradient > 0);
     }
@@ -71,13 +70,13 @@ public class LogisticVertexTest {
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a + 1.0);
-        double gradient = l.dLogDensityAtValue().get(l.getId());
+        double gradient = l.dLogProbAtValue().get(l.getId());
         log.info("Gradient at x > a: " + gradient);
         assertTrue(gradient < 0);
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPda() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPda() {
         UniformVertex uniformA = new UniformVertex(new ConstantDoubleVertex(0.), new ConstantDoubleVertex(1.));
         LogisticVertex l = new LogisticVertex(uniformA, new ConstantDoubleVertex(1.0));
 
@@ -97,7 +96,7 @@ public class LogisticVertexTest {
     }
 
     @Test
-    public void dDensityMatchesFiniteDifferenceCalculationFordPdb() {
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdb() {
         UniformVertex uniformB = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.));
         LogisticVertex l = new LogisticVertex(new ConstantDoubleVertex(0.0), uniformB);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleContract.java
@@ -17,9 +17,9 @@ import static org.junit.Assert.assertEquals;
 public class ProbabilisticDoubleContract {
 
     /**
-     * This method brute force verifies that a given vertex's sample method accurately reflects its density method.
+     * This method brute force verifies that a given vertex's sample method accurately reflects its logProb method.
      * This is done for a given range with a specified resolution (bucketSize). The error due to the approximate
-     * nature of the brute force technique will be larger where the gradient of the density is large as well.
+     * nature of the brute force technique will be larger where the gradient of the logProb is large as well.
      *
      * @param vertexUnderTest
      * @param sampleCount
@@ -27,7 +27,7 @@ public class ProbabilisticDoubleContract {
      * @param to
      * @param bucketSize
      */
-    public static void sampleMethodMatchesDensityMethod(Vertex<Double> vertexUnderTest,
+    public static void sampleMethodMatchesLogProbMethod(Vertex<Double> vertexUnderTest,
                                                         long sampleCount,
                                                         double from,
                                                         double to,
@@ -51,10 +51,10 @@ public class ProbabilisticDoubleContract {
             double percentage = (double) sampleBucket.getValue() / sampleCount;
             double bucketCenter = sampleBucket.getKey();
 
-            double densityAtBucketCenter = Math.exp(vertexUnderTest.logDensity(bucketCenter));
+            double densityAtBucketCenter = Math.exp(vertexUnderTest.logProb(bucketCenter));
             double actual = percentage / bucketSize;
 
-            assertThat("Problem with density at " + bucketCenter, densityAtBucketCenter, closeTo(actual, maxError));
+            assertThat("Problem with logProb at " + bucketCenter, densityAtBucketCenter, closeTo(actual, maxError));
         }
     }
 
@@ -116,16 +116,16 @@ public class ProbabilisticDoubleContract {
 
     public static void testGradientAtHyperParameterValue(double hyperParameterValue, Vertex<Double> hyperParameterVertex, double vertexValue, Vertex<Double> vertexUnderTest, double gradientDelta) {
         hyperParameterVertex.setAndCascade(hyperParameterValue - gradientDelta);
-        double lnDensityA1 = vertexUnderTest.logDensity(vertexValue);
+        double lnDensityA1 = vertexUnderTest.logProb(vertexValue);
 
         hyperParameterVertex.setAndCascade(hyperParameterValue + gradientDelta);
-        double lnDensityA2 = vertexUnderTest.logDensity(vertexValue);
+        double lnDensityA2 = vertexUnderTest.logProb(vertexValue);
 
         double diffLnDensityApproxExpected = (lnDensityA2 - lnDensityA1) / (2 * gradientDelta);
 
         hyperParameterVertex.setAndCascade(hyperParameterValue);
 
-        Map<String, Double> diffln = vertexUnderTest.dLogDensityAtValue();
+        Map<String, Double> diffln = vertexUnderTest.dLogProbAtValue();
 
         double actualDiffLnDensity = diffln.get(hyperParameterVertex.getId());
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformTest.java
@@ -64,7 +64,7 @@ public class SmoothUniformTest {
     }
 
     @Test
-    public void smoothUniformSampleMethodMatchesDensityMethod() {
+    public void smoothUniformSampleMethodMatchesLogProbMethod() {
 
         double edgeSharpness = 1.0;
         SmoothUniformVertex uniform = new SmoothUniformVertex(
@@ -79,7 +79,7 @@ public class SmoothUniformTest {
         double delta = 0.05;
         long N = 1000000;
 
-        ProbabilisticDoubleContract.sampleMethodMatchesDensityMethod(uniform, N, from, to, delta, 1e-2);
+        ProbabilisticDoubleContract.sampleMethodMatchesLogProbMethod(uniform, N, from, to, delta, 1e-2);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertexTest.java
@@ -115,7 +115,7 @@ public class FuzzyCastToIntegerVertexTest {
         DoubleVertex input = new ConstantDoubleVertex(0.25);
 
         Vertex<Integer> fuzzyCast = new FuzzyCastToIntegerVertex(input, fuzzinessSigma, min, max, new Random());
-        double density = fuzzyCast.densityAtValue();
+        double density = Math.exp(fuzzyCast.logDensityAtValue());
 
         log.info("Value = " + fuzzyCast.getValue() + ", density = " + density);
         assertEquals(1.0, density, 0.0);
@@ -153,16 +153,16 @@ public class FuzzyCastToIntegerVertexTest {
         fuzzy.setValue(observedValue);
 
         mu.setValue(mu1);
-        double density1 = fuzzy.densityAtValue();
-        double actual_dPdmu = fuzzy.dDensityAtValue().get(mu.getId());
+        double logDensity1 = fuzzy.logDensityAtValue();
+        double actual_dPdmu = fuzzy.dLogDensityAtValue().get(mu.getId());
 
         mu.setValue(mu2);
-        double density2 = fuzzy.densityAtValue();
+        double logDensity2 = fuzzy.logDensityAtValue();
 
-        double expected_dPdmu = (density2 - density1) / delta;
+        double expected_dPdmu = (logDensity2 - logDensity1) / delta;
 
         log.info("Expected = " + expected_dPdmu + ", Actual = " + actual_dPdmu);
-        assertEquals(expected_dPdmu, actual_dPdmu, 1e-5);
+        assertEquals(expected_dPdmu, actual_dPdmu, 1e-4);
     }
 
     @Test
@@ -182,16 +182,16 @@ public class FuzzyCastToIntegerVertexTest {
         fuzzy.setValue(observedValue);
 
         sigma.setValue(sigma1);
-        double density1 = fuzzy.densityAtValue();
-        double actual_dPdsigma = fuzzy.dDensityAtValue().get(sigma.getId());
+        double logDensity1 = fuzzy.logDensityAtValue();
+        double actual_dPdsigma = fuzzy.dLogDensityAtValue().get(sigma.getId());
 
         sigma.setValue(sigma2);
-        double density2 = fuzzy.densityAtValue();
+        double logDensity2 = fuzzy.logDensityAtValue();
 
-        double expected_dPdsigma = (density2 - density1) / delta;
+        double expected_dPdsigma = (logDensity2 - logDensity1) / delta;
 
         log.info("Expected: " + expected_dPdsigma + ", Actual: " + actual_dPdsigma);
-        assertEquals(expected_dPdsigma, actual_dPdsigma, 1e-5);
+        assertEquals(expected_dPdsigma, actual_dPdsigma, 1e-4);
     }
 
     @Test
@@ -212,7 +212,7 @@ public class FuzzyCastToIntegerVertexTest {
 
         mu.setValue(mu1);
         double logDensity1 = fuzzy.logDensityAtValue();
-        double actual_dlnPdmu = fuzzy.dlnDensityAtValue().get(mu.getId());
+        double actual_dlnPdmu = fuzzy.dLogDensityAtValue().get(mu.getId());
 
         mu.setValue(mu2);
         double logDensity2 = fuzzy.logDensityAtValue();
@@ -241,7 +241,7 @@ public class FuzzyCastToIntegerVertexTest {
 
         sigma.setValue(sigma1);
         double logDensity1 = fuzzy.logDensityAtValue();
-        double actual_dlnPdsigma = fuzzy.dlnDensityAtValue().get(sigma.getId());
+        double actual_dlnPdsigma = fuzzy.dLogDensityAtValue().get(sigma.getId());
 
         sigma.setValue(sigma2);
         double logDensity2 = fuzzy.logDensityAtValue();

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertexTest.java
@@ -144,7 +144,7 @@ public class FuzzyCastToIntegerVertexTest {
         int max = 10;
 
         double mu1 = 4.0;
-        double delta = 0.0001;
+        double delta = 0.00001;
         double mu2 = mu1 + delta;
         int observedValue = 5;
 
@@ -162,7 +162,7 @@ public class FuzzyCastToIntegerVertexTest {
         double expected_dPdmu = (logDensity2 - logDensity1) / delta;
 
         log.info("Expected = " + expected_dPdmu + ", Actual = " + actual_dPdmu);
-        assertEquals(expected_dPdmu, actual_dPdmu, 1e-4);
+        assertEquals(expected_dPdmu, actual_dPdmu, 1e-5);
     }
 
     @Test
@@ -174,7 +174,7 @@ public class FuzzyCastToIntegerVertexTest {
         int observedValue = 5;
 
         double sigma1 = 2.0;
-        double delta = 0.0001;
+        double delta = 0.00001;
         double sigma2 = sigma1 + delta;
 
         DoubleVertex sigma = new UniformVertex(0d, 3d);
@@ -191,7 +191,7 @@ public class FuzzyCastToIntegerVertexTest {
         double expected_dPdsigma = (logDensity2 - logDensity1) / delta;
 
         log.info("Expected: " + expected_dPdsigma + ", Actual: " + actual_dPdsigma);
-        assertEquals(expected_dPdsigma, actual_dPdsigma, 1e-4);
+        assertEquals(expected_dPdsigma, actual_dPdsigma, 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertexTest.java
@@ -115,7 +115,7 @@ public class FuzzyCastToIntegerVertexTest {
         DoubleVertex input = new ConstantDoubleVertex(0.25);
 
         Vertex<Integer> fuzzyCast = new FuzzyCastToIntegerVertex(input, fuzzinessSigma, min, max, new Random());
-        double density = Math.exp(fuzzyCast.logDensityAtValue());
+        double density = Math.exp(fuzzyCast.logProbAtValue());
 
         log.info("Value = " + fuzzyCast.getValue() + ", density = " + density);
         assertEquals(1.0, density, 0.0);
@@ -153,11 +153,11 @@ public class FuzzyCastToIntegerVertexTest {
         fuzzy.setValue(observedValue);
 
         mu.setValue(mu1);
-        double logDensity1 = fuzzy.logDensityAtValue();
-        double actual_dPdmu = fuzzy.dLogDensityAtValue().get(mu.getId());
+        double logDensity1 = fuzzy.logProbAtValue();
+        double actual_dPdmu = fuzzy.dLogProbAtValue().get(mu.getId());
 
         mu.setValue(mu2);
-        double logDensity2 = fuzzy.logDensityAtValue();
+        double logDensity2 = fuzzy.logProbAtValue();
 
         double expected_dPdmu = (logDensity2 - logDensity1) / delta;
 
@@ -182,11 +182,11 @@ public class FuzzyCastToIntegerVertexTest {
         fuzzy.setValue(observedValue);
 
         sigma.setValue(sigma1);
-        double logDensity1 = fuzzy.logDensityAtValue();
-        double actual_dPdsigma = fuzzy.dLogDensityAtValue().get(sigma.getId());
+        double logDensity1 = fuzzy.logProbAtValue();
+        double actual_dPdsigma = fuzzy.dLogProbAtValue().get(sigma.getId());
 
         sigma.setValue(sigma2);
-        double logDensity2 = fuzzy.logDensityAtValue();
+        double logDensity2 = fuzzy.logProbAtValue();
 
         double expected_dPdsigma = (logDensity2 - logDensity1) / delta;
 
@@ -211,11 +211,11 @@ public class FuzzyCastToIntegerVertexTest {
         fuzzy.setValue(observedValue);
 
         mu.setValue(mu1);
-        double logDensity1 = fuzzy.logDensityAtValue();
-        double actual_dlnPdmu = fuzzy.dLogDensityAtValue().get(mu.getId());
+        double logDensity1 = fuzzy.logProbAtValue();
+        double actual_dlnPdmu = fuzzy.dLogProbAtValue().get(mu.getId());
 
         mu.setValue(mu2);
-        double logDensity2 = fuzzy.logDensityAtValue();
+        double logDensity2 = fuzzy.logProbAtValue();
 
         double expected_dlnPdmu = (logDensity2 - logDensity1) / delta;
 
@@ -240,11 +240,11 @@ public class FuzzyCastToIntegerVertexTest {
         fuzzy.setValue(observedValue);
 
         sigma.setValue(sigma1);
-        double logDensity1 = fuzzy.logDensityAtValue();
-        double actual_dlnPdsigma = fuzzy.dLogDensityAtValue().get(sigma.getId());
+        double logDensity1 = fuzzy.logProbAtValue();
+        double actual_dlnPdsigma = fuzzy.dLogProbAtValue().get(sigma.getId());
 
         sigma.setValue(sigma2);
-        double logDensity2 = fuzzy.logDensityAtValue();
+        double logDensity2 = fuzzy.logProbAtValue();
 
         double expected_dlnPdsigma = (logDensity2 - logDensity1) / delta;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
@@ -43,15 +43,15 @@ public class PoissonVertexTest {
 
 
     @Test
-    public void densityForValuesGreaterThanTwenty() {
+    public void logProbForValuesGreaterThanTwenty() {
         double mu = 25.0;
 
         PoissonVertex poissonVertex = new PoissonVertex(mu, new Random(1));
 
-        double density = poissonVertex.logDensity(19);
-        double densityThreshold = poissonVertex.logDensity(20);
-        double densityAboveThreshold = poissonVertex.logDensity(21);
+        double logProb = poissonVertex.logProb(19);
+        double logProbThreshold = poissonVertex.logProb(20);
+        double logProbAboveThreshold = poissonVertex.logProb(21);
 
-        assertTrue(densityAboveThreshold > densityThreshold && densityThreshold > density);
+        assertTrue(logProbAboveThreshold > logProbThreshold && logProbThreshold > logProb);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
@@ -48,9 +48,9 @@ public class PoissonVertexTest {
 
         PoissonVertex poissonVertex = new PoissonVertex(mu, new Random(1));
 
-        double density = poissonVertex.density(19);
-        double densityThreshold = poissonVertex.density(20);
-        double densityAboveThreshold = poissonVertex.density(21);
+        double density = poissonVertex.logDensity(19);
+        double densityThreshold = poissonVertex.logDensity(20);
+        double densityAboveThreshold = poissonVertex.logDensity(21);
 
         assertTrue(densityAboveThreshold > densityThreshold && densityThreshold > density);
     }


### PR DESCRIPTION
This PR removes density and dDensity from the base class Vertex. This makes logDensity and dLogDensity the preferred and required abstract methods. This was done because there's very little use cases where you would want density instead of the more numerically stable log density. Density and dDensity can be converted from the log versions if a user needs to but there's no use of it in our algorithms.

Also, the term logDensity (or density) has been replaced with logProb where appropriate. There's a disclaimer comment on the logProb that points out that in the continuous case this is actually logDensity but is accurate up to a constant.