### PR TITLE
Add testing for numerical equals vertex

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -504,7 +504,8 @@ public class Nd4jDoubleTensor implements DoubleTensor {
 
     @Override
     public DoubleTensor absInPlace() {
-        return duplicate().absInPlace();
+        Transforms.abs(tensor, false);
+        return this;
     }
 
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -321,7 +321,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
 
     @Override
     public DoubleTensor abs() {
-        return new Nd4jDoubleTensor(Transforms.abs(tensor));
+        return duplicate().absInPlace();
     }
 
     @Override

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/NumericalEqualsVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/NumericalEqualsVertexTest.java
@@ -1,0 +1,24 @@
+package io.improbable.keanu.vertices.bool.nonprobabilistic.operators;
+
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.vertices.ConstantVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class NumericalEqualsVertexTest {
+
+    @Test
+    public void canNumbersNotEqual() {
+
+        NumericalEqualsVertex equals = new NumericalEqualsVertex(
+            ConstantVertex.of(new double[]{1, 2, 3}),
+            ConstantVertex.of(new double[]{4, 5, 6}),
+            ConstantVertex.of(new double[]{0, 0, 0})
+        );
+
+        BooleanTensor equality = equals.lazyEval();
+
+        assertArrayEquals(new Boolean[]{false, false, false}, equality.asFlatArray());
+    }
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/NumericalEqualsVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/NumericalEqualsVertexTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertArrayEquals;
 public class NumericalEqualsVertexTest {
 
     @Test
-    public void canNumbersNotEqual() {
+    public void canCompareNumbersNotEqual() {
 
         NumericalEqualsVertex equals = new NumericalEqualsVertex(
             ConstantVertex.of(new double[]{1, 2, 3}),
@@ -20,5 +20,33 @@ public class NumericalEqualsVertexTest {
         BooleanTensor equality = equals.lazyEval();
 
         assertArrayEquals(new Boolean[]{false, false, false}, equality.asFlatArray());
+    }
+
+    @Test
+    public void canCompareNumbersEqual() {
+
+        NumericalEqualsVertex equals = new NumericalEqualsVertex(
+            ConstantVertex.of(new double[]{1, 2, 3}),
+            ConstantVertex.of(new double[]{1, 2, 3}),
+            ConstantVertex.of(new double[]{0, 0, 0})
+        );
+
+        BooleanTensor equality = equals.lazyEval();
+
+        assertArrayEquals(new Boolean[]{true, true, true}, equality.asFlatArray());
+    }
+
+    @Test
+    public void canCompareNumbersAlmostEqual() {
+
+        NumericalEqualsVertex equals = new NumericalEqualsVertex(
+            ConstantVertex.of(new double[]{1, 2, 3}),
+            ConstantVertex.of(new double[]{1.5, 2.01, 3}),
+            ConstantVertex.of(new double[]{0.1, 0.1, 0.1})
+        );
+
+        BooleanTensor equality = equals.lazyEval();
+
+        assertArrayEquals(new Boolean[]{false, true, true}, equality.asFlatArray());
     }
 }


### PR DESCRIPTION
This PR cleans up some tech debt. Some basic tests are added and a bug fix with DoubleTensor.absInPlace().