### PR TITLE
Add default Intellij editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+[*]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=false
+indent_style=space
+indent_size=4
+
+[*.csv]
+indent_style=tab
+tab_width=1
+
+[{*.yml,*.yaml}]
+indent_style=space
+indent_size=2
+


### PR DESCRIPTION
This PR adds a .editorconfig file that allows other code editors to format code as expected in the Keanu Repo. More about editor config [here](http://editorconfig.org/)