### PR TITLE
Linear regression with Matrix Multiply

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/FitnessFunctionWithGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/FitnessFunctionWithGradient.java
@@ -74,27 +74,13 @@ public class FitnessFunctionWithGradient {
         for (Vertex<DoubleTensor> vertex : latentVertices) {
             DoubleTensor tensor = diffs.get(vertex.getId());
             if (tensor != null) {
-                tensors.add(alignGradientToLatent(vertex, tensor));
+                tensors.add(tensor);
             } else {
                 tensors.add(DoubleTensor.zeros(vertex.getShape()));
             }
         }
 
         return flattenAll(tensors);
-    }
-
-    /**
-     * @param latentVertex wrt vertex
-     * @param gradients    gradient wrt latentVertex
-     * @return the gradient with the appropriate shape given the latent vertex
-     */
-    private static DoubleTensor alignGradientToLatent(Vertex<DoubleTensor> latentVertex,
-                                                      DoubleTensor gradients) {
-        if (TensorShape.isScalar(latentVertex.getShape()) && !TensorShape.isScalar(gradients.getShape())) {
-            return DoubleTensor.scalar(gradients.sum());
-        } else {
-            return gradients;
-        }
     }
 
     private static double[] flattenAll(List<DoubleTensor> tensors) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -4,9 +4,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.special.Gamma;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
-
 public class Beta {
 
     public static DoubleTensor sample(int[] shape,

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -52,10 +52,6 @@ public class Beta {
         DoubleTensor dLogPda = x.log().plusInPlace(digammaAlphaPlusBeta.minus(alpha.apply(Gamma::digamma)));
         DoubleTensor dLogPdb = oneMinusX.logInPlace().plusInPlace(digammaAlphaPlusBeta.minusInPlace(beta.apply(Gamma::digamma)));
 
-        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
-        dLogPda = dLogPda.reshape(concat(SCALAR_SHAPE, dLogPda.getShape()));
-        dLogPdb = dLogPdb.reshape(concat(SCALAR_SHAPE, dLogPdb.getShape()));
-
         return new DiffLogP(dLogPda, dLogPdb, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -48,9 +48,9 @@ public class Beta {
         final DoubleTensor digammaAlphaPlusBeta = alpha.plus(beta).applyInPlace(Gamma::digamma);
         final DoubleTensor alphaMinusOneDivX = x.reciprocal().timesInPlace(alpha.minus(1));
 
-        DoubleTensor dLogPdx = alphaMinusOneDivX.minusInPlace(oneMinusX.reciprocal().timesInPlace(beta.minus(1)));
-        DoubleTensor dLogPda = x.log().plusInPlace(digammaAlphaPlusBeta.minus(alpha.apply(Gamma::digamma)));
-        DoubleTensor dLogPdb = oneMinusX.logInPlace().plusInPlace(digammaAlphaPlusBeta.minusInPlace(beta.apply(Gamma::digamma)));
+        final DoubleTensor dLogPdx = alphaMinusOneDivX.minusInPlace(oneMinusX.reciprocal().timesInPlace(beta.minus(1)));
+        final DoubleTensor dLogPda = x.log().plusInPlace(digammaAlphaPlusBeta.minus(alpha.apply(Gamma::digamma)));
+        final DoubleTensor dLogPdb = oneMinusX.logInPlace().plusInPlace(digammaAlphaPlusBeta.minusInPlace(beta.apply(Gamma::digamma)));
 
         return new DiffLogP(dLogPda, dLogPdb, dLogPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -3,9 +3,6 @@ package io.improbable.keanu.distributions.continuous;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
-
 public class Exponential {
 
     private Exponential() {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -3,6 +3,9 @@ package io.improbable.keanu.distributions.continuous;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
+
 public class Exponential {
 
     private Exponential() {
@@ -18,21 +21,27 @@ public class Exponential {
         return negXMinusADivBMinusLogB.setWithMask(x.getLessThanMask(location), Double.NEGATIVE_INFINITY);
     }
 
-    public static Diff dlnPdf(DoubleTensor location, DoubleTensor lambda, DoubleTensor x) {
-        final DoubleTensor dPda = lambda.reciprocal();
-        final DoubleTensor dPdb = x.minus(location).minusInPlace(lambda).divInPlace(lambda.pow(2));
-        return new Diff(dPda, dPdb, dPda.unaryMinus());
+    public static DiffLogP dlnPdf(DoubleTensor location, DoubleTensor lambda, DoubleTensor x) {
+        DoubleTensor dLogPdlocation = lambda.reciprocal();
+        DoubleTensor dLogPdlambda = x.minus(location).minusInPlace(lambda).divInPlace(lambda.pow(2));
+        DoubleTensor dLogPdx = dLogPdlocation.unaryMinus();
+
+        dLogPdlocation = dLogPdlocation.reshape(concat(SCALAR_SHAPE, dLogPdlocation.getShape()));
+        dLogPdlambda = dLogPdlambda.reshape(concat(SCALAR_SHAPE, dLogPdlambda.getShape()));
+        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
+
+        return new DiffLogP(dLogPdlocation, dLogPdlambda, dLogPdx);
     }
 
-    public static class Diff {
-        public final DoubleTensor dPdlocation;
-        public final DoubleTensor dPdlambda;
-        public final DoubleTensor dPdx;
+    public static class DiffLogP {
+        public final DoubleTensor dLogPdlocation;
+        public final DoubleTensor dLogPdlambda;
+        public final DoubleTensor dLogPdx;
 
-        public Diff(DoubleTensor dPda, DoubleTensor dPdb, DoubleTensor dPdx) {
-            this.dPdlocation = dPda;
-            this.dPdlambda = dPdb;
-            this.dPdx = dPdx;
+        public DiffLogP(DoubleTensor dLogPdlocation, DoubleTensor dLogPdlambda, DoubleTensor dLogPdx) {
+            this.dLogPdlocation = dLogPdlocation;
+            this.dLogPdlambda = dLogPdlambda;
+            this.dLogPdx = dLogPdx;
         }
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -22,9 +22,9 @@ public class Exponential {
     }
 
     public static DiffLogP dlnPdf(DoubleTensor location, DoubleTensor lambda, DoubleTensor x) {
-        DoubleTensor dLogPdlocation = lambda.reciprocal();
-        DoubleTensor dLogPdlambda = x.minus(location).minusInPlace(lambda).divInPlace(lambda.pow(2));
-        DoubleTensor dLogPdx = dLogPdlocation.unaryMinus();
+        final DoubleTensor dLogPdlocation = lambda.reciprocal();
+        final DoubleTensor dLogPdlambda = x.minus(location).minusInPlace(lambda).divInPlace(lambda.pow(2));
+        final DoubleTensor dLogPdx = dLogPdlocation.unaryMinus();
 
         return new DiffLogP(dLogPdlocation, dLogPdlambda, dLogPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -26,10 +26,6 @@ public class Exponential {
         DoubleTensor dLogPdlambda = x.minus(location).minusInPlace(lambda).divInPlace(lambda.pow(2));
         DoubleTensor dLogPdx = dLogPdlocation.unaryMinus();
 
-        dLogPdlocation = dLogPdlocation.reshape(concat(SCALAR_SHAPE, dLogPdlocation.getShape()));
-        dLogPdlambda = dLogPdlambda.reshape(concat(SCALAR_SHAPE, dLogPdlambda.getShape()));
-        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
-
         return new DiffLogP(dLogPdlocation, dLogPdlambda, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -106,10 +106,10 @@ public class Gamma {
         final DoubleTensor kMinus1 = k.minus(1.);
         final DoubleTensor oneOverTheta = theta.reciprocal();
 
-        DoubleTensor dLogPdx = kMinus1.div(xMinusLocation).minusInPlace(oneOverTheta);
-        DoubleTensor dLogPdlocation = kMinus1.div(locationMinusX).plusInPlace(oneOverTheta);
-        DoubleTensor dLogPdtheta = theta.times(k).plus(locationMinusX).divInPlace(theta.pow(2.)).unaryMinusInPlace();
-        DoubleTensor dLogPdk = xMinusLocation.logInPlace().minusInPlace(theta.log()).minusInPlace(k.apply(org.apache.commons.math3.special.Gamma::digamma));
+        final DoubleTensor dLogPdx = kMinus1.div(xMinusLocation).minusInPlace(oneOverTheta);
+        final DoubleTensor dLogPdlocation = kMinus1.div(locationMinusX).plusInPlace(oneOverTheta);
+        final DoubleTensor dLogPdtheta = theta.times(k).plus(locationMinusX).divInPlace(theta.pow(2.)).unaryMinusInPlace();
+        final DoubleTensor dLogPdk = xMinusLocation.logInPlace().minusInPlace(theta.log()).minusInPlace(k.apply(org.apache.commons.math3.special.Gamma::digamma));
 
         return new DiffLogP(dLogPdlocation, dLogPdtheta, dLogPdk, dLogPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -111,11 +111,6 @@ public class Gamma {
         DoubleTensor dLogPdtheta = theta.times(k).plus(locationMinusX).divInPlace(theta.pow(2.)).unaryMinusInPlace();
         DoubleTensor dLogPdk = xMinusLocation.logInPlace().minusInPlace(theta.log()).minusInPlace(k.apply(org.apache.commons.math3.special.Gamma::digamma));
 
-        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
-        dLogPdlocation = dLogPdlocation.reshape(concat(SCALAR_SHAPE, dLogPdlocation.getShape()));
-        dLogPdtheta = dLogPdtheta.reshape(concat(SCALAR_SHAPE, dLogPdtheta.getShape()));
-        dLogPdk = dLogPdk.reshape(concat(SCALAR_SHAPE, dLogPdk.getShape()));
-
         return new DiffLogP(dLogPdlocation, dLogPdtheta, dLogPdk, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -5,8 +5,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.nd4j.linalg.util.ArrayUtil;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
 import static java.lang.Math.*;
 
 public class Gamma {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -30,9 +30,9 @@ public class Gaussian {
         final DoubleTensor variance = sigma.pow(2);
         final DoubleTensor xMinusMu = x.minus(mu);
 
-        DoubleTensor dLogPdmu = xMinusMu.div(variance);
-        DoubleTensor dLogPdx = dLogPdmu.unaryMinus();
-        DoubleTensor dLogPdsigma = xMinusMu.powInPlace(2)
+        final DoubleTensor dLogPdmu = xMinusMu.div(variance);
+        final DoubleTensor dLogPdx = dLogPdmu.unaryMinus();
+        final DoubleTensor dLogPdsigma = xMinusMu.powInPlace(2)
             .divInPlace(variance.timesInPlace(sigma))
             .minusInPlace(sigma.reciprocal());
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -36,10 +36,6 @@ public class Gaussian {
             .divInPlace(variance.timesInPlace(sigma))
             .minusInPlace(sigma.reciprocal());
 
-        dLogPdmu = dLogPdmu.reshape(concat(SCALAR_SHAPE, dLogPdmu.getShape()));
-        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
-        dLogPdsigma = dLogPdsigma.reshape(concat(SCALAR_SHAPE, dLogPdsigma.getShape()));
-
         return new DiffLogP(dLogPdmu, dLogPdsigma, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -3,6 +3,9 @@ package io.improbable.keanu.distributions.continuous;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
+
 public class Gaussian {
 
     public static final double SQRT_2PI = Math.sqrt(Math.PI * 2);
@@ -23,28 +26,33 @@ public class Gaussian {
         return xMinusMuSquaredOver2Variance.plusInPlace(lnSigma).plusInPlace(LN_SQRT_2PI).unaryMinusInPlace();
     }
 
-    public static Diff dlnPdf(DoubleTensor mu, DoubleTensor sigma, DoubleTensor x) {
+    public static DiffLogP dlnPdf(DoubleTensor mu, DoubleTensor sigma, DoubleTensor x) {
         final DoubleTensor variance = sigma.pow(2);
         final DoubleTensor xMinusMu = x.minus(mu);
 
-        final DoubleTensor dlnP_dmu = xMinusMu.div(variance);
-        final DoubleTensor dlnP_dx = dlnP_dmu.unaryMinus();
-        final DoubleTensor dlnP_dsigma = xMinusMu.powInPlace(2)
+        DoubleTensor dLogPdmu = xMinusMu.div(variance);
+        DoubleTensor dLogPdx = dLogPdmu.unaryMinus();
+        DoubleTensor dLogPdsigma = xMinusMu.powInPlace(2)
             .divInPlace(variance.timesInPlace(sigma))
             .minusInPlace(sigma.reciprocal());
 
-        return new Diff(dlnP_dmu, dlnP_dsigma, dlnP_dx);
+        dLogPdmu = dLogPdmu.reshape(concat(SCALAR_SHAPE, dLogPdmu.getShape()));
+        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
+        dLogPdsigma = dLogPdsigma.reshape(concat(SCALAR_SHAPE, dLogPdsigma.getShape()));
+
+        return new DiffLogP(dLogPdmu, dLogPdsigma, dLogPdx);
     }
 
-    public static class Diff {
-        public final DoubleTensor dPdmu;
-        public final DoubleTensor dPdsigma;
-        public final DoubleTensor dPdx;
+    public static class DiffLogP {
+        public final DoubleTensor dLogPdmu;
+        public final DoubleTensor dLogPdsigma;
+        public final DoubleTensor dLogPdx;
 
-        public Diff(DoubleTensor dPdmu, DoubleTensor dPdsigma, DoubleTensor dPdx) {
-            this.dPdmu = dPdmu;
-            this.dPdsigma = dPdsigma;
-            this.dPdx = dPdx;
+        public DiffLogP(DoubleTensor dLogPdmu, DoubleTensor dLogPdsigma, DoubleTensor dLogPdx) {
+            this.dLogPdmu = dLogPdmu;
+            this.dLogPdsigma = dLogPdsigma;
+            this.dLogPdx = dLogPdx;
         }
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -3,9 +3,6 @@ package io.improbable.keanu.distributions.continuous;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
-
 public class Gaussian {
 
     public static final double SQRT_2PI = Math.sqrt(Math.PI * 2);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -26,9 +26,9 @@ public class InverseGamma {
     }
 
     public static DiffLogP dlnPdf(DoubleTensor alpha, DoubleTensor beta, DoubleTensor x) {
-        DoubleTensor dLogPdalpha = x.log().unaryMinusInPlace().minusInPlace(alpha.apply(Gamma::digamma)).plusInPlace(beta.log());
-        DoubleTensor dLogPdbeta = x.reciprocal().unaryMinusInPlace().plusInPlace(alpha.div(beta));
-        DoubleTensor dLogPdx = x.pow(2).reciprocalInPlace().timesInPlace(x.times(alpha.plus(1).unaryMinusInPlace()).plusInPlace(beta));
+        final DoubleTensor dLogPdalpha = x.log().unaryMinusInPlace().minusInPlace(alpha.apply(Gamma::digamma)).plusInPlace(beta.log());
+        final DoubleTensor dLogPdbeta = x.reciprocal().unaryMinusInPlace().plusInPlace(alpha.div(beta));
+        final DoubleTensor dLogPdx = x.pow(2).reciprocalInPlace().timesInPlace(x.times(alpha.plus(1).unaryMinusInPlace()).plusInPlace(beta));
 
         return new DiffLogP(dLogPdalpha, dLogPdbeta, dLogPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -4,9 +4,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.special.Gamma;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
-
 public class InverseGamma {
 
     private InverseGamma() {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -30,10 +30,6 @@ public class InverseGamma {
         DoubleTensor dLogPdbeta = x.reciprocal().unaryMinusInPlace().plusInPlace(alpha.div(beta));
         DoubleTensor dLogPdx = x.pow(2).reciprocalInPlace().timesInPlace(x.times(alpha.plus(1).unaryMinusInPlace()).plusInPlace(beta));
 
-        dLogPdalpha = dLogPdalpha.reshape(concat(SCALAR_SHAPE, dLogPdalpha.getShape()));
-        dLogPdbeta = dLogPdbeta.reshape(concat(SCALAR_SHAPE, dLogPdbeta.getShape()));
-        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
-
         return new DiffLogP(dLogPdalpha, dLogPdbeta, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -56,9 +56,9 @@ public class Laplace {
 
         final DoubleTensor denominator = muMinusXAbs.times(beta);
 
-        DoubleTensor dLogPdx = muMinusX.divInPlace(denominator);
-        DoubleTensor dLogPdMu = x.minus(mu).divInPlace(denominator);
-        DoubleTensor dLogPdBeta = muMinusXAbs.minusInPlace(beta).divInPlace(beta.pow(2));
+        final DoubleTensor dLogPdx = muMinusX.divInPlace(denominator);
+        final DoubleTensor dLogPdMu = x.minus(mu).divInPlace(denominator);
+        final DoubleTensor dLogPdBeta = muMinusXAbs.minusInPlace(beta).divInPlace(beta.pow(2));
 
         return new DiffLogP(dLogPdMu, dLogPdBeta, dLogPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -5,6 +5,9 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.nd4j.linalg.util.ArrayUtil;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
+
 public class Laplace {
 
     private Laplace() {
@@ -47,28 +50,32 @@ public class Laplace {
         return muMinusXAbsNegDivBeta.plusInPlace(logTwoBeta).unaryMinus();
     }
 
-    public static Diff dlnPdf(DoubleTensor mu, DoubleTensor beta, DoubleTensor x) {
+    public static DiffLogP dlnPdf(DoubleTensor mu, DoubleTensor beta, DoubleTensor x) {
         final DoubleTensor muMinusX = mu.minus(x);
         final DoubleTensor muMinusXAbs = muMinusX.abs();
 
         final DoubleTensor denominator = muMinusXAbs.times(beta);
 
-        final DoubleTensor dPdx = muMinusX.divInPlace(denominator);
-        final DoubleTensor dPdMu = x.minus(mu).divInPlace(denominator);
-        final DoubleTensor dPdBeta = muMinusXAbs.minusInPlace(beta).divInPlace(beta.pow(2));
+        DoubleTensor dLogPdx = muMinusX.divInPlace(denominator);
+        DoubleTensor dLogPdMu = x.minus(mu).divInPlace(denominator);
+        DoubleTensor dLogPdBeta = muMinusXAbs.minusInPlace(beta).divInPlace(beta.pow(2));
 
-        return new Diff(dPdMu, dPdBeta, dPdx);
+        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
+        dLogPdMu = dLogPdMu.reshape(concat(SCALAR_SHAPE, dLogPdMu.getShape()));
+        dLogPdBeta = dLogPdBeta.reshape(concat(SCALAR_SHAPE, dLogPdBeta.getShape()));
+
+        return new DiffLogP(dLogPdMu, dLogPdBeta, dLogPdx);
     }
 
-    public static class Diff {
-        public final DoubleTensor dPdmu;
-        public final DoubleTensor dPdbeta;
-        public final DoubleTensor dPdx;
+    public static class DiffLogP {
+        public final DoubleTensor dLogPdmu;
+        public final DoubleTensor dLogPdbeta;
+        public final DoubleTensor dLogPdx;
 
-        public Diff(DoubleTensor dPdmu, DoubleTensor dPdbeta, DoubleTensor dPdx) {
-            this.dPdmu = dPdmu;
-            this.dPdbeta = dPdbeta;
-            this.dPdx = dPdx;
+        public DiffLogP(DoubleTensor dLogPdmu, DoubleTensor dLogPdbeta, DoubleTensor dLogPdx) {
+            this.dLogPdmu = dLogPdmu;
+            this.dLogPdbeta = dLogPdbeta;
+            this.dLogPdx = dLogPdx;
         }
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -60,10 +60,6 @@ public class Laplace {
         DoubleTensor dLogPdMu = x.minus(mu).divInPlace(denominator);
         DoubleTensor dLogPdBeta = muMinusXAbs.minusInPlace(beta).divInPlace(beta.pow(2));
 
-        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
-        dLogPdMu = dLogPdMu.reshape(concat(SCALAR_SHAPE, dLogPdMu.getShape()));
-        dLogPdBeta = dLogPdBeta.reshape(concat(SCALAR_SHAPE, dLogPdBeta.getShape()));
-
         return new DiffLogP(dLogPdMu, dLogPdBeta, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -5,9 +5,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.nd4j.linalg.util.ArrayUtil;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
-
 public class Laplace {
 
     private Laplace() {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
@@ -40,9 +40,9 @@ public class LogNormal {
         final DoubleTensor variance = sigma.pow(2);
         final DoubleTensor lnXMinusMu = x.log().minusInPlace(mu);
 
-        DoubleTensor dLogPdmu = lnXMinusMu.div(variance);
-        DoubleTensor dlogPdx = dLogPdmu.plus(1.0).unaryMinus().divInPlace(x);
-        DoubleTensor dlogPdsigma = lnXMinusMu.powInPlace(2)
+        final DoubleTensor dLogPdmu = lnXMinusMu.div(variance);
+        final DoubleTensor dlogPdx = dLogPdmu.plus(1.0).unaryMinus().divInPlace(x);
+        final DoubleTensor dlogPdsigma = lnXMinusMu.powInPlace(2)
             .divInPlace(variance.timesInPlace(sigma))
             .minusInPlace(sigma.reciprocal());
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
@@ -4,6 +4,8 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 import static io.improbable.keanu.distributions.continuous.Gaussian.LN_SQRT_2PI;
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 
 public class LogNormal {
 
@@ -34,28 +36,32 @@ public class LogNormal {
         return lnXMinusMuSquaredOver2Variance.plusInPlace(lnSigmaX).plusInPlace(LN_SQRT_2PI).unaryMinusInPlace();
     }
 
-    public static LogNormal.Diff dlnPdf(DoubleTensor mu, DoubleTensor sigma, DoubleTensor x) {
+    public static DiffLogP dlnPdf(DoubleTensor mu, DoubleTensor sigma, DoubleTensor x) {
         final DoubleTensor variance = sigma.pow(2);
         final DoubleTensor lnXMinusMu = x.log().minusInPlace(mu);
 
-        final DoubleTensor dlnP_dmu = lnXMinusMu.div(variance);
-        final DoubleTensor dlnP_dx = dlnP_dmu.plus(1.0).unaryMinus().divInPlace(x);
-        final DoubleTensor dlnP_dsigma = lnXMinusMu.powInPlace(2)
+        DoubleTensor dLogPdmu = lnXMinusMu.div(variance);
+        DoubleTensor dlogPdx = dLogPdmu.plus(1.0).unaryMinus().divInPlace(x);
+        DoubleTensor dlogPdsigma = lnXMinusMu.powInPlace(2)
             .divInPlace(variance.timesInPlace(sigma))
             .minusInPlace(sigma.reciprocal());
 
-        return new LogNormal.Diff(dlnP_dmu, dlnP_dsigma, dlnP_dx);
+        dLogPdmu = dLogPdmu.reshape(concat(SCALAR_SHAPE, dLogPdmu.getShape()));
+        dlogPdsigma = dlogPdsigma.reshape(concat(SCALAR_SHAPE, dlogPdsigma.getShape()));
+        dlogPdx = dlogPdx.reshape(concat(SCALAR_SHAPE, dlogPdx.getShape()));
+
+        return new DiffLogP(dLogPdmu, dlogPdsigma, dlogPdx);
     }
 
-    public static class Diff {
-        public final DoubleTensor dPdmu;
-        public final DoubleTensor dPdsigma;
-        public final DoubleTensor dPdx;
+    public static class DiffLogP {
+        public final DoubleTensor dLogPdmu;
+        public final DoubleTensor dLogPdsigma;
+        public final DoubleTensor dLogPdx;
 
-        public Diff(DoubleTensor dPdmu, DoubleTensor dPdsigma, DoubleTensor dPdx) {
-            this.dPdmu = dPdmu;
-            this.dPdsigma = dPdsigma;
-            this.dPdx = dPdx;
+        public DiffLogP(DoubleTensor dLogPdmu, DoubleTensor dLogPdsigma, DoubleTensor dLogPdx) {
+            this.dLogPdmu = dLogPdmu;
+            this.dLogPdsigma = dLogPdsigma;
+            this.dLogPdx = dLogPdx;
         }
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
@@ -46,10 +46,6 @@ public class LogNormal {
             .divInPlace(variance.timesInPlace(sigma))
             .minusInPlace(sigma.reciprocal());
 
-        dLogPdmu = dLogPdmu.reshape(concat(SCALAR_SHAPE, dLogPdmu.getShape()));
-        dlogPdsigma = dlogPdsigma.reshape(concat(SCALAR_SHAPE, dlogPdsigma.getShape()));
-        dlogPdx = dlogPdx.reshape(concat(SCALAR_SHAPE, dlogPdx.getShape()));
-
         return new DiffLogP(dLogPdmu, dlogPdsigma, dlogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
@@ -4,8 +4,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 import static io.improbable.keanu.distributions.continuous.Gaussian.LN_SQRT_2PI;
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
 
 public class LogNormal {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -3,6 +3,9 @@ package io.improbable.keanu.distributions.continuous;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
+
 public class Logistic {
 
     /**
@@ -31,15 +34,15 @@ public class Logistic {
         );
     }
 
-    public static Diff dlnPdf(DoubleTensor mu, DoubleTensor s, DoubleTensor x) {
+    public static DiffLogP dlnPdf(DoubleTensor mu, DoubleTensor s, DoubleTensor x) {
         final DoubleTensor expAOverB = mu.div(s).expInPlace();
         final DoubleTensor expXOverB = x.div(s).expInPlace();
         final DoubleTensor expPlus = expAOverB.plus(expXOverB);
         final DoubleTensor bTimesExpAOverB = expAOverB.times(s);
         final DoubleTensor bTimesExpXOverB = expXOverB.times(s);
 
-        final DoubleTensor dPda = expXOverB.minus(expAOverB).divInPlace(s.times(expPlus));
-        final DoubleTensor dPdx = expAOverB.minus(expXOverB).divInPlace(bTimesExpAOverB.plus(bTimesExpXOverB));
+        DoubleTensor dLogPdmu = expXOverB.minus(expAOverB).divInPlace(s.times(expPlus));
+        DoubleTensor dLogPdx = expAOverB.minus(expXOverB).divInPlace(bTimesExpAOverB.plus(bTimesExpXOverB));
 
         final DoubleTensor numeratorPartOne = mu.times(expXOverB).plusInPlace(x.times(expAOverB)).plusInPlace(
             mu.times(expAOverB.unaryMinus())
@@ -47,20 +50,24 @@ public class Logistic {
         final DoubleTensor numeratorPartTwo = bTimesExpAOverB.plus(bTimesExpXOverB).minusInPlace(x.times(expXOverB));
         final DoubleTensor denominator = s.pow(2).timesInPlace(expPlus);
 
-        final DoubleTensor dPdb = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
+        DoubleTensor dLogPds = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
 
-        return new Diff(dPda, dPdb, dPdx);
+        dLogPdmu = dLogPdmu.reshape(concat(SCALAR_SHAPE, dLogPdmu.getShape()));
+        dLogPds = dLogPds.reshape(concat(SCALAR_SHAPE, dLogPds.getShape()));
+        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
+
+        return new DiffLogP(dLogPdmu, dLogPds, dLogPdx);
     }
 
-    public static class Diff {
-        public final DoubleTensor dPdmu;
-        public final DoubleTensor dPds;
-        public final DoubleTensor dPdx;
+    public static class DiffLogP {
+        public final DoubleTensor dLogPdmu;
+        public final DoubleTensor dLogPds;
+        public final DoubleTensor dLogPdx;
 
-        public Diff(DoubleTensor dPdmu, DoubleTensor dPds, DoubleTensor dPdx) {
-            this.dPdmu = dPdmu;
-            this.dPds = dPds;
-            this.dPdx = dPdx;
+        public DiffLogP(DoubleTensor dLogPdmu, DoubleTensor dLogPds, DoubleTensor dLogPdx) {
+            this.dLogPdmu = dLogPdmu;
+            this.dLogPds = dLogPds;
+            this.dLogPdx = dLogPdx;
         }
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -41,8 +41,8 @@ public class Logistic {
         final DoubleTensor bTimesExpAOverB = expAOverB.times(s);
         final DoubleTensor bTimesExpXOverB = expXOverB.times(s);
 
-        DoubleTensor dLogPdmu = expXOverB.minus(expAOverB).divInPlace(s.times(expPlus));
-        DoubleTensor dLogPdx = expAOverB.minus(expXOverB).divInPlace(bTimesExpAOverB.plus(bTimesExpXOverB));
+        final DoubleTensor dLogPdmu = expXOverB.minus(expAOverB).divInPlace(s.times(expPlus));
+        final DoubleTensor dLogPdx = expAOverB.minus(expXOverB).divInPlace(bTimesExpAOverB.plus(bTimesExpXOverB));
 
         final DoubleTensor numeratorPartOne = mu.times(expXOverB).plusInPlace(x.times(expAOverB)).plusInPlace(
             mu.times(expAOverB.unaryMinus())
@@ -50,7 +50,7 @@ public class Logistic {
         final DoubleTensor numeratorPartTwo = bTimesExpAOverB.plus(bTimesExpXOverB).minusInPlace(x.times(expXOverB));
         final DoubleTensor denominator = s.pow(2).timesInPlace(expPlus);
 
-        DoubleTensor dLogPds = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
+        final DoubleTensor dLogPds = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
 
         return new DiffLogP(dLogPdmu, dLogPds, dLogPdx);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -3,9 +3,6 @@ package io.improbable.keanu.distributions.continuous;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
-
 public class Logistic {
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -52,10 +52,6 @@ public class Logistic {
 
         DoubleTensor dLogPds = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
 
-        dLogPdmu = dLogPdmu.reshape(concat(SCALAR_SHAPE, dLogPdmu.getShape()));
-        dLogPds = dLogPds.reshape(concat(SCALAR_SHAPE, dLogPds.getShape()));
-        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
-
         return new DiffLogP(dLogPdmu, dLogPds, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -3,9 +3,6 @@ package io.improbable.keanu.distributions.continuous;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
-
 /**
  * The Smooth Uniform distribution is the usual Uniform distribution with the edges
  * at max and min smoothed by attaching a sigmoid as shoulders.

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -3,6 +3,9 @@ package io.improbable.keanu.distributions.continuous;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
+
 /**
  * The Smooth Uniform distribution is the usual Uniform distribution with the edges
  * at max and min smoothed by attaching a sigmoid as shoulders.
@@ -114,7 +117,7 @@ public class SmoothUniform {
             .plusInPlace(thirdConditional.timesInPlace(thirdConditionalResult));
     }
 
-    public static DoubleTensor dlnPdf(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor shoulderWidth, DoubleTensor x) {
+    public static DoubleTensor dPdf(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor shoulderWidth, DoubleTensor x) {
         final DoubleTensor bodyWidth = xMax.minus(xMin);
         final DoubleTensor leftCutoff = xMin.minus(shoulderWidth);
         final DoubleTensor rightCutoff = xMax.plus(shoulderWidth);
@@ -130,8 +133,12 @@ public class SmoothUniform {
             shoulderWidth.minus(x).plusInPlace(rightCutoff)
         ).unaryMinusInPlace();
 
-        return firstConditional.timesInPlace(firstConditionalResult)
+        DoubleTensor dLogPdx = firstConditional.timesInPlace(firstConditionalResult)
             .plusInPlace(secondConditional.timesInPlace(secondConditionalResult));
+
+        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
+
+        return dLogPdx;
     }
 
     private static DoubleTensor shoulder(DoubleTensor Sw, DoubleTensor Bw, DoubleTensor x) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -133,12 +133,8 @@ public class SmoothUniform {
             shoulderWidth.minus(x).plusInPlace(rightCutoff)
         ).unaryMinusInPlace();
 
-        DoubleTensor dLogPdx = firstConditional.timesInPlace(firstConditionalResult)
+        return firstConditional.timesInPlace(firstConditionalResult)
             .plusInPlace(secondConditional.timesInPlace(secondConditionalResult));
-
-        dLogPdx = dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape()));
-
-        return dLogPdx;
     }
 
     private static DoubleTensor shoulder(DoubleTensor Sw, DoubleTensor Bw, DoubleTensor x) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -5,6 +5,8 @@ import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.special.Gamma;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static java.lang.Math.PI;
 import static java.lang.Math.log;
 
@@ -63,7 +65,7 @@ public class StudentT {
      * @param t random variable
      * @return Differential of the Log of the Probability Density Function
      */
-    public static Diff dLogPdf(IntegerTensor v, DoubleTensor t) {
+    public static DiffLogP dLnPdf(IntegerTensor v, DoubleTensor t) {
 
         DoubleTensor vAsDouble = v.toDouble();
         DoubleTensor dPdt = t.unaryMinus()
@@ -72,17 +74,19 @@ public class StudentT {
                 t.pow(2).plusInPlace(vAsDouble)
             );
 
-        return new Diff(dPdt);
+        dPdt = dPdt.reshape(concat(SCALAR_SHAPE, dPdt.getShape()));
+
+        return new DiffLogP(dPdt);
     }
 
     /**
      * Differential Equation Class to store result of d/dv and d/dt
      */
-    public static class Diff {
-        public DoubleTensor dPdt;
+    public static class DiffLogP {
+        public DoubleTensor dLogPdt;
 
-        public Diff(DoubleTensor dPdt) {
-            this.dPdt = dPdt;
+        public DiffLogP(DoubleTensor dLogPdt) {
+            this.dLogPdt = dLogPdt;
         }
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -5,8 +5,6 @@ import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.special.Gamma;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
 import static java.lang.Math.PI;
 import static java.lang.Math.log;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -74,8 +74,6 @@ public class StudentT {
                 t.pow(2).plusInPlace(vAsDouble)
             );
 
-        dPdt = dPdt.reshape(concat(SCALAR_SHAPE, dPdt.getShape()));
-
         return new DiffLogP(dPdt);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -1,5 +1,7 @@
 package io.improbable.keanu.tensor;
 
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+
 import java.util.Arrays;
 
 public class TensorShape {
@@ -94,4 +96,48 @@ public class TensorShape {
         System.arraycopy(shape2, 0, result, shape1.length, shape2.length);
         return result;
     }
+
+    /**
+     * @param fromDimension starting from and including this dimension
+     * @param toDimension   up to but excluding this dimension
+     * @return an int array containing the dimension numbers from a given dimension to a higher
+     * dimension. e.g. dimensionRange(0, 3) = int[]{0, 1, 2}
+     */
+    public static int[] dimensionRange(int fromDimension, int toDimension) {
+        if (fromDimension > toDimension) {
+            throw new IllegalArgumentException("from dimension must be less than to dimension");
+        }
+
+        int dimensionCount = toDimension - fromDimension;
+        int[] dims = new int[dimensionCount];
+        for (int i = 0; i < dimensionCount; i++) {
+            dims[i] = i + fromDimension;
+        }
+        return dims;
+    }
+
+    public static DoubleTensor increaseRankByAppendingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
+        return increaseRankByPaddingOnes(lowRankTensor, desiredRank, true);
+    }
+
+    public static DoubleTensor increaseRankByPrependingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
+        return increaseRankByPaddingOnes(lowRankTensor, desiredRank, false);
+    }
+
+    private static DoubleTensor increaseRankByPaddingOnes(DoubleTensor lowRankTensor, int desiredRank, boolean append) {
+        int[] shape = lowRankTensor.getShape();
+        if (shape.length == desiredRank) {
+            return lowRankTensor;
+        }
+
+        int[] paddedShape = new int[desiredRank];
+        Arrays.fill(paddedShape, 1);
+        if (append) {
+            System.arraycopy(shape, 0, paddedShape, 0, shape.length);
+        } else {
+            System.arraycopy(shape, 0, paddedShape, shape.length, shape.length);
+        }
+        return lowRankTensor.reshape(paddedShape);
+    }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -115,29 +115,4 @@ public class TensorShape {
         }
         return dims;
     }
-
-    public static DoubleTensor increaseRankByAppendingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
-        return increaseRankByPaddingOnes(lowRankTensor, desiredRank, true);
-    }
-
-    public static DoubleTensor increaseRankByPrependingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
-        return increaseRankByPaddingOnes(lowRankTensor, desiredRank, false);
-    }
-
-    private static DoubleTensor increaseRankByPaddingOnes(DoubleTensor lowRankTensor, int desiredRank, boolean append) {
-        int[] shape = lowRankTensor.getShape();
-        if (shape.length == desiredRank) {
-            return lowRankTensor;
-        }
-
-        int[] paddedShape = new int[desiredRank];
-        Arrays.fill(paddedShape, 1);
-        if (append) {
-            System.arraycopy(shape, 0, paddedShape, 0, shape.length);
-        } else {
-            System.arraycopy(shape, 0, paddedShape, shape.length, shape.length);
-        }
-        return lowRankTensor.reshape(paddedShape);
-    }
-
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -113,4 +113,28 @@ public class TensorShape {
         }
         return dims;
     }
+
+    public static int[] shapeDesiredToRankByAppendingOnes(int[] lowRankTensorShape, int desiredRank) {
+        return increaseRankByPaddingOnes(lowRankTensorShape, desiredRank, true);
+    }
+
+    public static int[] shapeToDesiredRankByPrependingOnes(int[] lowRankTensorShape, int desiredRank) {
+        return increaseRankByPaddingOnes(lowRankTensorShape, desiredRank, false);
+    }
+
+    private static int[] increaseRankByPaddingOnes(int[] lowRankTensorShape, int desiredRank, boolean append) {
+        int[] paddedShape = new int[desiredRank];
+        if (lowRankTensorShape.length > desiredRank) {
+            throw new IllegalArgumentException("low rank tensor must be rank less than or equal to desired rank");
+        }
+
+        Arrays.fill(paddedShape, 1);
+        if (append) {
+            System.arraycopy(lowRankTensorShape, 0, paddedShape, 0, lowRankTensorShape.length);
+        } else {
+            System.arraycopy(lowRankTensorShape, 0, paddedShape, lowRankTensorShape.length, lowRankTensorShape.length);
+        }
+
+        return paddedShape;
+    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -11,6 +11,7 @@ import org.apache.commons.math3.linear.LUDecomposition;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.ops.impl.broadcast.BroadcastMulOp;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.*;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.conditions.Conditions;
@@ -340,7 +341,18 @@ public class Nd4jDoubleTensor implements DoubleTensor {
             return that.times(this.scalar());
         } else {
             INDArray thatArray = unsafeGetNd4J(that);
-            return new Nd4jDoubleTensor(tensor.mul(thatArray));
+//            if (Arrays.equals(tensor.shape(), thatArray.shape())) {
+                return new Nd4jDoubleTensor(tensor.mul(thatArray));
+//            } else {
+//                INDArray result = Nd4j.createUninitialized(tensor.shape(), tensor.ordering());
+//                int[] broadcastDimensions = new int[]{0};
+//                Nd4j.getExecutioner().exec(
+//                    new BroadcastMulOp(tensor, thatArray, result, broadcastDimensions),
+//                    broadcastDimensions
+//                );
+//
+//                return new Nd4jDoubleTensor(result);
+//            }
         }
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 
 import java.util.Collections;
@@ -277,11 +278,8 @@ public class DualNumber {
 
     public DualNumber sum() {
         DoubleTensor sumOfAll = DoubleTensor.scalar(value.sum());
-        int[] resultDims = new int[value.getRank()];
-        for (int i = 0; i < value.getRank(); i++) {
-            resultDims[i] = i;
-        }
-        return new DualNumber(sumOfAll, this.partialDerivatives.sum(resultDims));
+        int[] resultDims = TensorShape.dimensionRange(0, value.getRank());
+        return new DualNumber(sumOfAll, this.partialDerivatives.sum(false, resultDims));
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -9,8 +9,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.TensorShape.increaseRankByAppendingOnesToShape;
-import static io.improbable.keanu.tensor.TensorShape.increaseRankByPrependingOnesToShape;
 import static java.util.Collections.singletonMap;
 
 public class PartialDerivatives {
@@ -237,5 +235,29 @@ public class PartialDerivatives {
             clone.put(entry.getKey(), entry.getValue());
         }
         return clone;
+    }
+
+    private static DoubleTensor increaseRankByAppendingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
+        return increaseRankByPaddingOnes(lowRankTensor, desiredRank, true);
+    }
+
+    private static DoubleTensor increaseRankByPrependingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
+        return increaseRankByPaddingOnes(lowRankTensor, desiredRank, false);
+    }
+
+    private static DoubleTensor increaseRankByPaddingOnes(DoubleTensor lowRankTensor, int desiredRank, boolean append) {
+        int[] shape = lowRankTensor.getShape();
+        if (shape.length == desiredRank) {
+            return lowRankTensor;
+        }
+
+        int[] paddedShape = new int[desiredRank];
+        Arrays.fill(paddedShape, 1);
+        if (append) {
+            System.arraycopy(shape, 0, paddedShape, 0, shape.length);
+        } else {
+            System.arraycopy(shape, 0, paddedShape, shape.length, shape.length);
+        }
+        return lowRankTensor.reshape(paddedShape);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -257,29 +257,15 @@ public class PartialDerivatives {
         return wrtShape;
     }
 
-
-    private static DoubleTensor increaseRankByAppendingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
-        return increaseRankByPaddingOnes(lowRankTensor, desiredRank, true);
+    public static DoubleTensor increaseRankByPrependingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
+        return lowRankTensor.reshape(
+            TensorShape.shapeToDesiredRankByPrependingOnes(lowRankTensor.getShape(), desiredRank)
+        );
     }
 
-    private static DoubleTensor increaseRankByPrependingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
-        return increaseRankByPaddingOnes(lowRankTensor, desiredRank, false);
+    public static DoubleTensor increaseRankByAppendingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
+        return lowRankTensor.reshape(
+            TensorShape.shapeDesiredToRankByAppendingOnes(lowRankTensor.getShape(), desiredRank)
+        );
     }
-
-    private static DoubleTensor increaseRankByPaddingOnes(DoubleTensor lowRankTensor, int desiredRank, boolean append) {
-        int[] shape = lowRankTensor.getShape();
-        if (shape.length == desiredRank) {
-            return lowRankTensor;
-        }
-
-        int[] paddedShape = new int[desiredRank];
-        Arrays.fill(paddedShape, 1);
-        if (append) {
-            System.arraycopy(shape, 0, paddedShape, 0, shape.length);
-        } else {
-            System.arraycopy(shape, 0, paddedShape, shape.length, shape.length);
-        }
-        return lowRankTensor.reshape(paddedShape);
-    }
-
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -10,8 +10,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -100,7 +99,9 @@ public class BetaVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromAlpha.add(dLogPdInputsFromBeta);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
+                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
+            );
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -10,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -98,7 +100,7 @@ public class BetaVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromAlpha.add(dLogPdInputsFromBeta);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.Beta;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -19,7 +20,7 @@ public class BetaVertex extends ProbabilisticDouble {
 
     /**
      * One alpha or beta or both that match a proposed tensor shape of Beta.
-     *
+     * <p>
      * If all provided parameters are scalar then the proposed shape determines the shape
      *
      * @param tensorShape the desired shape of the tensor contained in the vertex
@@ -84,23 +85,24 @@ public class BetaVertex extends ProbabilisticDouble {
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        Beta.Diff dlnP = Beta.dlnPdf(alpha.getValue(), beta.getValue(), value);
-        return convertDualNumbersToDiff(dlnP.dPdalpha, dlnP.dPdbeta, dlnP.dPdx);
+        Beta.DiffLogP dlnP = Beta.dlnPdf(alpha.getValue(), beta.getValue(), value);
+        return convertDualNumbersToDiff(dlnP.dLogPdalpha, dlnP.dLogPdbeta, dlnP.dLogPdx);
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdalpha,
-                                                             DoubleTensor dPdbeta,
-                                                             DoubleTensor dPdx) {
+    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdalpha,
+                                                             DoubleTensor dLogPdbeta,
+                                                             DoubleTensor dLogPdx) {
 
-        PartialDerivatives dPdInputsFromAlpha = alpha.getDualNumber().getPartialDerivatives().multiplyBy(dPdalpha);
-        PartialDerivatives dPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dPdbeta);
-        PartialDerivatives dPdInputs = dPdInputsFromAlpha.add(dPdInputsFromBeta);
+        PartialDerivatives dLogPdInputsFromAlpha = alpha.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdalpha);
+        PartialDerivatives dLogPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdbeta);
+        PartialDerivatives dLogPdInputs = dLogPdInputsFromAlpha.add(dLogPdInputsFromBeta);
 
         if (!this.isObserved()) {
-            dPdInputs.putWithRespectTo(getId(), dPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
         }
 
-        return dPdInputs.asMap();
+        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
+        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -10,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -90,7 +92,7 @@ public class ExponentialVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromA.add(dLogPdInputsFromB);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.Exponential;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -76,23 +77,24 @@ public class ExponentialVertex extends ProbabilisticDouble {
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        Exponential.Diff dlnP = Exponential.dlnPdf(location.getValue(), lambda.getValue(), value);
-        return convertDualNumbersToDiff(dlnP.dPdlocation, dlnP.dPdlambda, dlnP.dPdx);
+        Exponential.DiffLogP dlnP = Exponential.dlnPdf(location.getValue(), lambda.getValue(), value);
+        return convertDualNumbersToDiff(dlnP.dLogPdlocation, dlnP.dLogPdlambda, dlnP.dLogPdx);
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdlocation,
-                                                             DoubleTensor dPdlambda,
-                                                             DoubleTensor dPdx) {
+    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlocation,
+                                                             DoubleTensor dLogPdlambda,
+                                                             DoubleTensor dLogPdx) {
 
-        PartialDerivatives dPdInputsFromA = location.getDualNumber().getPartialDerivatives().multiplyBy(dPdlocation);
-        PartialDerivatives dPdInputsFromB = lambda.getDualNumber().getPartialDerivatives().multiplyBy(dPdlambda);
-        PartialDerivatives dPdInputs = dPdInputsFromA.add(dPdInputsFromB);
+        PartialDerivatives dLogPdInputsFromA = location.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlocation);
+        PartialDerivatives dLogPdInputsFromB = lambda.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlambda);
+        PartialDerivatives dLogPdInputs = dLogPdInputsFromA.add(dLogPdInputsFromB);
 
         if (!this.isObserved()) {
-            dPdInputs.putWithRespectTo(getId(), dPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
         }
 
-        return dPdInputs.asMap();
+        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
+        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -10,8 +10,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -92,7 +91,9 @@ public class ExponentialVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromA.add(dLogPdInputsFromB);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
+                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
+            );
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -10,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -107,7 +109,7 @@ public class GammaVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromA.add(dLogPdInputsFromTheta).add(dLogPdInputsFromK);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -10,8 +10,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -109,7 +108,9 @@ public class GammaVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromA.add(dLogPdInputsFromTheta).add(dLogPdInputsFromK);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
+                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
+            );
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -10,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -99,7 +101,7 @@ public class GaussianVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromSigma);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -10,8 +10,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -101,7 +100,9 @@ public class GaussianVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromSigma);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
+                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
+            );
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -10,8 +10,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -98,7 +97,9 @@ public class InverseGammaVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromAlpha.add(dLogPdInputsFromBeta);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
+                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
+            );
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -10,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -96,7 +98,7 @@ public class InverseGammaVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromAlpha.add(dLogPdInputsFromBeta);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -10,8 +10,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -88,7 +87,9 @@ public class LaplaceVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromBeta);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
+                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
+            );
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -10,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -86,7 +88,7 @@ public class LaplaceVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromBeta);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.Laplace;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -19,7 +20,7 @@ public class LaplaceVertex extends ProbabilisticDouble {
 
     /**
      * One mu or beta or both that match a proposed tensor shape of Laplace
-     *
+     * <p>
      * If all provided parameters are scalar then the proposed shape determines the shape
      *
      * @param tensorShape the desired shape of the tensor within the vertex
@@ -72,23 +73,24 @@ public class LaplaceVertex extends ProbabilisticDouble {
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        Laplace.Diff dlnP = Laplace.dlnPdf(mu.getValue(), beta.getValue(), value);
-        return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPdbeta, dlnP.dPdx);
+        Laplace.DiffLogP dlnPdf = Laplace.dlnPdf(mu.getValue(), beta.getValue(), value);
+        return convertDualNumbersToDiff(dlnPdf.dLogPdmu, dlnPdf.dLogPdbeta, dlnPdf.dLogPdx);
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdmu,
-                                                             DoubleTensor dPdbeta,
-                                                             DoubleTensor dPdx) {
+    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
+                                                             DoubleTensor dLogPdbeta,
+                                                             DoubleTensor dLogPdx) {
 
-        PartialDerivatives dPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dPdmu);
-        PartialDerivatives dPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dPdbeta);
-        PartialDerivatives dPdInputs = dPdInputsFromMu.add(dPdInputsFromBeta);
+        PartialDerivatives dLogPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdmu);
+        PartialDerivatives dLogPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdbeta);
+        PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromBeta);
 
         if (!this.isObserved()) {
-            dPdInputs.putWithRespectTo(getId(), dPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
         }
 
-        return dPdInputs.asMap();
+        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
+        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -10,8 +10,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -92,7 +91,9 @@ public class LogNormalVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromSigma);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
+                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
+            );
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -10,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -90,7 +92,7 @@ public class LogNormalVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromSigma);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -10,8 +10,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -80,7 +79,9 @@ public class LogisticVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromS);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
+                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
+            );
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -10,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -78,7 +80,7 @@ public class LogisticVertex extends ProbabilisticDouble {
         PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromS);
 
         if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx);
+            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(concat(SCALAR_SHAPE, dLogPdx.getShape())));
         }
 
         PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
+import io.improbable.keanu.distributions.continuous.MultivariateGaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
@@ -7,7 +8,7 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 import java.util.Map;
 
-public class MultivariateGaussian extends ProbabilisticDouble {
+public class MultivariateGaussianVertex extends ProbabilisticDouble {
 
     private final DoubleVertex mu;
     private final DoubleVertex covariance;
@@ -20,7 +21,7 @@ public class MultivariateGaussian extends ProbabilisticDouble {
      * @param mu         the mu of the Multivariate Gaussian
      * @param covariance the covariance matrix of the Multivariate Gaussian
      */
-    public MultivariateGaussian(int[] shape, DoubleVertex mu, DoubleVertex covariance) {
+    public MultivariateGaussianVertex(int[] shape, DoubleVertex mu, DoubleVertex covariance) {
 
         checkValidMultivariateShape(mu.getShape(), covariance.getShape());
 
@@ -36,7 +37,7 @@ public class MultivariateGaussian extends ProbabilisticDouble {
      * @param mu         the mu of the Multivariate Gaussian
      * @param covariance the covariance matrix of the Multivariate Gaussian
      */
-    public MultivariateGaussian(DoubleVertex mu, DoubleVertex covariance) {
+    public MultivariateGaussianVertex(DoubleVertex mu, DoubleVertex covariance) {
         this(checkValidMultivariateShape(mu.getShape(), covariance.getShape()), mu, covariance);
     }
 
@@ -49,11 +50,11 @@ public class MultivariateGaussian extends ProbabilisticDouble {
      * @param mu         the mu of the Multivariate Gaussian
      * @param covariance the scale of the identity matrix
      */
-    public MultivariateGaussian(DoubleVertex mu, double covariance) {
+    public MultivariateGaussianVertex(DoubleVertex mu, double covariance) {
         this(mu, ConstantVertex.of(DoubleTensor.eye(mu.getShape()[0])).times(covariance));
     }
 
-    public MultivariateGaussian(double mu, double covariance) {
+    public MultivariateGaussianVertex(double mu, double covariance) {
         this(ConstantVertex.of(mu), ConstantVertex.of(covariance));
     }
 
@@ -72,7 +73,7 @@ public class MultivariateGaussian extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return io.improbable.keanu.distributions.continuous.MultivariateGaussian.sample(mu.getValue(), covariance.getValue(), random);
+        return MultivariateGaussian.sample(mu.getValue(), covariance.getValue(), random);
     }
 
     private static int[] checkValidMultivariateShape(int[] muShape, int[] covarianceShape) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.SmoothUniform;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -22,7 +23,7 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
 
     /**
      * One xMin or Xmax or both that match a proposed tensor shape of Smooth Uniform
-     *
+     * <p>
      * If all provided parameters are scalar then the proposed shape determines the shape
      *
      * @param tensorShape   the desired shape of the vertex
@@ -124,11 +125,12 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
         final DoubleTensor min = xMin.getValue();
         final DoubleTensor max = xMax.getValue();
         final DoubleTensor shoulderWidth = (max.minus(min)).timesInPlace(this.edgeSharpness);
-        final DoubleTensor dPdfdx = SmoothUniform.dlnPdf(min, max, shoulderWidth, value);
+        final DoubleTensor dPdfdx = SmoothUniform.dPdf(min, max, shoulderWidth, value);
         final DoubleTensor density = SmoothUniform.pdf(min, max, shoulderWidth, value);
-        final DoubleTensor dlogPdfdx = dPdfdx.divInPlace(density);
+        final DoubleTensor dLogPdfdx = dPdfdx.divInPlace(density);
+        final DoubleTensor dLogPdfdxSummed = dLogPdfdx.sum(TensorShape.dimensionRange(0, getShape().length));
 
-        return singletonMap(getId(), dlogPdfdx);
+        return singletonMap(getId(), dLogPdfdxSummed);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -9,6 +9,8 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 
 import java.util.Map;
 
+import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
+import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 import static java.util.Collections.singletonMap;
@@ -125,12 +127,11 @@ public class SmoothUniformVertex extends ProbabilisticDouble {
         final DoubleTensor min = xMin.getValue();
         final DoubleTensor max = xMax.getValue();
         final DoubleTensor shoulderWidth = (max.minus(min)).timesInPlace(this.edgeSharpness);
-        final DoubleTensor dPdfdx = SmoothUniform.dPdf(min, max, shoulderWidth, value);
+        final DoubleTensor dPdx = SmoothUniform.dPdf(min, max, shoulderWidth, value);
         final DoubleTensor density = SmoothUniform.pdf(min, max, shoulderWidth, value);
-        final DoubleTensor dLogPdfdx = dPdfdx.divInPlace(density);
-        final DoubleTensor dLogPdfdxSummed = dLogPdfdx.sum(TensorShape.dimensionRange(0, getShape().length));
+        final DoubleTensor dLogPdx = dPdx.divInPlace(density);
 
-        return singletonMap(getId(), dLogPdfdxSummed);
+        return singletonMap(getId(), dLogPdx);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.SmoothUniform;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -9,8 +8,6 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 
 import java.util.Map;
 
-import static io.improbable.keanu.tensor.Tensor.SCALAR_SHAPE;
-import static io.improbable.keanu.tensor.TensorShape.concat;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 import static java.util.Collections.singletonMap;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -2,15 +2,16 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.StudentT;
 import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
+import static java.util.Collections.singletonMap;
 
 public class StudentTVertex extends ProbabilisticDouble {
 
@@ -54,10 +55,9 @@ public class StudentTVertex extends ProbabilisticDouble {
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor t) {
-        StudentT.Diff diff = StudentT.dLogPdf(v.getValue(), t);
-        Map<Long, DoubleTensor> m = new HashMap<>();
-        m.put(getId(), diff.dPdt);
-        return m;
+        StudentT.DiffLogP diff = StudentT.dLnPdf(v.getValue(), t);
+        DoubleTensor dLogPdtSummed = diff.dLogPdt.sum(TensorShape.dimensionRange(0, getShape().length));
+        return singletonMap(getId(), dLogPdtSummed);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -2,7 +2,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.StudentT;
 import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -56,8 +55,7 @@ public class StudentTVertex extends ProbabilisticDouble {
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor t) {
         StudentT.DiffLogP diff = StudentT.dLnPdf(v.getValue(), t);
-        DoubleTensor dLogPdtSummed = diff.dLogPdt.sum(TensorShape.dimensionRange(0, getShape().length));
-        return singletonMap(getId(), dLogPdtSummed);
+        return singletonMap(getId(), diff.dLogPdt);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -19,7 +19,7 @@ public class TriangularVertex extends ProbabilisticDouble {
 
     /**
      * One xMin, xMax, c or all three that match a proposed tensor shape of Triangular
-     *
+     * <p>
      * If all provided parameters are scalar then the proposed shape determines the shape
      *
      * @param tensorShape the desired shape of the vertex

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.Uniform;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -19,12 +20,12 @@ public class UniformVertex extends ProbabilisticDouble {
 
     /**
      * One xMin or xMax or both that match a proposed tensor shape of Uniform Vertex
-     *
+     * <p>
      * If all provided parameters are scalar then the proposed shape determines the shape
      *
      * @param tensorShape desired tensor shape
-     * @param xMin  the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
-     * @param xMax  the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
+     * @param xMin        the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
+     * @param xMax        the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
      */
     public UniformVertex(int[] tensorShape, DoubleVertex xMin, DoubleVertex xMax) {
 
@@ -40,8 +41,8 @@ public class UniformVertex extends ProbabilisticDouble {
      * One to one constructor for mapping some shape of mu and sigma to
      * a matching shaped Uniform Vertex
      *
-     * @param xMin  the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
-     * @param xMax  the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
+     * @param xMin the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
+     * @param xMax the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
      */
     public UniformVertex(DoubleVertex xMin, DoubleVertex xMax) {
         this(checkHasSingleNonScalarShapeOrAllScalar(xMin.getShape(), xMax.getShape()), xMin, xMax);
@@ -86,12 +87,12 @@ public class UniformVertex extends ProbabilisticDouble {
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
+        DoubleTensor dLogPdx = DoubleTensor.zeros(this.xMax.getShape());
+        dLogPdx = dLogPdx.setWithMaskInPlace(value.getGreaterThanMask(xMax.getValue()), Double.NEGATIVE_INFINITY);
+        dLogPdx = dLogPdx.setWithMaskInPlace(value.getLessThanOrEqualToMask(xMin.getValue()), Double.POSITIVE_INFINITY);
+        dLogPdx = dLogPdx.sum(TensorShape.dimensionRange(0, getShape().length));
 
-        DoubleTensor dlogPdf = DoubleTensor.zeros(this.xMax.getShape());
-        dlogPdf = dlogPdf.setWithMaskInPlace(value.getGreaterThanMask(xMax.getValue()), Double.NEGATIVE_INFINITY);
-        dlogPdf = dlogPdf.setWithMaskInPlace(value.getLessThanOrEqualToMask(xMin.getValue()), Double.POSITIVE_INFINITY);
-
-        return singletonMap(getId(), dlogPdf);
+        return singletonMap(getId(), dLogPdx);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.Uniform;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -90,7 +89,6 @@ public class UniformVertex extends ProbabilisticDouble {
         DoubleTensor dLogPdx = DoubleTensor.zeros(this.xMax.getShape());
         dLogPdx = dLogPdx.setWithMaskInPlace(value.getGreaterThanMask(xMax.getValue()), Double.NEGATIVE_INFINITY);
         dLogPdx = dLogPdx.setWithMaskInPlace(value.getLessThanOrEqualToMask(xMin.getValue()), Double.POSITIVE_INFINITY);
-        dLogPdx = dLogPdx.sum(TensorShape.dimensionRange(0, getShape().length));
 
         return singletonMap(getId(), dLogPdx);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegression.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegression.java
@@ -151,4 +151,41 @@ public class LinearRegression {
         }
     }
 
+    @Test
+    public void linearRegressionTwoFactorTensorWithMatrixMultiplyVariationalMAP() {
+
+        // Generate data
+        int N = 100000;
+        double expectedW1 = 3.0;
+        double expectedW2 = 7.0;
+        double expectedB = 20.0;
+
+        DoubleVertex wGenerator = ConstantVertex.of(DoubleTensor.create(new double[]{expectedW1, expectedW2}, 2, 1));
+        DoubleVertex xGenerator = new UniformVertex(new int[]{N, 2}, 0, 10);
+        DoubleVertex yGenerator = new GaussianVertex(
+            xGenerator.matrixMultiply(wGenerator).plus(expectedB),
+            1.0
+        );
+        DoubleTensor xData = xGenerator.sample(random);
+        xGenerator.setAndCascade(xData);
+        DoubleTensor yData = yGenerator.sample(random);
+
+        // Linear Regression
+        DoubleVertex w = new GaussianVertex(new int[]{2, 1}, 0.0, 10.0);
+        DoubleVertex b = new GaussianVertex(0.0, 10.0);
+        DoubleVertex x = ConstantVertex.of(xData);
+        DoubleVertex y = new GaussianVertex(x.matrixMultiply(w).plus(b), 5.0);
+        y.observe(yData);
+
+        BayesianNetwork bayesNet = new BayesianNetwork(y.getConnectedGraph());
+        GradientOptimizer optimizer = new GradientOptimizer(bayesNet);
+
+        optimizer.maxLikelihood();
+
+        log.info("W1 = " + w.getValue(0) + " W2 = " + w.getValue(1) + ", B = " + b.getValue().scalar());
+        assertEquals(expectedW1, w.getValue(0), 0.05);
+        assertEquals(expectedW2, w.getValue(1), 0.05);
+        assertEquals(expectedB, b.getValue().scalar(), 0.05);
+    }
+
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorShapeTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorShapeTest.java
@@ -21,16 +21,6 @@ public class TensorShapeTest {
     }
 
     @Test
-    public void canReshapeByPaddingOnes() {
-
-    }
-
-    @Test
-    public void canReshapeByAppendingOnes() {
-
-    }
-
-    @Test
     public void canGetDimensionRange() {
         int[] actual = TensorShape.dimensionRange(2, 5);
         int[] expected = new int[]{2, 3, 4};

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorShapeTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorShapeTest.java
@@ -19,4 +19,21 @@ public class TensorShapeTest {
         int[] shape = new int[]{2, 3, 7, 4};
         assertEquals(168, TensorShape.getLength(shape));
     }
+
+    @Test
+    public void canReshapeByPaddingOnes() {
+
+    }
+
+    @Test
+    public void canReshapeByAppendingOnes() {
+
+    }
+
+    @Test
+    public void canGetDimensionRange() {
+        int[] actual = TensorShape.dimensionRange(2, 5);
+        int[] expected = new int[]{2, 3, 4};
+        assertArrayEquals(actual, expected);
+    }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -137,9 +137,11 @@ public class Nd4jDoubleTensorTest {
     @Test
     public void canBroadcastMultiplyRank4ContainingVectorAndMatrix() {
         DoubleTensor rank4 = DoubleTensor.create(new double[]{1, 2, 3, 4, 5, 6, 7, 8}, new int[]{2, 2, 2, 1});
-        DoubleTensor actual = rank4.times(matrixA.reshape(2, 2, 1, 1));
+        DoubleTensor matrix = matrixA.reshape(2, 2, 1, 1);
         DoubleTensor expected = DoubleTensor.create(new double[]{1, 2, 6, 8, 15, 18, 28, 32}, new int[]{2, 2, 2, 1});
-        assertEquals(actual, expected);
+
+        assertTimesOperationEquals(rank4, matrix, expected);
+        assertTimesInPlaceOperationEquals(rank4, matrix, expected);
     }
 
     @Test
@@ -149,27 +151,42 @@ public class Nd4jDoubleTensorTest {
             4, 3, 2, 1, 7, 5, 8, 6
         }, new int[]{2, 2, 2, 2});
 
-        DoubleTensor actual = rank4.times(matrixA.reshape(2, 2, 1, 1));
+        DoubleTensor matrix = matrixA.reshape(2, 2, 1, 1);
         DoubleTensor expected = DoubleTensor.create(new double[]{
             1, 2, 3, 4, 10, 12, 14, 16,
             12, 9, 6, 3, 28, 20, 32, 24
         }, new int[]{2, 2, 2, 2});
-        assertEquals(actual, expected);
+
+
+        assertTimesOperationEquals(rank4, matrix, expected);
+        assertTimesInPlaceOperationEquals(rank4, matrix, expected);
     }
 
     @Test
     public void canBroadcastMultiplyRank5ContainingMatrixAndMatrix() {
-        DoubleTensor rank4 = DoubleTensor.create(new double[]{
+        DoubleTensor rank5 = DoubleTensor.create(new double[]{
             1, 2, 3, 4, 5, 6, 7, 8, 4, 3, 2, 1, 7, 5, 8, 6,
             6, 3, 2, 9, 3, 4, 7, 6, 6, 2, 5, 4, 0, 2, 1, 3
         }, new int[]{2, 2, 2, 2, 2});
 
-        DoubleTensor actual = rank4.times(matrixA.reshape(2, 2, 1, 1, 1));
+        DoubleTensor matrix = matrixA.reshape(2, 2, 1, 1, 1);
         DoubleTensor expected = DoubleTensor.create(new double[]{
             1, 2, 3, 4, 5, 6, 7, 8, 8, 6, 4, 2, 14, 10, 16, 12,
             18, 9, 6, 27, 9, 12, 21, 18, 24, 8, 20, 16, 0, 8, 4, 12
         }, new int[]{2, 2, 2, 2, 2});
+
+        assertTimesOperationEquals(rank5, matrix, expected);
+        assertTimesInPlaceOperationEquals(rank5, matrix, expected);
+    }
+
+    private void assertTimesOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
+        DoubleTensor actual = left.times(right);
         assertEquals(actual, expected);
+    }
+
+    private void assertTimesInPlaceOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
+        left.timesInPlace(right);
+        assertEquals(left, expected);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -1,11 +1,7 @@
 package io.improbable.keanu.tensor.dbl;
 
-import org.apache.commons.math3.linear.Array2DRowRealMatrix;
-import org.apache.commons.math3.linear.RealMatrix;
 import org.junit.Before;
 import org.junit.Test;
-import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -136,6 +132,44 @@ public class Nd4jDoubleTensorTest {
     public void canApplySqrt() {
         DoubleTensor result = scalarA.sqrt();
         assertEquals(Math.sqrt(2.0), result.scalar(), 0.0);
+    }
+
+    @Test
+    public void canBroadcastMultiplyRank4ContainingVectorAndMatrix() {
+        DoubleTensor rank4 = DoubleTensor.create(new double[]{1, 2, 3, 4, 5, 6, 7, 8}, new int[]{2, 2, 2, 1});
+        DoubleTensor actual = rank4.times(matrixA.reshape(2, 2, 1, 1));
+        DoubleTensor expected = DoubleTensor.create(new double[]{1, 2, 6, 8, 15, 18, 28, 32}, new int[]{2, 2, 2, 1});
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void canBroadcastMultiplyRank4ContainingMatrixAndMatrix() {
+        DoubleTensor rank4 = DoubleTensor.create(new double[]{
+            1, 2, 3, 4, 5, 6, 7, 8,
+            4, 3, 2, 1, 7, 5, 8, 6
+        }, new int[]{2, 2, 2, 2});
+
+        DoubleTensor actual = rank4.times(matrixA.reshape(2, 2, 1, 1));
+        DoubleTensor expected = DoubleTensor.create(new double[]{
+            1, 2, 3, 4, 10, 12, 14, 16,
+            12, 9, 6, 3, 28, 20, 32, 24
+        }, new int[]{2, 2, 2, 2});
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void canBroadcastMultiplyRank5ContainingMatrixAndMatrix() {
+        DoubleTensor rank4 = DoubleTensor.create(new double[]{
+            1, 2, 3, 4, 5, 6, 7, 8, 4, 3, 2, 1, 7, 5, 8, 6,
+            6, 3, 2, 9, 3, 4, 7, 6, 6, 2, 5, 4, 0, 2, 1, 3
+        }, new int[]{2, 2, 2, 2, 2});
+
+        DoubleTensor actual = rank4.times(matrixA.reshape(2, 2, 1, 1, 1));
+        DoubleTensor expected = DoubleTensor.create(new double[]{
+            1, 2, 3, 4, 5, 6, 7, 8, 8, 6, 4, 2, 14, 10, 16, 12,
+            18, 9, 6, 27, 9, 12, 21, 18, 24, 8, 20, 16, 0, 8, 4, 12
+        }, new int[]{2, 2, 2, 2, 2});
+        assertEquals(actual, expected);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianTest.java
@@ -29,7 +29,7 @@ public class MultivariateGaussianTest {
 
     @Test
     public void samplingFromUnivariateGaussianMatchesLogDensity() {
-        MultivariateGaussian mvg = new MultivariateGaussian(0, 1);
+        MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(0, 1);
 
         double from = -2.;
         double to = 2.;
@@ -40,7 +40,7 @@ public class MultivariateGaussianTest {
 
     @Test
     public void univariateGaussianMatchesLogDensityOfScalar() {
-        MultivariateGaussian mvg = new MultivariateGaussian(5, 1);
+        MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(5, 1);
 
         double expectedDensity = new NormalDistribution(5.0, 1).logDensity(0.5);
         double density = mvg.logPdf(Nd4jDoubleTensor.scalar(0.5));
@@ -53,7 +53,7 @@ public class MultivariateGaussianTest {
         DoubleVertex mu = ConstantVertex.of(
             new Nd4jDoubleTensor(new double[]{2, 3}, new int[]{2, 1}));
 
-        MultivariateGaussian mvg = new MultivariateGaussian(mu, 1);
+        MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, 1);
 
         double expectedDensity1 = new NormalDistribution(2, 1).logDensity(8);
         double expectedDensity2 = new NormalDistribution(3, 1).logDensity(10);
@@ -71,7 +71,7 @@ public class MultivariateGaussianTest {
         DoubleVertex covarianceMatrix = ConstantVertex.of(
             new Nd4jDoubleTensor(new double[]{1, 0.3, 0.3, 0.6}, new int[]{2, 2}));
 
-        MultivariateGaussian mvg = new MultivariateGaussian(mu, covarianceMatrix);
+        MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, covarianceMatrix);
         double density = mvg.logPdf(new Nd4jDoubleTensor(new double[]{0.5, 0.4}, new int[]{2, 1}));
         double expected = -3.6874792995813834;
 
@@ -94,7 +94,7 @@ public class MultivariateGaussianTest {
             )
         );
 
-        MultivariateGaussian mvg = new MultivariateGaussian(mu, covarianceMatrix);
+        MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, covarianceMatrix);
         double density = mvg.logPdf(new Nd4jDoubleTensor(new double[]{0.2, 0.3, 0.4}, new int[]{3, 1}));
         double expected = -8.155504532016181;
 
@@ -106,7 +106,7 @@ public class MultivariateGaussianTest {
         DoubleVertex mu = ConstantVertex.of(
             new Nd4jDoubleTensor(new double[]{0, 0}, new int[]{2, 1}));
 
-        MultivariateGaussian mvg = new MultivariateGaussian(mu, 1);
+        MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, 1);
 
         double from = -1.;
         double to = 1.;
@@ -115,7 +115,7 @@ public class MultivariateGaussianTest {
         sampleMethodMatchesLogProbMethodMultiVariate(mvg, from, to, bucketSize, 0.01, 100000, random);
     }
 
-    private static void sampleMethodMatchesLogProbMethodMultiVariate(MultivariateGaussian vertexUnderTest,
+    private static void sampleMethodMatchesLogProbMethodMultiVariate(MultivariateGaussianVertex vertexUnderTest,
                                                                      double from,
                                                                      double to,
                                                                      double bucketSize,

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -63,12 +63,12 @@ public class ProbabilisticDoubleTensorContract {
     }
 
     public static void sampleUnivariateMethodMatchesLogProbMethod(Vertex<DoubleTensor> vertexUnderTest,
-                                                        double from,
-                                                        double to,
-                                                        double bucketSize,
-                                                        double maxError,
-                                                        KeanuRandom random,
-                                                        int sampleCount) {
+                                                                  double from,
+                                                                  double to,
+                                                                  double bucketSize,
+                                                                  double maxError,
+                                                                  KeanuRandom random,
+                                                                  int sampleCount) {
         double bucketCount = ((to - from) / bucketSize);
 
         if (bucketCount != (int) bucketCount) {
@@ -219,13 +219,13 @@ public class ProbabilisticDoubleTensorContract {
     public static void matchesKnownDerivativeLogDensityOfVector(double[] vector, Supplier<DoubleVertex> vertexUnderTestSupplier) {
 
         DoubleVertex[] scalarVertices = new DoubleVertex[vector.length];
-        PartialDerivatives tensorPartialDerivatives = new PartialDerivatives(new HashMap<>());
+        PartialDerivatives expectedPartialDerivatives = new PartialDerivatives(new HashMap<>());
 
         for (int i = 0; i < vector.length; i++) {
 
             scalarVertices[i] = vertexUnderTestSupplier.get();
 
-            tensorPartialDerivatives = tensorPartialDerivatives.add(
+            expectedPartialDerivatives = expectedPartialDerivatives.add(
                 new PartialDerivatives(
                     scalarVertices[i].dLogPdf(vector[i])
                 )
@@ -242,12 +242,16 @@ public class ProbabilisticDoubleTensorContract {
         hyperParameterVertices.remove(tensorVertex.getId());
 
         for (Long id : hyperParameterVertices) {
-            assertEquals(tensorPartialDerivatives.withRespectTo(id).sum(), actualDerivatives.get(id).sum(), 1e-5);
+            assertEquals(expectedPartialDerivatives.withRespectTo(id).sum(), actualDerivatives.get(id).sum(), 1e-5);
         }
 
+        double expected = 0;
         for (int i = 0; i < vector.length; i++) {
-            assertEquals(tensorPartialDerivatives.withRespectTo(scalarVertices[i]).scalar(), actualDerivatives.get(tensorVertex.getId()).getValue(i), 1e-5);
+            expected += expectedPartialDerivatives.withRespectTo(scalarVertices[i]).scalar();
         }
+
+        double actual = actualDerivatives.get(tensorVertex.getId()).sum();
+        assertEquals(expected, actual, 1e-5);
     }
 
 }


### PR DESCRIPTION
When trying to implement linear regression with the new matrix multiply vertex, I came across two bugs:

1. The summing done in the logProb for vertices is not being reflected in the dLogProb result. The bottom dimensions need to be summed over in order to match the behaviour of logProb.
2. The broadcast multiply in ND4J does not match what we expect or what is returned from numpy. The times operation on DoubleTensor now catches would be broadcast multiplies and does them correctly instead of letting ND4j take it. I'll raise this with the ND4J team as well.

Also, while trying to debug the problem I came up against some incorrect variable names in the distribution derivative code. I've refactored these to be sensible and consistent.