### PR TITLE
Change Vertex base class to be able to handle derivatives of tensors

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -40,7 +40,7 @@ public class Hamiltonian {
 
         final List<Vertex<Double>> latentVertices = bayesNet.getContinuousLatentVertices();
         final Map<String, Long> latentSetAndCascadeCache = VertexValuePropagation.exploreSetting(latentVertices);
-        final List<Vertex> probabilisticVertices = bayesNet.getVerticesThatContributeToMasterP();
+        final List<Vertex> probabilisticVertices = bayesNet.getLatentAndObservedVertices();
 
         final Map<String, List<?>> samples = new HashMap<>();
         addSampleFromVertices(samples, fromVertices);
@@ -50,7 +50,7 @@ public class Hamiltonian {
         Map<String, Double> positionBeforeLeapfrog = new HashMap<>();
 
         Map<String, Double> gradient = LogProbGradient.getJointLogProbGradientWrtLatents(
-                bayesNet.getVerticesThatContributeToMasterP()
+                bayesNet.getLatentAndObservedVertices()
         );
         Map<String, Double> gradientBeforeLeapfrog = new HashMap<>();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -117,7 +117,7 @@ public class MetropolisHastings {
     }
 
     private static void checkBayesNetInHealthyState(BayesNet bayesNet) {
-        if (bayesNet.getVerticesThatContributeToMasterP().isEmpty()) {
+        if (bayesNet.getLatentAndObservedVertices().isEmpty()) {
             throw new IllegalArgumentException("Cannot sample from a completely deterministic BayesNet");
         } else if (bayesNet.isInImpossibleState()) {
             throw new IllegalArgumentException("Cannot start optimizer on zero probability network");

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
@@ -47,10 +47,10 @@ public class GradientOptimizer {
      * @return the natural logarithm of the Maximum A Posteriori (MAP)
      */
     public double maxAPosteriori(int maxEvaluations, NonLinearConjugateGradientOptimizer optimizer) {
-        if (bayesNet.getVerticesThatContributeToMasterP().isEmpty()) {
+        if (bayesNet.getLatentAndObservedVertices().isEmpty()) {
             throw new IllegalArgumentException("Cannot find MAP of network without any probabilistic vertices");
         }
-        return optimize(maxEvaluations, bayesNet.getVerticesThatContributeToMasterP(), optimizer);
+        return optimize(maxEvaluations, bayesNet.getLatentAndObservedVertices(), optimizer);
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/NonGradientOptimizer.java
@@ -68,7 +68,7 @@ public class NonGradientOptimizer {
      * @return the natural logarithm of the Maximum a posteriori (MAP)
      */
     public double maxAPosteriori(int maxEvaluations, double boundsRange) {
-        return optimize(maxEvaluations, boundsRange, bayesNet.getVerticesThatContributeToMasterP());
+        return optimize(maxEvaluations, boundsRange, bayesNet.getLatentAndObservedVertices());
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesNet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesNet.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
  */
 public class BayesNet {
 
-    private final List<Vertex> verticesThatContributeToMasterP;
+    private final List<Vertex> latentAndObservedVertices;
     private final List<Vertex> latentVertices;
     private final List<Vertex> observedVertices;
 
@@ -22,15 +22,15 @@ public class BayesNet {
 
     public BayesNet(Set<? extends Vertex> vertices) {
 
-        verticesThatContributeToMasterP = vertices.stream()
+        latentAndObservedVertices = vertices.stream()
                 .filter(v -> v.isObserved() || v.isProbabilistic())
                 .collect(Collectors.toList());
 
-        observedVertices = verticesThatContributeToMasterP.stream()
+        observedVertices = latentAndObservedVertices.stream()
                 .filter(Vertex::isObserved)
                 .collect(Collectors.toList());
 
-        latentVertices = verticesThatContributeToMasterP.stream()
+        latentVertices = latentAndObservedVertices.stream()
                 .filter(v -> !v.isObserved())
                 .collect(Collectors.toList());
     }
@@ -39,8 +39,8 @@ public class BayesNet {
         this(new HashSet<>(vertices));
     }
 
-    public List<Vertex> getVerticesThatContributeToMasterP() {
-        return verticesThatContributeToMasterP;
+    public List<Vertex> getLatentAndObservedVertices() {
+        return latentAndObservedVertices;
     }
 
     public List<Vertex> getLatentVertices() {
@@ -83,7 +83,7 @@ public class BayesNet {
 
     public double getLogOfMasterP() {
         double sum = 0.0;
-        for (Vertex<?> vertex : verticesThatContributeToMasterP) {
+        for (Vertex<?> vertex : latentAndObservedVertices) {
             sum += vertex.logProbAtValue();
         }
         return sum;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/ContinuousVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/ContinuousVertex.java
@@ -1,5 +1,7 @@
 package io.improbable.keanu.vertices;
 
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
+
 import java.util.Map;
 
 public abstract class ContinuousVertex<T> extends Vertex<T> {
@@ -10,12 +12,12 @@ public abstract class ContinuousVertex<T> extends Vertex<T> {
     }
 
     @Override
-    public final Map<String, Double> dLogProb(T value) {
+    public final Map<String, DoubleTensor> dLogProb(T value) {
         return dLogPdf(value);
     }
 
     public abstract double logPdf(T value);
 
-    public abstract Map<String, Double> dLogPdf(T value);
+    public abstract Map<String, DoubleTensor> dLogPdf(T value);
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/DiscreteVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/DiscreteVertex.java
@@ -1,5 +1,7 @@
 package io.improbable.keanu.vertices;
 
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
+
 import java.util.Map;
 
 public abstract class DiscreteVertex<T> extends Vertex<T> {
@@ -10,12 +12,12 @@ public abstract class DiscreteVertex<T> extends Vertex<T> {
     }
 
     @Override
-    public final Map<String, Double> dLogProb(T value) {
+    public final Map<String, DoubleTensor> dLogProb(T value) {
         return dLogPmf(value);
     }
 
     public abstract double logPmf(T value);
 
-    public abstract Map<String, Double> dLogPmf(T value);
+    public abstract Map<String, DoubleTensor> dLogPmf(T value);
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices;
 import io.improbable.keanu.Identifiable;
 import io.improbable.keanu.algorithms.graphtraversal.DiscoverGraph;
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -37,9 +38,9 @@ public abstract class Vertex<T> implements Identifiable {
      * @param value at a given value
      * @return the partial derivatives of the log density
      */
-    public abstract Map<String, Double> dLogProb(T value);
+    public abstract Map<String, DoubleTensor> dLogProb(T value);
 
-    public Map<String, Double> dLogProbAtValue() {
+    public Map<String, DoubleTensor> dLogProbAtValue() {
         return dLogProb(getValue());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NonProbabilisticBool.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NonProbabilisticBool.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic;
 
 import io.improbable.keanu.vertices.bool.BoolVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 
@@ -12,7 +13,7 @@ public abstract class NonProbabilisticBool extends BoolVertex {
     }
 
     @Override
-    public Map<String, Double> dLogPmf(Boolean value) {
+    public Map<String, DoubleTensor> dLogPmf(Boolean value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/Flip.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/Flip.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.bool.probabilistic;
 
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -37,7 +38,7 @@ public class Flip extends ProbabilisticBool {
     }
 
     @Override
-    public Map<String, Double> dLogPmf(Boolean value) {
+    public Map<String, DoubleTensor> dLogPmf(Boolean value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/NonProbabilisticDouble.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
 import io.improbable.keanu.vertices.NonProbabilisticObservationException;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public abstract class NonProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.HashMap;
 import java.util.List;
@@ -35,11 +36,11 @@ public class LogProbGradient {
         //dlogProbForProbabilisticVertex is the partial differentials of the natural
         //log of the fitness vertex's probability w.r.t latent vertices. The key of the
         //map is the latent vertex's id.
-        final Map<String, Double> dlogProbForProbabilisticVertex = probabilisticVertex.dLogProbAtValue();
+        final Map<String, DoubleTensor> dlogProbForProbabilisticVertex = probabilisticVertex.dLogProbAtValue();
 
-        for (Map.Entry<String, Double> partialDiffLogPWrt : dlogProbForProbabilisticVertex.entrySet()) {
+        for (Map.Entry<String, DoubleTensor> partialDiffLogPWrt : dlogProbForProbabilisticVertex.entrySet()) {
             final String wrtLatentVertexId = partialDiffLogPWrt.getKey();
-            final double partialDiffLogProbContribution = partialDiffLogPWrt.getValue();
+            final double partialDiffLogProbContribution = partialDiffLogPWrt.getValue().scalar();
 
             //partialDiffLogProbContribution is the contribution to the rate of change of
             //the natural log of the fitness vertex due to wrtLatentVertexId.

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.Beta;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -63,12 +64,12 @@ public class BetaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         Beta.Diff dlnPdf = Beta.dlnPdf(alpha.getValue(), beta.getValue(), value);
         return convertDualNumbersToDiff(dlnPdf.dPdAlpha, dlnPdf.dPdBeta, dlnPdf.dPdx);
     }
 
-    public Map<String, Double> convertDualNumbersToDiff(double dPdAlpha, double dPdBeta, double dPdx) {
+    public Map<String, DoubleTensor> convertDualNumbersToDiff(double dPdAlpha, double dPdBeta, double dPdx) {
         PartialDerivatives dPdInputsFromAlpha = alpha.getDualNumber().getPartialDerivatives().multiplyBy(dPdAlpha);
         PartialDerivatives dPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dPdBeta);
         PartialDerivatives dPdInputs = dPdInputsFromAlpha.add(dPdInputsFromBeta);
@@ -77,7 +78,7 @@ public class BetaVertex extends ProbabilisticDouble {
             dPdInputs.putWithRespectTo(getId(), dPdx);
         }
 
-        return dPdInputs.asMap();
+        return DoubleTensor.fromScalars(dPdInputs.asMap());
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.ChiSquared;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 
@@ -41,7 +42,7 @@ public class ChiSquaredVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.Exponential;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -63,7 +64,7 @@ public class ExponentialVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         Exponential.Diff dP = Exponential.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
     }
@@ -73,7 +74,7 @@ public class ExponentialVertex extends ProbabilisticDouble {
         return Exponential.sample(a.getValue(), b.getValue(), random);
     }
 
-    private Map<String, Double> convertDualNumbersToDiff(double dPda, double dPdb, double dPdx) {
+    private Map<String, DoubleTensor> convertDualNumbersToDiff(double dPda, double dPdb, double dPdx) {
         PartialDerivatives dPdInputsFromMu = a.getDualNumber().getPartialDerivatives().multiplyBy(dPda);
         PartialDerivatives dPdInputsFromSigma = b.getDualNumber().getPartialDerivatives().multiplyBy(dPdb);
         PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromSigma);
@@ -82,7 +83,7 @@ public class ExponentialVertex extends ProbabilisticDouble {
             dPdInputs.putWithRespectTo(getId(), dPdx);
         }
 
-        return dPdInputs.asMap();
+        return DoubleTensor.fromScalars(dPdInputs.asMap());
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.Gamma;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -79,12 +80,12 @@ public class GammaVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         Gamma.Diff diff = Gamma.dlnPdf(a.getValue(), theta.getValue(), k.getValue(), value);
         return convertDualNumbersToDiff(diff.dPda, diff.dPdtheta, diff.dPdk, diff.dPdx);
     }
 
-    private Map<String, Double> convertDualNumbersToDiff(double dPda, double dPdtheta, double dPdk, double dPdx) {
+    private Map<String, DoubleTensor> convertDualNumbersToDiff(double dPda, double dPdtheta, double dPdk, double dPdx) {
         PartialDerivatives dPdInputsFromA = a.getDualNumber().getPartialDerivatives().multiplyBy(dPda);
         PartialDerivatives dPdInputsFromTheta = theta.getDualNumber().getPartialDerivatives().multiplyBy(dPdtheta);
         PartialDerivatives dPdInputsFromK = k.getDualNumber().getPartialDerivatives().multiplyBy(dPdk);
@@ -94,7 +95,7 @@ public class GammaVertex extends ProbabilisticDouble {
             dPdInputs.putWithRespectTo(getId(), dPdx);
         }
 
-        return dPdInputs.asMap();
+        return DoubleTensor.fromScalars(dPdInputs.asMap());
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.Gaussian;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -64,12 +65,12 @@ public class GaussianVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         Gaussian.Diff dlnP = Gaussian.dlnPdf(mu.getValue(), sigma.getValue(), value);
         return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPdsigma, dlnP.dPdx);
     }
 
-    private Map<String, Double> convertDualNumbersToDiff(double dPdmu, double dPdsigma, double dPdx) {
+    private Map<String, DoubleTensor> convertDualNumbersToDiff(double dPdmu, double dPdsigma, double dPdx) {
         PartialDerivatives dPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dPdmu);
         PartialDerivatives dPdInputsFromSigma = sigma.getDualNumber().getPartialDerivatives().multiplyBy(dPdsigma);
         PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromSigma);
@@ -78,7 +79,7 @@ public class GaussianVertex extends ProbabilisticDouble {
             dPdInputs.putWithRespectTo(getId(), dPdx);
         }
 
-        return dPdInputs.asMap();
+        return DoubleTensor.fromScalars(dPdInputs.asMap());
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.InverseGamma;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -60,12 +61,12 @@ public class InverseGammaVertex extends ProbabilisticDouble {
         return InverseGamma.logPdf(a.getValue(), b.getValue(), value);
     }
 
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         InverseGamma.Diff dP = InverseGamma.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(dP.dPda, dP.dPdb, dP.dPdx);
     }
 
-    private Map<String, Double> convertDualNumbersToDiff(double dPda, double dPdb, double dPdx) {
+    private Map<String, DoubleTensor> convertDualNumbersToDiff(double dPda, double dPdb, double dPdx) {
         PartialDerivatives dPdInputsFromA = a.getDualNumber().getPartialDerivatives().multiplyBy(dPda);
         PartialDerivatives dPdInputsFromB = b.getDualNumber().getPartialDerivatives().multiplyBy(dPdb);
         PartialDerivatives dPdInputs = dPdInputsFromA.add(dPdInputsFromB);
@@ -74,7 +75,7 @@ public class InverseGammaVertex extends ProbabilisticDouble {
             dPdInputs.putWithRespectTo(getId(), dPdx);
         }
 
-        return dPdInputs.asMap();
+        return DoubleTensor.fromScalars(dPdInputs.asMap());
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.Laplace;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -55,7 +56,7 @@ public class LaplaceVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         Laplace.Diff diff = Laplace.dlnPdf(mu.getValue(), beta.getValue(), value);
         return convertDualNumbersToDiff(diff.dPdmu, diff.dPdbeta, diff.dPdx);
     }
@@ -65,7 +66,7 @@ public class LaplaceVertex extends ProbabilisticDouble {
         return Laplace.sample(mu.getValue(), beta.getValue(), random);
     }
 
-    private Map<String, Double> convertDualNumbersToDiff(double dPdmu, double dPdbeta, double dPdx) {
+    private Map<String, DoubleTensor> convertDualNumbersToDiff(double dPdmu, double dPdbeta, double dPdx) {
         PartialDerivatives dPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dPdmu);
         PartialDerivatives dPdInputsFromSigma = beta.getDualNumber().getPartialDerivatives().multiplyBy(dPdbeta);
         PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromSigma);
@@ -74,6 +75,6 @@ public class LaplaceVertex extends ProbabilisticDouble {
             dPdInputs.putWithRespectTo(getId(), dPdx);
         }
 
-        return dPdInputs.asMap();
+        return DoubleTensor.fromScalars(dPdInputs.asMap());
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.Logistic;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -63,12 +64,12 @@ public class LogisticVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         Logistic.Diff diff = Logistic.dlnPdf(a.getValue(), b.getValue(), value);
         return convertDualNumbersToDiff(diff.dPda, diff.dPdb, diff.dPdx);
     }
 
-    private Map<String, Double> convertDualNumbersToDiff(double dPda, double dPdb, double dPdx) {
+    private Map<String, DoubleTensor> convertDualNumbersToDiff(double dPda, double dPdb, double dPdx) {
         PartialDerivatives dPdInputsFromMu = a.getDualNumber().getPartialDerivatives().multiplyBy(dPda);
         PartialDerivatives dPdInputsFromSigma = b.getDualNumber().getPartialDerivatives().multiplyBy(dPdb);
         PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromSigma);
@@ -77,7 +78,7 @@ public class LogisticVertex extends ProbabilisticDouble {
             dPdInputs.putWithRespectTo(getId(), dPdx);
         }
 
-        return dPdInputs.asMap();
+        return DoubleTensor.fromScalars(dPdInputs.asMap());
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import io.improbable.keanu.distributions.continuous.SmoothUniformDistribution;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Collections;
 import java.util.Map;
@@ -77,7 +78,7 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
 
         if (isObserved()) {
             return Collections.emptyMap();
@@ -90,7 +91,7 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
         final double density = SmoothUniformDistribution.pdf(min, max, shoulderWidth, value);
         final double dlogPdfdx = dPdfdx / density;
 
-        return singletonMap(getId(), dlogPdfdx);
+        return DoubleTensor.fromScalars(singletonMap(getId(), dlogPdfdx));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import io.improbable.keanu.distributions.continuous.Triangular;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -96,7 +97,7 @@ public class TriangularVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Collections;
 import java.util.Map;
@@ -65,7 +66,7 @@ public class UniformVertex extends ProbabilisticDouble {
     }
 
     @Override
-    public Map<String, Double> dLogPdf(Double value) {
+    public Map<String, DoubleTensor> dLogPdf(Double value) {
 
         if (isObserved()) {
             return Collections.emptyMap();
@@ -75,11 +76,11 @@ public class UniformVertex extends ProbabilisticDouble {
         double max = this.xMax.getValue();
 
         if (this.getValue() <= min) {
-            return singletonMap(getId(), Double.POSITIVE_INFINITY);
+            return DoubleTensor.fromScalars(singletonMap(getId(), Double.POSITIVE_INFINITY));
         } else if (this.getValue() >= max) {
-            return singletonMap(getId(), Double.NEGATIVE_INFINITY);
+            return DoubleTensor.fromScalars(singletonMap(getId(), Double.NEGATIVE_INFINITY));
         } else {
-            return singletonMap(getId(), 0.0);
+            return DoubleTensor.fromScalars(singletonMap(getId(), 0.0));
         }
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/DoubleTensor.java
@@ -19,16 +19,6 @@ public interface DoubleTensor extends Tensor {
         return asTensors;
     }
 
-    static Map<String, Double> toScalars(Map<String, DoubleTensor> tensors) {
-        Map<String, Double> asTensors = new HashMap<>();
-
-        for (Map.Entry<String, DoubleTensor> entry : tensors.entrySet()) {
-            asTensors.put(entry.getKey(), entry.getValue().scalar());
-        }
-
-        return asTensors;
-    }
-
     double scalar();
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/DoubleTensor.java
@@ -1,0 +1,34 @@
+package io.improbable.keanu.vertices.dbltensor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public interface DoubleTensor extends Tensor {
+
+    static DoubleTensor scalar(double scalarValue) {
+        return new SimpleScalarTensor(scalarValue);
+    }
+
+    static Map<String, DoubleTensor> fromScalars(Map<String, Double> scalars) {
+        Map<String, DoubleTensor> asTensors = new HashMap<>();
+
+        for (Map.Entry<String, Double> entry : scalars.entrySet()) {
+            asTensors.put(entry.getKey(), DoubleTensor.scalar(entry.getValue()));
+        }
+
+        return asTensors;
+    }
+
+    static Map<String, Double> toScalars(Map<String, DoubleTensor> tensors) {
+        Map<String, Double> asTensors = new HashMap<>();
+
+        for (Map.Entry<String, DoubleTensor> entry : tensors.entrySet()) {
+            asTensors.put(entry.getKey(), entry.getValue().scalar());
+        }
+
+        return asTensors;
+    }
+
+    double scalar();
+
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/SimpleScalarTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/SimpleScalarTensor.java
@@ -14,16 +14,6 @@ public class SimpleScalarTensor implements DoubleTensor {
     }
 
     @Override
-    public int getRank() {
-        return 2;
-    }
-
-    @Override
-    public int[] getShape() {
-        return new int[]{1, 1};
-    }
-
-    @Override
     public int getLength() {
         return 1;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/SimpleScalarTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/SimpleScalarTensor.java
@@ -1,0 +1,30 @@
+package io.improbable.keanu.vertices.dbltensor;
+
+public class SimpleScalarTensor implements DoubleTensor {
+
+    private double scalar;
+
+    public SimpleScalarTensor(double scalar) {
+        this.scalar = scalar;
+    }
+
+    @Override
+    public double scalar() {
+        return scalar;
+    }
+
+    @Override
+    public int getRank() {
+        return 2;
+    }
+
+    @Override
+    public int[] getShape() {
+        return new int[]{1, 1};
+    }
+
+    @Override
+    public int getLength() {
+        return 1;
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/Tensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/Tensor.java
@@ -1,0 +1,32 @@
+package io.improbable.keanu.vertices.dbltensor;
+
+import java.util.Arrays;
+
+public interface Tensor {
+
+    int getRank();
+
+    int[] getShape();
+
+    int getLength();
+
+    default boolean isScalar() {
+        return getLength() == 1;
+    }
+
+    default boolean isVector() {
+        return getRank() == 1;
+    }
+
+    default boolean isMatrix() {
+        return getRank() == 2;
+    }
+
+    default boolean hasSameShapeAs(Tensor that) {
+        return hasSameShapeAs(that.getShape());
+    }
+
+    default boolean hasSameShapeAs(int[] shape) {
+        return Arrays.equals(this.getShape(), shape);
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/Tensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/Tensor.java
@@ -1,32 +1,6 @@
 package io.improbable.keanu.vertices.dbltensor;
 
-import java.util.Arrays;
-
 public interface Tensor {
 
-    int getRank();
-
-    int[] getShape();
-
     int getLength();
-
-    default boolean isScalar() {
-        return getLength() == 1;
-    }
-
-    default boolean isVector() {
-        return getRank() == 1;
-    }
-
-    default boolean isMatrix() {
-        return getRank() == 2;
-    }
-
-    default boolean hasSameShapeAs(Tensor that) {
-        return hasSameShapeAs(that.getShape());
-    }
-
-    default boolean hasSameShapeAs(int[] shape) {
-        return Arrays.equals(this.getShape(), shape);
-    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/NonProbabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/NonProbabilistic.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.generic.nonprobabilistic;
 
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 
@@ -12,7 +13,7 @@ public abstract class NonProbabilistic<T> extends Vertex<T> {
     }
 
     @Override
-    public Map<String, Double> dLogProb(T value) {
+    public Map<String, DoubleTensor> dLogProb(T value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/SelectVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/SelectVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.generic.probabilistic.discrete;
 
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 import io.improbable.keanu.vertices.generic.probabilistic.Probabilistic;
 
 import java.util.LinkedHashMap;
@@ -62,7 +63,7 @@ public class SelectVertex<T> extends Probabilistic<T> {
     }
 
     @Override
-    public Map<String, Double> dLogProb(T value) {
+    public Map<String, DoubleTensor> dLogProb(T value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/NonProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/NonProbabilisticInteger.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic;
 
 import io.improbable.keanu.vertices.NonProbabilisticObservationException;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 
 import java.util.Map;
@@ -27,7 +28,7 @@ public abstract class NonProbabilisticInteger extends IntegerVertex {
     }
 
     @Override
-    public Map<String, Double> dLogPmf(Integer value) {
+    public Map<String, DoubleTensor> dLogPmf(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 
 import java.util.Map;
@@ -92,7 +93,7 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public Map<String, Double> dLogPmf(Integer value) {
+    public Map<String, DoubleTensor> dLogPmf(Integer value) {
         int i = getValue();
         double x = input.getValue();
         double clampedX = getClampedInput();
@@ -134,12 +135,12 @@ public class FuzzyCastToIntegerVertex extends ProbabilisticInteger {
         return Math.min(Math.max(input.getValue(), minClamped), maxClamped);
     }
 
-    private Map<String, Double> convertDualNumbersToDiff(double dPdInput, double dPdSigma) {
+    private Map<String, DoubleTensor> convertDualNumbersToDiff(double dPdInput, double dPdSigma) {
         PartialDerivatives dPdInputsFromInput = input.getDualNumber().getPartialDerivatives().multiplyBy(dPdInput);
         PartialDerivatives dPdInputsFromSigma = fuzzinessSigma.getDualNumber().getPartialDerivatives().multiplyBy(dPdSigma);
         PartialDerivatives dPdInputs = dPdInputsFromInput.add(dPdInputsFromSigma);
 
-        return dPdInputs.asMap();
+        return DoubleTensor.fromScalars(dPdInputs.asMap());
     }
 
     private double s(double x, double sigma) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.discrete.Poisson;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 
 import java.util.Map;
 import java.util.Random;
@@ -41,7 +42,7 @@ public class PoissonVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public Map<String, Double> dLogPmf(Integer value) {
+    public Map<String, DoubleTensor> dLogPmf(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 
 import java.util.Map;
@@ -59,7 +60,7 @@ public class UniformIntVertex extends ProbabilisticInteger {
     }
 
     @Override
-    public Map<String, Double> dLogPmf(Integer value) {
+    public Map<String, DoubleTensor> dLogPmf(Integer value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -44,7 +44,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dLogProbAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId()).scalar();
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(0, gradient, 0);
     }
@@ -54,7 +54,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.25;
         b.setValue(value);
-        double gradient = b.dLogProbAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId()).scalar();
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(1, Math.signum(gradient), 0);
     }
@@ -64,7 +64,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(3.0), random);
         double value = 0.75;
         b.setValue(value);
-        double gradient = b.dLogProbAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId()).scalar();
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(-1, Math.signum(gradient), 0);
     }
@@ -74,7 +74,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(3.0), new ConstantDoubleVertex(1.5), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dLogProbAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId()).scalar();
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(1, Math.signum(gradient), 0);
     }
@@ -84,7 +84,7 @@ public class BetaVertexTest {
         BetaVertex b = new BetaVertex(new ConstantDoubleVertex(1.5), new ConstantDoubleVertex(3.0), random);
         double value = 0.5;
         b.setValue(value);
-        double gradient = b.dLogProbAtValue().get(b.getId());
+        double gradient = b.dLogProbAtValue().get(b.getId()).scalar();
         log.info("Gradient at " + value + ": " + gradient);
         assertEquals(-1, Math.signum(gradient), 0);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -49,7 +49,7 @@ public class ExponentialVertexTest {
         double b = 1.0;
         ExponentialVertex e = new ExponentialVertex(a, b, new Random(1));
         e.setValue(a);
-        double gradient = e.dLogProbAtValue().get(e.getId());
+        double gradient = e.dLogProbAtValue().get(e.getId()).scalar();
         log.info("Gradient at a: " + gradient);
         assertEquals(-1, gradient, 0);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -163,7 +163,7 @@ public class GammaVertexTest {
         for (double x = 0.01; x <= 1.0; x += 0.1) {
             double approxExpected = (g.logProb(x + DELTA) - g.logProb(x - DELTA)) / (2 * DELTA);
             g.setValue(x);
-            double actual = g.dLogProbAtValue().get(g.getId());
+            double actual = g.dLogProbAtValue().get(g.getId()).scalar();
             assertThat("   Gradient at " + x + " = " + actual + " (approx expected = " + approxExpected + ")",
                     approxExpected, closeTo(actual, 0.1)
             );

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -41,7 +41,7 @@ public class GaussianVertexTest {
     public void gradientAtMuIsZero() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(0.0);
-        double gradient = g.dLogProbAtValue().get(g.getId());
+        double gradient = g.dLogProbAtValue().get(g.getId()).scalar();
         log.info("Gradient at mu: " + gradient);
         assertEquals(0, gradient, 0);
     }
@@ -50,7 +50,7 @@ public class GaussianVertexTest {
     public void gradientBeforeMuIsPositive() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(-1.0);
-        double gradient = g.dLogProbAtValue().get(g.getId());
+        double gradient = g.dLogProbAtValue().get(g.getId()).scalar();
         log.info("Gradient after mu: " + gradient);
         assertTrue(gradient > 0);
     }
@@ -59,7 +59,7 @@ public class GaussianVertexTest {
     public void gradientAfterMuIsNegative() {
         GaussianVertex g = new GaussianVertex(new ConstantDoubleVertex(0.0), new ConstantDoubleVertex(1.0), random);
         g.setValue(1.0);
-        double gradient = g.dLogProbAtValue().get(g.getId());
+        double gradient = g.dLogProbAtValue().get(g.getId()).scalar();
         log.info("Gradient after mu: " + gradient);
         assertTrue(gradient < 0);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -48,7 +48,7 @@ public class LogisticVertexTest {
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a);
-        double gradient = l.dLogProbAtValue().get(l.getId());
+        double gradient = l.dLogProbAtValue().get(l.getId()).scalar();
         log.info("Gradient at a: " + gradient);
         assertEquals(gradient, 0, 0);
     }
@@ -59,7 +59,7 @@ public class LogisticVertexTest {
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a - 1.0);
-        double gradient = l.dLogProbAtValue().get(l.getId());
+        double gradient = l.dLogProbAtValue().get(l.getId()).scalar();
         log.info("Gradient at x < a: " + gradient);
         assertTrue(gradient > 0);
     }
@@ -70,7 +70,7 @@ public class LogisticVertexTest {
         double b = 0.5;
         LogisticVertex l = new LogisticVertex(a, b, new Random(1));
         l.setValue(a + 1.0);
-        double gradient = l.dLogProbAtValue().get(l.getId());
+        double gradient = l.dLogProbAtValue().get(l.getId()).scalar();
         log.info("Gradient at x > a: " + gradient);
         assertTrue(gradient < 0);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleContract.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensor;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 import java.util.ArrayList;
@@ -136,9 +137,9 @@ public class ProbabilisticDoubleContract {
 
         hyperParameterVertex.setAndCascade(hyperParameterValue);
 
-        Map<String, Double> diffln = vertexUnderTest.dLogProbAtValue();
+        Map<String, DoubleTensor> diffln = vertexUnderTest.dLogProbAtValue();
 
-        double actualDiffLnDensity = diffln.get(hyperParameterVertex.getId());
+        double actualDiffLnDensity = diffln.get(hyperParameterVertex.getId()).scalar();
 
         assertEquals("Diff ln density problem at " + vertexValue + " hyper param value " + hyperParameterValue,
                 diffLnDensityApproxExpected, actualDiffLnDensity, 0.1);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/FuzzyCastToIntegerVertexTest.java
@@ -154,7 +154,7 @@ public class FuzzyCastToIntegerVertexTest {
 
         mu.setValue(mu1);
         double logDensity1 = fuzzy.logProbAtValue();
-        double actual_dPdmu = fuzzy.dLogProbAtValue().get(mu.getId());
+        double actual_dPdmu = fuzzy.dLogProbAtValue().get(mu.getId()).scalar();
 
         mu.setValue(mu2);
         double logDensity2 = fuzzy.logProbAtValue();
@@ -183,7 +183,7 @@ public class FuzzyCastToIntegerVertexTest {
 
         sigma.setValue(sigma1);
         double logDensity1 = fuzzy.logProbAtValue();
-        double actual_dPdsigma = fuzzy.dLogProbAtValue().get(sigma.getId());
+        double actual_dPdsigma = fuzzy.dLogProbAtValue().get(sigma.getId()).scalar();
 
         sigma.setValue(sigma2);
         double logDensity2 = fuzzy.logProbAtValue();
@@ -212,7 +212,7 @@ public class FuzzyCastToIntegerVertexTest {
 
         mu.setValue(mu1);
         double logDensity1 = fuzzy.logProbAtValue();
-        double actual_dlnPdmu = fuzzy.dLogProbAtValue().get(mu.getId());
+        double actual_dlnPdmu = fuzzy.dLogProbAtValue().get(mu.getId()).scalar();
 
         mu.setValue(mu2);
         double logDensity2 = fuzzy.logProbAtValue();
@@ -241,7 +241,7 @@ public class FuzzyCastToIntegerVertexTest {
 
         sigma.setValue(sigma1);
         double logDensity1 = fuzzy.logProbAtValue();
-        double actual_dlnPdsigma = fuzzy.dLogProbAtValue().get(sigma.getId());
+        double actual_dlnPdsigma = fuzzy.dLogProbAtValue().get(sigma.getId()).scalar();
 
         sigma.setValue(sigma2);
         double logDensity2 = fuzzy.logProbAtValue();


### PR DESCRIPTION
This PR is work factored out of the double tensor work in order to size down the next PR. The changes include:

- In BayesNet, change verticesThatContributeToMasterP to latentAndObservedVertices. This gets away from the internal naming of masterP.

- Make the dLogProb on Vertex able to return partial derivatives with respect to tensor vertices. As a first step all of the effectively scalar vertices (DoubleVertex) just wraps the DoubleTensor back to a Double or up to a DoubleTensor where appropriate.