### PR TITLE
Added git-version plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,15 @@
 
+plugins {
+    id 'com.palantir.git-version' version '0.11.0'
+}
+
 repositories {
     mavenLocal()
     mavenCentral()
+}
+
+allprojects {
+    version gitVersion()
 }
 
 dependencies {

--- a/keanu-docs/code/build.gradle
+++ b/keanu-docs/code/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 group = 'improbable'
-version = '0.0.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/keanu-examples/coalMiningDisasters/build.gradle
+++ b/keanu-examples/coalMiningDisasters/build.gradle
@@ -5,7 +5,6 @@ plugins {
 mainClassName = "com.example.coal.Model"
 
 group = 'improbable'
-version = '0.0.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/keanu-examples/starter/build.gradle
+++ b/keanu-examples/starter/build.gradle
@@ -6,7 +6,6 @@ plugins {
 mainClassName = "com.example.starter.Model"
 
 group = 'improbable'
-version = '0.0.1'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/keanu-project/build.gradle
+++ b/keanu-project/build.gradle
@@ -14,7 +14,6 @@ plugins {
 }
 
 group = 'io.improbable'
-version = '0.0.8'
 archivesBaseName = "keanu"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
https://github.com/palantir/gradle-git-version

Now when you do a `./gradlew build` it creates artifacts with names like `keanu-c06889c.jar`

It should create names like `keanu-v0.0.10-1-gc06889c.jar` - the reason it isn't (at least on this feature branch) is to do with the `--first-parent` option in [`git describe`](https://git-scm.com/docs/git-describe): "Follow only the first parent commit upon seeing a merge commit". Perhaps the behaviour will be different on the develop and/or master branches.

    