### PR TITLE
Random not required

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/particlefiltering/ParticleFilter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/particlefiltering/ParticleFilter.java
@@ -12,6 +12,14 @@ public class ParticleFilter {
     private ParticleFilter() {
     }
 
+
+    public static List<Particle> getProbableValues(Collection<? extends Vertex> vertices,
+                                                   int numParticles,
+                                                   int resamplingCycles,
+                                                   double resamplingProportion) {
+        return getProbableValues(vertices, numParticles, resamplingCycles, resamplingProportion, KeanuRandom.getDefaultRandom());
+    }
+
     /***
      * A particle filtering approach is used to find probable values for the latent vertices of a Bayesian network,
      * given a set of observed vertices. This is done by incrementally increasing the proportion of the graph under
@@ -35,9 +43,11 @@ public class ParticleFilter {
      * @param random a random number generator
      * @return a list of particles representing the most probable found values of latent variables
      */
-
-    public static List<Particle> getProbableValues(Collection<? extends Vertex> vertices, int numParticles,
-                                                   int resamplingCycles, double resamplingProportion, KeanuRandom random) {
+    public static List<Particle> getProbableValues(Collection<? extends Vertex> vertices,
+                                                   int numParticles,
+                                                   int resamplingCycles,
+                                                   double resamplingProportion,
+                                                   KeanuRandom random) {
 
         Map<Vertex, Set<Vertex>> obsVertIncrDependencies = LatentIncrementSort.sort(vertices);
         List<Vertex> observedVertexOrder = new ArrayList<>(obsVertIncrDependencies.keySet());

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/Prior.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/Prior.java
@@ -18,14 +18,18 @@ public class Prior {
 
     public static NetworkSamples sample(BayesianNetwork bayesNet,
                                         List<? extends Vertex> fromVertices,
+                                        int sampleCount) {
+        return sample(bayesNet, fromVertices, sampleCount, KeanuRandom.getDefaultRandom());
+    }
+
+    public static NetworkSamples sample(BayesianNetwork bayesNet,
+                                        List<? extends Vertex> fromVertices,
                                         int sampleCount,
                                         KeanuRandom random) {
 
         if (!bayesNet.getObservedVertices().isEmpty()) {
             throw new IllegalStateException("Cannot sample prior from graph with observations");
         }
-
-        bayesNet.cascadeObservations();
 
         List<? extends Vertex> topologicallySorted = TopologicalSort.sort(bayesNet.getLatentVertices());
         Map<Long, List> samplesByVertex = new HashMap<>();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
@@ -19,6 +19,13 @@ public class RejectionSampler {
     public static double getPosteriorProbability(List<? extends Vertex> latentVertices,
                                                  List<? extends Vertex> observedVertices,
                                                  Supplier<Boolean> isSuccess,
+                                                 int sampleCount) {
+        return getPosteriorProbability(latentVertices, observedVertices, isSuccess, sampleCount, KeanuRandom.getDefaultRandom());
+    }
+
+    public static double getPosteriorProbability(List<? extends Vertex> latentVertices,
+                                                 List<? extends Vertex> observedVertices,
+                                                 Supplier<Boolean> isSuccess,
                                                  int sampleCount,
                                                  KeanuRandom random) {
         int matchedSampleCount = 0;

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -62,6 +62,11 @@ public class BayesianNetwork {
         VertexValuePropagation.cascadeUpdate(observedVertices);
     }
 
+
+    public void probeForNonZeroMasterP(int attempts) {
+        probeForNonZeroMasterP(attempts, KeanuRandom.getDefaultRandom());
+    }
+
     /**
      * Attempt to find a non-zero master probability
      * by naively sampling vertices in order of data dependency
@@ -103,8 +108,18 @@ public class BayesianNetwork {
         return logOfMasterP == Double.NEGATIVE_INFINITY || logOfMasterP == Double.NaN;
     }
 
+
+    public static void setFromSampleAndCascade(List<? extends Vertex> vertices) {
+        setFromSampleAndCascade(vertices, KeanuRandom.getDefaultRandom());
+    }
+
     public static void setFromSampleAndCascade(List<? extends Vertex> vertices, KeanuRandom random) {
         setFromSampleAndCascade(vertices, VertexValuePropagation.exploreSetting(vertices), random);
+    }
+
+    public static void setFromSampleAndCascade(List<? extends Vertex> vertices,
+                                               Map<Long, Long> setAndCascadeCache) {
+        setFromSampleAndCascade(vertices, setAndCascadeCache, KeanuRandom.getDefaultRandom());
     }
 
     public static void setFromSampleAndCascade(List<? extends Vertex> vertices,

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -52,7 +52,7 @@ public abstract class Vertex<T> {
      */
     public abstract T sample(KeanuRandom random);
 
-    public T sampleUsingDefaultRandom() {
+    public T sample() {
         return sample(KeanuRandom.getDefaultRandom());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBool.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBool.java
@@ -8,7 +8,7 @@ public abstract class ProbabilisticBool extends BoolVertex {
     @Override
     public BooleanTensor updateValue() {
         if (!hasValue()) {
-            setValue(sampleUsingDefaultRandom());
+            setValue(sample());
         }
         return getValue();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -12,7 +12,7 @@ public abstract class ProbabilisticDouble extends DoubleVertex {
     @Override
     public DoubleTensor updateValue() {
         if (!hasValue()) {
-            setValue(sampleUsingDefaultRandom());
+            setValue(sample());
         }
         return getValue();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/Probabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/Probabilistic.java
@@ -1,6 +1,5 @@
 package io.improbable.keanu.vertices.generic.probabilistic;
 
-import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.vertices.Vertex;
 
 public abstract class Probabilistic<T> extends Vertex<T> {
@@ -8,7 +7,7 @@ public abstract class Probabilistic<T> extends Vertex<T> {
     @Override
     public T updateValue() {
         if (!hasValue()) {
-            setValue(sampleUsingDefaultRandom());
+            setValue(sample());
         }
         return getValue();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
@@ -8,7 +8,7 @@ public abstract class ProbabilisticInteger extends IntegerVertex {
     @Override
     public IntegerTensor updateValue() {
         if (!hasValue()) {
-            setValue(sampleUsingDefaultRandom());
+            setValue(sample());
         }
         return getValue();
     }


### PR DESCRIPTION
This PR allows a user to not care about a random number generator and instead use the default one available. IF the user wants to make the run deterministic, they can set the default seed by `KeanuRandom.setDefaultRandomSeed(some_seed_value);`