### PR TITLE
Added getValue short hand for getValue().getValue(x,y)

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
@@ -85,4 +85,8 @@ public abstract class BoolVertex extends DiscreteVertex<BooleanTensor> {
         return this.dLogPmf(BooleanTensor.create(values));
     }
 
+    public boolean getValue(int... index) {
+        return getValue().getValue(index);
+    }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -224,4 +224,8 @@ public abstract class DoubleVertex extends ContinuousVertex<DoubleTensor> implem
     public Map<Long, DoubleTensor> dLogPdf(double[] values) {
         return this.dLogPdf(DoubleTensor.create(values));
     }
+
+    public double getValue(int... index) {
+        return getValue().getValue(index);
+    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
@@ -148,4 +148,8 @@ public abstract class IntegerVertex extends DiscreteVertex<IntegerTensor> implem
         return this.dLogPmf(IntegerTensor.create(values));
     }
 
+    public int getValue(int... index) {
+        return getValue().getValue(index);
+    }
+
 }


### PR DESCRIPTION
It's a pain to do vertex.getValue().getValue(1,2,3), so this adds a convenience method for this. 