### PR TITLE
Correct number of interpolation points for Non Gradient Optimizer

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/FitnessFunction.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/FitnessFunction.java
@@ -59,6 +59,10 @@ public class FitnessFunction {
         VertexValuePropagation.cascadeUpdate(latentVertices);
     }
 
+    public long numLatentDimensions() {
+        return latentVertices.stream().mapToLong(FitnessFunction::numDimensions).sum();
+    }
+
     static long numDimensions(Vertex<DoubleTensor> vertex) {
         return vertex.getValue().getLength();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GradientOptimizer.java
@@ -18,14 +18,12 @@ import java.util.function.BiConsumer;
 
 import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
 
-public class GradientOptimizer {
+public class GradientOptimizer extends Optimizer {
 
     public static final NonLinearConjugateGradientOptimizer DEFAULT_OPTIMIZER = new NonLinearConjugateGradientOptimizer(
         NonLinearConjugateGradientOptimizer.Formula.POLAK_RIBIERE,
         new SimpleValueChecker(1e-8, 1e-8)
     );
-
-    private static final double FLAT_GRADIENT = 1e-16;
 
     private final BayesianNetwork bayesNet;
 
@@ -149,35 +147,5 @@ public class GradientOptimizer {
         );
 
         return pointValuePair.getValue();
-    }
-
-    static double[] currentPoint(List<Vertex<DoubleTensor>> continuousVertices) {
-
-        long totalLatentDimensions = 0;
-        for (Vertex<DoubleTensor> vertex : continuousVertices) {
-            totalLatentDimensions += FitnessFunction.numDimensions(vertex);
-        }
-
-        if (totalLatentDimensions > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException("Greater than " + Integer.MAX_VALUE + " latent dimensions not supported");
-        }
-
-        int position = 0;
-        double[] point = new double[(int) totalLatentDimensions];
-
-        for (Vertex<DoubleTensor> vertex : continuousVertices) {
-            double[] values = vertex.getValue().asFlatDoubleArray();
-            System.arraycopy(values, 0, point, position, values.length);
-            position += values.length;
-        }
-
-        return point;
-    }
-
-    private void warnIfGradientIsFlat(double[] gradient) {
-        double maxGradient = Arrays.stream(gradient).max().getAsDouble();
-        if (Math.abs(maxGradient) <= FLAT_GRADIENT) {
-            throw new IllegalStateException("The initial gradient is very flat. The largest gradient is " + maxGradient);
-        }
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/NonGradientOptimizer.java
@@ -14,10 +14,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import static io.improbable.keanu.algorithms.variational.GradientOptimizer.currentPoint;
 import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
 
-public class NonGradientOptimizer {
+public class NonGradientOptimizer extends Optimizer {
 
     private final BayesianNetwork bayesNet;
     private final List<BiConsumer<double[], Double>> onFitnessCalculations;
@@ -56,7 +55,7 @@ public class NonGradientOptimizer {
             this::handleFitnessCalculation
         );
 
-        BOBYQAOptimizer optimizer = new BOBYQAOptimizer(2 * latentVertices.size() + 1);
+        BOBYQAOptimizer optimizer = new BOBYQAOptimizer(getNumInterpolationPoints(latentVertices));
 
         double[] startPoint = currentPoint(bayesNet.getContinuousLatentVertices());
         double initialFitness = fitnessFunction.fitness().value(startPoint);
@@ -82,6 +81,10 @@ public class NonGradientOptimizer {
         );
 
         return pointValuePair.getValue();
+    }
+
+    private int getNumInterpolationPoints(List<? extends Vertex<DoubleTensor>> latentVertices){
+        return (int)(2 * totalNumLatentDimensions(latentVertices) + 1);
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/Optimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/Optimizer.java
@@ -1,0 +1,42 @@
+package io.improbable.keanu.algorithms.variational;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class Optimizer {
+
+    private static final double FLAT_GRADIENT = 1e-16;
+
+    static double[] currentPoint(List<Vertex<DoubleTensor>> continuousLatentVertices) {
+        long totalLatentDimensions = totalNumLatentDimensions(continuousLatentVertices);
+
+        if (totalLatentDimensions > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Greater than " + Integer.MAX_VALUE + " latent dimensions not supported");
+        }
+
+        int position = 0;
+        double[] point = new double[(int) totalLatentDimensions];
+
+        for (Vertex<DoubleTensor> vertex : continuousLatentVertices) {
+            double[] values = vertex.getValue().asFlatDoubleArray();
+            System.arraycopy(values, 0, point, position, values.length);
+            position += values.length;
+        }
+
+        return point;
+    }
+
+    static long totalNumLatentDimensions(List<? extends Vertex<DoubleTensor>> continuousLatentVertices) {
+        return continuousLatentVertices.stream().mapToLong(FitnessFunction::numDimensions).sum();
+    }
+
+    static void warnIfGradientIsFlat(double[] gradient) {
+        double maxGradient = Arrays.stream(gradient).max().getAsDouble();
+        if (Math.abs(maxGradient) <= FLAT_GRADIENT) {
+            throw new IllegalStateException("The initial gradient is very flat. The largest gradient is " + maxGradient);
+        }
+    }
+}


### PR DESCRIPTION
Previously the number of interpolation points for the BOBYQA algorithm was calculated using the number of latent vertices, which didn't take into account tensors.

Now the number of interpolation points is calculated based on the total number of latent dimensions, taking tensor vertices into account.

ALSO: refactored some optimizer functions into a shared abstract class