### PR TITLE
Run Sonar on Internal PR's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ addons:
   sonarcloud:
     organization: "improbable-keanu"
 script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner; fi'
+  - 'if [[ ! -z $SONAR_TOKEN ]]; then sonar-scanner; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ addons:
   sonarcloud:
     organization: "improbable-keanu"
 script:
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sonar-scanner; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ addons:
   sonarcloud:
     organization: "improbable-keanu"
 script:
-  - sonar-scanner
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then sonar-scanner; fi'


### PR DESCRIPTION
Due to Travis security concerns we cannot run `sonar-scanner` on PR's sourced from external (forked) repo's.

This allows the build to pass for PR's raised from external repo's by not running `sonar-scanner`.

Tested on Justin's external PR: https://travis-ci.org/improbable-research/keanu/builds/378740910