### PR TITLE
Add Windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+os:
+  - linux
+  - windows
 jdk:
   - oraclejdk8
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: java
-os:
-  - linux
-  - windows
 jdk:
   - oraclejdk8
 addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,3 @@
+version: 1.0.{build}
+build_script:
+- cmd: ./gradlew.bat build


### PR DESCRIPTION
Unfortunately Travis doesn't support Windows builds at the moment. However, [Appveyor](https://ci.appveyor.com/) does and it was super easy to setup. We might want to switch to a single CI that supports both but at the moment we are using Appveyor and Travis for exactly what they were meant to do and they do them well. 