### PR TITLE
Run examples independently of parent build

### DIFF
--- a/keanu-examples/coalMiningDisasters/settings.gradle
+++ b/keanu-examples/coalMiningDisasters/settings.gradle
@@ -1,0 +1,2 @@
+include 'keanu-project'
+project(':keanu-project').projectDir = new File('../../keanu-project')

--- a/keanu-examples/starter/build.gradle
+++ b/keanu-examples/starter/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'application'
 }
 
-mainClassName = "starter.Model"
+mainClassName = "com.example.starter.Model"
 
 group = 'improbable'
 version = '0.0.1'


### PR DESCRIPTION
Add required settings for running coal mining example independently  outside of top level Keanu build.

This PR enables a user to change directory into the coal mining example and `gradle build` just the example. It also allows them to use `gradle run` in the coal mining example and the starter project to automatically run their respective `main(String[] args)` methods.