### PR TITLE
Respect observed vertices as constants

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/FitnessFunctionWithGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/FitnessFunctionWithGradient.java
@@ -27,7 +27,7 @@ public class FitnessFunctionWithGradient extends FitnessFunction {
     private double[] alignGradientsToAppropriateIndex(Map<String /*Vertex Label*/, Double /*Gradient*/> diffs) {
         double[] gradient = new double[latentVertices.size()];
         for (int i = 0; i < gradient.length; i++) {
-            gradient[i] = diffs.get(latentVertices.get(i).getId());
+            gradient[i] = diffs.getOrDefault(latentVertices.get(i).getId(), 0.0);
         }
         return gradient;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -23,7 +23,7 @@ public abstract class DoubleVertex extends ContinuousVertex<Double> implements D
      */
     protected abstract DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers);
 
-    public DualNumber getDualNumber() {
+    public final DualNumber getDualNumber() {
         Map<Vertex, DualNumber> dualNumbers = new HashMap<>();
         Deque<DoubleVertex> stack = new ArrayDeque<>();
         stack.push(this);
@@ -41,7 +41,7 @@ public abstract class DoubleVertex extends ContinuousVertex<Double> implements D
 
             } else {
 
-                for (Vertex<?> vertex : parentsThatDualNumberIsNotCalculated) {
+                for (Vertex vertex : parentsThatDualNumberIsNotCalculated) {
                     if (vertex instanceof DoubleVertex) {
                         stack.push((DoubleVertex) vertex);
                     } else {
@@ -52,7 +52,18 @@ public abstract class DoubleVertex extends ContinuousVertex<Double> implements D
             }
 
         }
+
         return dualNumbers.get(this);
+    }
+
+    private Set<Vertex> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, Set<Vertex> parents) {
+        Set<Vertex> notCalculatedParents = new HashSet<>();
+        for (Vertex<?> next : parents) {
+            if (!dualNumbers.containsKey(next)){
+                notCalculatedParents.add(next);
+            }
+        }
+        return notCalculatedParents;
     }
 
     public DoubleVertex minus(DoubleVertex that) {
@@ -164,16 +175,6 @@ public abstract class DoubleVertex extends ContinuousVertex<Double> implements D
 
     public DoubleVertex acos() {
         return new ArcCosVertex(this);
-    }
-
-    private Set<Vertex> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, Set<Vertex> parents) {
-        Set<Vertex> notCalculatedParents = new HashSet<>();
-        for (Vertex<?> next : parents) {
-            if (!dualNumbers.containsKey(next)){
-                notCalculatedParents.add(next);
-            }
-        }
-        return notCalculatedParents;
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
@@ -2,7 +2,6 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
 import io.improbable.keanu.vertices.NonProbabilisticObservationException;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 
@@ -28,7 +27,7 @@ public abstract class NonProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public Map<String, DoubleTensor> dLogPdf(Double value) {
+    public Map<String, Double> dLogPdf(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
 import io.improbable.keanu.vertices.NonProbabilisticObservationException;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public abstract class NonProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
@@ -29,6 +29,10 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         return partialDerivatives;
     }
 
+    public boolean isOfConstant(){
+        return partialDerivatives.isEmpty();
+    }
+
     public DualNumber add(DualNumber that) {
         // dc = da + db;
         double newValue = this.value + that.value;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -28,6 +28,10 @@ public class PartialDerivatives {
         return derivativeWithRespectTo.getOrDefault(id, 0.0);
     }
 
+    public boolean isEmpty() {
+        return derivativeWithRespectTo.isEmpty();
+    }
+
     public Map<String, Double> asMap() {
         return derivativeWithRespectTo;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -72,7 +72,10 @@ public class BetaVertex extends ProbabilisticDouble {
         PartialDerivatives dPdInputsFromAlpha = alpha.getDualNumber().getPartialDerivatives().multiplyBy(dPdAlpha);
         PartialDerivatives dPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dPdBeta);
         PartialDerivatives dPdInputs = dPdInputsFromAlpha.add(dPdInputsFromBeta);
-        dPdInputs.putWithRespectTo(getId(), dPdx);
+
+        if (!isObserved()) {
+            dPdInputs.putWithRespectTo(getId(), dPdx);
+        }
 
         return dPdInputs.asMap();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -15,7 +15,6 @@ public class ChiSquaredVertex extends ProbabilisticDouble {
     public ChiSquaredVertex(IntegerVertex k, Random random) {
         this.k = k;
         this.random = random;
-        setValue(sample());
         setParents(k);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -78,7 +78,10 @@ public class ExponentialVertex extends ProbabilisticDouble {
         PartialDerivatives dPdInputsFromSigma = b.getDualNumber().getPartialDerivatives().multiplyBy(dPdb);
         PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromSigma);
 
-        dPdInputs.putWithRespectTo(getId(), dPdx);
+        if (!isObserved()) {
+            dPdInputs.putWithRespectTo(getId(), dPdx);
+        }
+
         return dPdInputs.asMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -89,7 +89,10 @@ public class GammaVertex extends ProbabilisticDouble {
         PartialDerivatives dPdInputsFromTheta = theta.getDualNumber().getPartialDerivatives().multiplyBy(dPdtheta);
         PartialDerivatives dPdInputsFromK = k.getDualNumber().getPartialDerivatives().multiplyBy(dPdk);
         PartialDerivatives dPdInputs = dPdInputsFromA.add(dPdInputsFromTheta).add(dPdInputsFromK);
-        dPdInputs.putWithRespectTo(getId(), dPdx);
+
+        if (!isObserved()) {
+            dPdInputs.putWithRespectTo(getId(), dPdx);
+        }
 
         return dPdInputs.asMap();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -74,7 +74,9 @@ public class GaussianVertex extends ProbabilisticDouble {
         PartialDerivatives dPdInputsFromSigma = sigma.getDualNumber().getPartialDerivatives().multiplyBy(dPdsigma);
         PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromSigma);
 
-        dPdInputs.putWithRespectTo(getId(), dPdx);
+        if (!isObserved()) {
+            dPdInputs.putWithRespectTo(getId(), dPdx);
+        }
 
         return dPdInputs.asMap();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -70,7 +70,9 @@ public class InverseGammaVertex extends ProbabilisticDouble {
         PartialDerivatives dPdInputsFromB = b.getDualNumber().getPartialDerivatives().multiplyBy(dPdb);
         PartialDerivatives dPdInputs = dPdInputsFromA.add(dPdInputsFromB);
 
-        dPdInputs.putWithRespectTo(getId(), dPdx);
+        if (!isObserved()) {
+            dPdInputs.putWithRespectTo(getId(), dPdx);
+        }
 
         return dPdInputs.asMap();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -69,7 +69,10 @@ public class LaplaceVertex extends ProbabilisticDouble {
         PartialDerivatives dPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dPdmu);
         PartialDerivatives dPdInputsFromSigma = beta.getDualNumber().getPartialDerivatives().multiplyBy(dPdbeta);
         PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromSigma);
-        dPdInputs.putWithRespectTo(getId(), dPdx);
+
+        if (!isObserved()) {
+            dPdInputs.putWithRespectTo(getId(), dPdx);
+        }
 
         return dPdInputs.asMap();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -73,7 +73,10 @@ public class LogisticVertex extends ProbabilisticDouble {
         PartialDerivatives dPdInputsFromSigma = b.getDualNumber().getPartialDerivatives().multiplyBy(dPdb);
         PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromSigma);
 
-        dPdInputs.putWithRespectTo(getId(), dPdx);
+        if (!isObserved()) {
+            dPdInputs.putWithRespectTo(getId(), dPdx);
+        }
+
         return dPdInputs.asMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -28,7 +28,11 @@ public abstract class ProbabilisticDouble extends DoubleVertex {
 
     @Override
     public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
-        return DualNumber.createWithRespectToSelf(getId(), getValue());
+        if (isObserved()) {
+            return DualNumber.createConstant(getValue());
+        } else {
+            return DualNumber.createWithRespectToSelf(getId(), getValue());
+        }
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.SmoothUniformDistribution;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 
@@ -77,6 +78,11 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
 
     @Override
     public Map<String, Double> dLogPdf(Double value) {
+
+        if (isObserved()) {
+            return Collections.emptyMap();
+        }
+
         final double min = xMin.getValue();
         final double max = xMax.getValue();
         final double shoulderWidth = this.edgeSharpness * (max - min);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 
@@ -65,6 +66,11 @@ public class UniformVertex extends ProbabilisticDouble {
 
     @Override
     public Map<String, Double> dLogPdf(Double value) {
+
+        if (isObserved()) {
+            return Collections.emptyMap();
+        }
+
         double min = this.xMin.getValue();
         double max = this.xMax.getValue();
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -90,6 +90,16 @@ public class BetaVertexTest {
     }
 
     @Test
+    public void isTreatedAsConstantWhenObserved() {
+        BetaVertex vertexUnderTest = new BetaVertex(
+                new UniformVertex(0.0, 1.0),
+                new ConstantDoubleVertex(3.0), random
+        );
+        ProbabilisticDoubleContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
+    }
+
+    @Test
     public void sampleMatchesLogProb() {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(2.0), new ConstantDoubleVertex(2.0), random);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Random;
 
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class ExponentialVertexTest {
@@ -53,6 +52,17 @@ public class ExponentialVertexTest {
         double gradient = e.dLogProbAtValue().get(e.getId());
         log.info("Gradient at a: " + gradient);
         assertEquals(-1, gradient, 0);
+    }
+
+    @Test
+    public void isTreatedAsConstantWhenObserved() {
+        ExponentialVertex vertexUnderTest = new ExponentialVertex(
+                new UniformVertex(0.0, 1.0),
+                new ConstantDoubleVertex(3.0),
+                random
+        );
+        ProbabilisticDoubleContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -171,6 +171,19 @@ public class GammaVertexTest {
     }
 
     @Test
+    public void isTreatedAsConstantWhenObserved() {
+        GammaVertex vertexUnderTest = new GammaVertex(
+                new UniformVertex(0.0, 1.0),
+                new ConstantDoubleVertex(3.0),
+                new ConstantDoubleVertex(1.0),
+                random
+        );
+
+        ProbabilisticDoubleContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
+    }
+
+    @Test
     public void samplingMatchesLogProb() {
         GammaVertex gamma = new GammaVertex(
                 new ConstantDoubleVertex(0.0),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -65,6 +65,17 @@ public class GaussianVertexTest {
     }
 
     @Test
+    public void isTreatedAsConstantWhenObserved() {
+        GaussianVertex vertexUnderTest = new GaussianVertex(
+                new UniformVertex(0.0, 1.0),
+                new ConstantDoubleVertex(3.0),
+                random
+        );
+        ProbabilisticDoubleContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
+    }
+
+    @Test
     public void gaussianSampleMethodMatchesLogProbMethod() {
 
         Random random = new Random(1);
@@ -134,14 +145,14 @@ public class GaussianVertexTest {
         muSigma.add(new ConstantDoubleVertex(trueSigma));
 
         List<DoubleVertex> latentMuSigma = new ArrayList<>();
-        latentMuSigma.add(new SmoothUniformVertex(0.01, 10.0, random));
-        latentMuSigma.add(new SmoothUniformVertex(0.01, 10.0, random));
+        latentMuSigma.add(new SmoothUniformVertex(-10.0, 10.0, random));
+        latentMuSigma.add(new SmoothUniformVertex(-10.0, 10.0, random));
 
         VertexVariationalMAP.inferHyperParamsFromSamples(
                 hyperParams -> new GaussianVertex(hyperParams.get(0), hyperParams.get(1), random),
                 muSigma,
                 latentMuSigma,
-                1000
+                2000
         );
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Random;
 
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-import static org.junit.Assert.assertEquals;
 
 public class InverseGammaVertexTest {
 
@@ -115,6 +114,17 @@ public class InverseGammaVertexTest {
                 vertexEndValue,
                 vertexIncrement,
                 DELTA);
+    }
+
+    @Test
+    public void isTreatedAsConstantWhenObserved() {
+        InverseGammaVertex vertexUnderTest = new InverseGammaVertex(
+                new UniformVertex(0.0, 1.0),
+                new ConstantDoubleVertex(3.0),
+                random
+        );
+        ProbabilisticDoubleContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Random;
 
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-import static org.junit.Assert.assertEquals;
 
 public class LaplaceVertexTest {
 
@@ -94,6 +93,17 @@ public class LaplaceVertexTest {
                 vertexEndValue,
                 vertexIncrement,
                 DELTA);
+    }
+
+    @Test
+    public void isTreatedAsConstantWhenObserved() {
+        LaplaceVertex vertexUnderTest = new LaplaceVertex(
+                new UniformVertex(0.0, 1.0),
+                new ConstantDoubleVertex(3.0),
+                random
+        );
+        ProbabilisticDoubleContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -96,6 +96,17 @@ public class LogisticVertexTest {
     }
 
     @Test
+    public void isTreatedAsConstantWhenObserved() {
+        LogisticVertex vertexUnderTest = new LogisticVertex(
+                new UniformVertex(0.0, 1.0),
+                new ConstantDoubleVertex(3.0),
+                random
+        );
+        ProbabilisticDoubleContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
+    }
+
+    @Test
     public void dLogProbMatchesFiniteDifferenceCalculationFordPdb() {
         UniformVertex uniformB = new UniformVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.));
         LogisticVertex l = new LogisticVertex(new ConstantDoubleVertex(0.0), uniformB);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleContract.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 import java.util.ArrayList;
@@ -13,6 +14,8 @@ import static java.util.stream.Collectors.groupingBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ProbabilisticDoubleContract {
 
@@ -97,7 +100,15 @@ public class ProbabilisticDoubleContract {
 
         for (double value = vertexStartValue; value <= vertexEndValue; value += vertexValueIncrement) {
             vertexUnderTest.setAndCascade(value);
-            testGradientAcrossMultipleHyperParameterValues(hyperParameterStartValue, hyperParameterEndValue, hyperParameterValueIncrement, hyperParameterVertex, value, vertexUnderTest, gradientDelta);
+            testGradientAcrossMultipleHyperParameterValues(
+                    hyperParameterStartValue,
+                    hyperParameterEndValue,
+                    hyperParameterValueIncrement,
+                    hyperParameterVertex,
+                    value,
+                    vertexUnderTest,
+                    gradientDelta
+            );
         }
     }
 
@@ -131,6 +142,16 @@ public class ProbabilisticDoubleContract {
 
         assertEquals("Diff ln density problem at " + vertexValue + " hyper param value " + hyperParameterValue,
                 diffLnDensityApproxExpected, actualDiffLnDensity, 0.1);
+    }
+
+    public static void isTreatedAsConstantWhenObserved(DoubleVertex vertexUnderTest) {
+        vertexUnderTest.observe(1.0);
+        assertTrue(vertexUnderTest.getDualNumber().isOfConstant());
+    }
+
+    public static void hasNoGradientWithRespectToItsValueWhenObserved(DoubleVertex vertexUnderTest) {
+        vertexUnderTest.observe(1.0);
+        assertNull(vertexUnderTest.dLogProb(1.0).get(vertexUnderTest.getId()));
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformTest.java
@@ -82,4 +82,16 @@ public class SmoothUniformTest {
         ProbabilisticDoubleContract.sampleMethodMatchesLogProbMethod(uniform, N, from, to, delta, 1e-2);
     }
 
+    @Test
+    public void isTreatedAsConstantWhenObserved() {
+        SmoothUniformVertex vertexUnderTest = new SmoothUniformVertex(
+                new UniformVertex(0.0, 1.0),
+                new ConstantDoubleVertex(3.0),
+                0.01,
+                random
+        );
+        ProbabilisticDoubleContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
+    }
+
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/VertexVariationalMAP.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/VertexVariationalMAP.java
@@ -51,7 +51,7 @@ public class VertexVariationalMAP {
 
         GradientOptimizer g = new GradientOptimizer(inferNet);
 
-        g.maxAPosteriori(5000);
+        g.maxLikelihood(5000);
     }
 
     private static List<Double> getSamples(DoubleVertex knownVertex, int numSamples) {


### PR DESCRIPTION
This PR fixes a few very inefficient bits of Keanu.

1. We calculate and return the gradient of an observed vertex with respect to itself. Instead, since the value of the vertex is fixed, the gradient should be zero.

2. For dual number calculation, an observed vertex should behave as a constant since it has no derivative with respect to anything.

3. In the case where we are doing max likelihood, it's possible that the likelihood function has no dependency on a particular latent vertex. In this case we were getting an NPE but it should just recognize that the gradient with respect to that latent is zero.