### PR TITLE
Fix autodiff bug and add debug helpers for optimizer

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -43,6 +43,8 @@ public class Hamiltonian {
                                                      final double stepSize,
                                                      final KeanuRandom random) {
 
+        bayesNet.cascadeObservations();
+
         final List<Vertex<Double>> latentVertices = bayesNet.getContinuousLatentVertices();
         final Map<Long, Long> latentSetAndCascadeCache = VertexValuePropagation.exploreSetting(latentVertices);
         final List<Vertex> probabilisticVertices = bayesNet.getLatentAndObservedVertices();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -124,6 +124,7 @@ public class MetropolisHastings {
     }
 
     private static void checkBayesNetInHealthyState(BayesianNetwork bayesNet) {
+        bayesNet.cascadeObservations();
         if (bayesNet.getLatentAndObservedVertices().isEmpty()) {
             throw new IllegalArgumentException("Cannot sample from a completely deterministic BayesNet");
         } else if (bayesNet.isInImpossibleState()) {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
@@ -40,6 +40,8 @@ public class NUTS {
                                                      final double epsilon,
                                                      final KeanuRandom random) {
 
+        bayesNet.cascadeObservations();
+
         final List<Vertex<Double>> latentVertices = bayesNet.getContinuousLatentVertices();
         final Map<Long, Long> latentSetAndCascadeCache = VertexValuePropagation.exploreSetting(latentVertices);
         final List<Vertex> probabilisticVertices = bayesNet.getLatentAndObservedVertices();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SimulatedAnnealing.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SimulatedAnnealing.java
@@ -51,6 +51,8 @@ public class SimulatedAnnealing {
                                                  AnnealingSchedule annealingSchedule,
                                                  KeanuRandom random) {
 
+        bayesNet.cascadeObservations();
+
         if (bayesNet.isInImpossibleState()) {
             throw new IllegalArgumentException("Cannot start optimizer on zero probability network");
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/initialconditions/MultiModeDiscovery.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/initialconditions/MultiModeDiscovery.java
@@ -22,7 +22,7 @@ public class MultiModeDiscovery {
                                                                    KeanuRandom random) {
 
         List<NetworkState> maxSamples = new ArrayList<>();
-        VertexValuePropagation.cascadeUpdate(network.getObservedVertices());
+        network.cascadeObservations();
         List<Vertex> sortedByDependency = TopologicalSort.sort(network.getLatentVertices());
 
         for (int i = 0; i < attempts; i++) {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/tensor/TensorHamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/tensor/TensorHamiltonian.java
@@ -43,6 +43,8 @@ public class TensorHamiltonian {
                                                      final double stepSize,
                                                      final KeanuRandom random) {
 
+        bayesNet.cascadeObservations();
+
         final List<Vertex<DoubleTensor>> latentVertices = bayesNet.getContinuousLatentVertices();
         final Map<Long, Long> latentSetAndCascadeCache = VertexValuePropagation.exploreSetting(latentVertices);
         final List<Vertex> probabilisticVertices = bayesNet.getLatentAndObservedVertices();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/tensor/TensorNUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/tensor/TensorNUTS.java
@@ -40,6 +40,8 @@ public class TensorNUTS {
                                                      final double epsilon,
                                                      final KeanuRandom random) {
 
+        bayesNet.cascadeObservations();
+
         final List<Vertex<DoubleTensor>> latentVertices = bayesNet.getContinuousLatentVertices();
         final Map<Long, Long> latentSetAndCascadeCache = VertexValuePropagation.exploreSetting(latentVertices);
         final List<Vertex> probabilisticVertices = bayesNet.getLatentAndObservedVertices();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/Prior.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/Prior.java
@@ -25,6 +25,8 @@ public class Prior {
             throw new IllegalStateException("Cannot sample prior from graph with observations");
         }
 
+        bayesNet.cascadeObservations();
+
         List<? extends Vertex> topologicallySorted = TopologicalSort.sort(bayesNet.getLatentVertices());
         Map<Long, List> samplesByVertex = new HashMap<>();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
@@ -52,6 +52,8 @@ public class RejectionSampler {
                                                      int sampleCount,
                                                      KeanuRandom random) {
 
+        bayesNet.cascadeObservations();
+
         Map<Long, List<?>> samples = new HashMap<>();
         long acceptedCount = 0;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
@@ -90,6 +90,8 @@ public class GradientOptimizer {
                             List<? extends Vertex> outputVertices,
                             NonLinearConjugateGradientOptimizer optimizer) {
 
+        bayesNet.cascadeObservations();
+
         FitnessFunctionWithGradient fitnessFunction = new FitnessFunctionWithGradient(outputVertices, bayesNet.getContinuousLatentVertices());
         ObjectiveFunction fitness = new ObjectiveFunction(fitnessFunction.fitness());
         ObjectiveFunctionGradient gradient = new ObjectiveFunctionGradient(fitnessFunction.gradient());

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/NonGradientOptimizer.java
@@ -27,6 +27,8 @@ public class NonGradientOptimizer {
 
     public double optimize(int maxEvaluations, double boundsRange, List<? extends Vertex> outputVertices) {
 
+        bayesNet.cascadeObservations();
+
         if (bayesNet.isInImpossibleState()) {
             throw new IllegalArgumentException("Cannot start optimizer on zero probability network");
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/tensor/TensorFitnessFunctionWithGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/tensor/TensorFitnessFunctionWithGradient.java
@@ -77,18 +77,27 @@ public class TensorFitnessFunctionWithGradient {
         for (Vertex<DoubleTensor> vertex : latentVertices) {
             DoubleTensor tensor = diffs.get(vertex.getId());
             if (tensor != null) {
-                if (TensorShape.isScalar(vertex.getShape()) && !TensorShape.isScalar(tensor.getShape())) {
-                    tensors.add(DoubleTensor.scalar(tensor.sum()));
-                } else {
-                    tensors.add(tensor);
-                }
+                tensors.add(alignGradientToLatent(vertex, tensor));
             } else {
-                int[] missingVertexShape = vertex.getValue().getShape();
-                tensors.add(DoubleTensor.zeros(missingVertexShape));
+                tensors.add(DoubleTensor.zeros(vertex.getShape()));
             }
         }
 
         return flattenAll(tensors);
+    }
+
+    /**
+     * @param latentVertex wrt vertex
+     * @param gradients    gradient wrt latentVertex
+     * @return the gradient with the appropriate shape given the latent vertex
+     */
+    private static DoubleTensor alignGradientToLatent(Vertex<DoubleTensor> latentVertex,
+                                                      DoubleTensor gradients) {
+        if (TensorShape.isScalar(latentVertex.getShape()) && !TensorShape.isScalar(gradients.getShape())) {
+            return DoubleTensor.scalar(gradients.sum());
+        } else {
+            return gradients;
+        }
     }
 
     private static double[] flattenAll(List<DoubleTensor> tensors) {

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -53,6 +53,10 @@ public class BayesianNetwork {
         return sum;
     }
 
+    public void cascadeObservations() {
+        VertexValuePropagation.cascadeUpdate(observedVertices);
+    }
+
     /**
      * Attempt to find a non-zero master probability
      * by naively sampling vertices in order of data dependency
@@ -61,8 +65,6 @@ public class BayesianNetwork {
      * @param random   random source for sampling
      */
     public void probeForNonZeroMasterP(int attempts, KeanuRandom random) {
-
-        VertexValuePropagation.cascadeUpdate(observedVertices);
 
         if (isInImpossibleState()) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/nonprobabilistic/diff/TensorPartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbltensor/nonprobabilistic/diff/TensorPartialDerivatives.java
@@ -85,12 +85,7 @@ public class TensorPartialDerivatives {
 
         for (Map.Entry<Long, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
             long k = entry.getKey();
-            DoubleTensor v;
-            if (entry.getValue().isScalar() && !multiplier.isScalar()) {
-                v = entry.getValue().times(multiplier.sum());
-            } else {
-                v = entry.getValue().times(multiplier);
-            }
+            DoubleTensor v = entry.getValue().times(multiplier);
             multiplied.put(k, v);
         }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegression.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegression.java
@@ -54,14 +54,10 @@ public class LinearRegression {
 
         double expectedM = 3.0;
         double expectedB = 20.0;
-//        List<Point> points = make1FactorTestData(10000, expectedM, expectedB);
+        List<Point> points = make1FactorTestData(10000, expectedM, expectedB);
 
         ProbabilisticDouble m = new GaussianVertex(0.0, 10.0);
         ProbabilisticDouble b = new GaussianVertex(0.0, 10.0);
-
-        List<Point> points = new ArrayList<>();
-        points.add(new Point(20, new double[]{0}));
-        points.add(new Point(23, new double[]{1}));
 
         log.info("Building graph");
         for (Point p : points) {

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegression.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegression.java
@@ -2,12 +2,19 @@ package io.improbable.keanu.e2e.regression;
 
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.variational.GradientOptimizer;
+import io.improbable.keanu.algorithms.variational.tensor.TensorGradientOptimizer;
 import io.improbable.keanu.network.BayesNetDoubleAsContinuous;
+import io.improbable.keanu.network.BayesNetTensorAsContinuous;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDouble;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import io.improbable.keanu.vertices.dbltensor.DoubleTensorVertex;
 import io.improbable.keanu.vertices.dbltensor.KeanuRandom;
+import io.improbable.keanu.vertices.dbltensor.nonprobabilistic.ConstantDoubleTensorVertex;
+import io.improbable.keanu.vertices.dbltensor.probabilistic.TensorGaussianVertex;
+import io.improbable.keanu.vertices.dbltensor.probabilistic.TensorUniformVertex;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,10 +54,14 @@ public class LinearRegression {
 
         double expectedM = 3.0;
         double expectedB = 20.0;
-        List<Point> points = make1FactorTestData(1000, expectedM, expectedB);
+//        List<Point> points = make1FactorTestData(10000, expectedM, expectedB);
 
         ProbabilisticDouble m = new GaussianVertex(0.0, 10.0);
         ProbabilisticDouble b = new GaussianVertex(0.0, 10.0);
+
+        List<Point> points = new ArrayList<>();
+        points.add(new Point(20, new double[]{0}));
+        points.add(new Point(23, new double[]{1}));
 
         log.info("Building graph");
         for (Point p : points) {
@@ -68,6 +79,38 @@ public class LinearRegression {
         log.info("M = " + m.getValue() + ", B = " + b.getValue());
         assertEquals(expectedM, m.getValue(), 0.01);
         assertEquals(expectedB, b.getValue(), 0.01);
+    }
+
+
+    @Test
+    public void linearRegression1FactorTensorVariationalMAP() {
+
+        // Generate data
+        int N = 100000;
+        double expectedM = 3.0;
+        double expectedB = 20.0;
+
+        DoubleTensorVertex xGenerator = new TensorUniformVertex(new int[]{1, N}, 0, 10);
+        DoubleTensorVertex yGenerator = new TensorGaussianVertex(xGenerator.multiply(expectedM).plus(expectedB), 1.0);
+        DoubleTensor xData = xGenerator.sample(random);
+        xGenerator.setAndCascade(xData);
+        DoubleTensor yData = yGenerator.sample(random);
+
+        // Linear Regression
+        DoubleTensorVertex m = new TensorGaussianVertex(0.0, 10.0);
+        DoubleTensorVertex b = new TensorGaussianVertex(0.0, 10.0);
+        DoubleTensorVertex x = new ConstantDoubleTensorVertex(xData);
+        DoubleTensorVertex y = new TensorGaussianVertex(x.multiply(m).plus(b), 5.0);
+        y.observe(yData);
+
+        BayesNetTensorAsContinuous bayesNet = new BayesNetTensorAsContinuous(m.getConnectedGraph());
+        TensorGradientOptimizer optimizer = new TensorGradientOptimizer(bayesNet);
+
+        optimizer.maxLikelihood(10000);
+
+        log.info("M = " + m.getValue().scalar() + ", B = " + b.getValue().scalar());
+        assertEquals(expectedM, m.getValue().scalar(), 0.05);
+        assertEquals(expectedB, b.getValue().scalar(), 0.05);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbltensor/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbltensor/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -207,7 +207,7 @@ public class ProbabilisticDoubleTensorContract {
         hyperParameterVertices.remove(tensorVertex.getId());
 
         for (Long id : hyperParameterVertices) {
-            assertEquals(tensorPartialDerivatives.withRespectTo(id).scalar(), actualDerivatives.get(id).scalar(), 1e-5);
+            assertEquals(tensorPartialDerivatives.withRespectTo(id).sum(), actualDerivatives.get(id).sum(), 1e-5);
         }
 
         for (int i = 0; i < vector.length; i++) {


### PR DESCRIPTION
This PR fixes a bug with tensor autodiff. It also adds a `onGradientCalculation(...)` and a `onFitnessCalculation(...)` for easy debug of optimizer convergence checking.