### PR TITLE
Change behaviour to reshape on setValue and observe

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
@@ -27,7 +27,8 @@ public class SimpleBooleanTensor implements BooleanTensor {
     private final int[] stride;
 
     public SimpleBooleanTensor(boolean[] data, int[] shape) {
-        this.data = data;
+        this.data = new boolean[(int) TensorShape.getLength(shape)];
+        System.arraycopy(data, 0, this.data, 0, this.data.length);
         this.shape = shape;
         this.stride = TensorShape.getRowFirstStride(shape);
     }
@@ -46,9 +47,9 @@ public class SimpleBooleanTensor implements BooleanTensor {
 
     public SimpleBooleanTensor(boolean constant, int[] shape) {
         this.data = new boolean[(int) TensorShape.getLength(shape)];
+        Arrays.fill(this.data, constant);
         this.shape = shape;
         this.stride = TensorShape.getRowFirstStride(shape);
-        Arrays.fill(this.data, constant);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
@@ -26,6 +26,10 @@ public class SimpleBooleanTensor implements BooleanTensor {
     private final int[] shape;
     private final int[] stride;
 
+    /**
+     * @param data  tensor data used c ordering
+     * @param shape desired shape of tensor
+     */
     public SimpleBooleanTensor(boolean[] data, int[] shape) {
         this.data = new boolean[(int) TensorShape.getLength(shape)];
         System.arraycopy(data, 0, this.data, 0, this.data.length);
@@ -33,18 +37,28 @@ public class SimpleBooleanTensor implements BooleanTensor {
         this.stride = TensorShape.getRowFirstStride(shape);
     }
 
+    /**
+     * @param constant constant boolean value to fill shape
+     */
     public SimpleBooleanTensor(boolean constant) {
         this.data = new boolean[]{constant};
         this.shape = Tensor.SCALAR_SHAPE;
         this.stride = Tensor.SCALAR_STRIDE;
     }
 
+    /**
+     * @param shape shape to use as place holder
+     */
     public SimpleBooleanTensor(int[] shape) {
         this.data = null;
         this.shape = shape;
         this.stride = TensorShape.getRowFirstStride(shape);
     }
 
+    /**
+     * @param constant constant boolean value to fill shape
+     * @param shape    desired shape of tensor
+     */
     public SimpleBooleanTensor(boolean constant, int[] shape) {
         this.data = new boolean[(int) TensorShape.getLength(shape)];
         Arrays.fill(this.data, constant);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
@@ -38,27 +38,27 @@ public abstract class BoolVertex extends DiscreteVertex<BooleanTensor> {
     }
 
     public void setValue(boolean value) {
-        super.setValue(BooleanTensor.create(value, getShape()));
+        super.setValue(BooleanTensor.scalar(value));
     }
 
     public void setValue(boolean[] values) {
-        super.setValue(BooleanTensor.create(values, getShape()));
+        super.setValue(BooleanTensor.create(values));
     }
 
     public void setAndCascade(boolean value) {
-        super.setAndCascade(BooleanTensor.create(value, getShape()));
+        super.setAndCascade(BooleanTensor.scalar(value));
     }
 
     public void setAndCascade(boolean[] values) {
-        super.setAndCascade(BooleanTensor.create(values, getShape()));
+        super.setAndCascade(BooleanTensor.create(values));
     }
 
     public void observe(boolean value) {
-        super.observe(BooleanTensor.create(value, getShape()));
+        super.observe(BooleanTensor.scalar(value));
     }
 
     public void observe(boolean[] values) {
-        super.observe(BooleanTensor.create(values, getShape()));
+        super.observe(BooleanTensor.create(values));
     }
 
     public double logPmf(boolean value) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -186,27 +186,27 @@ public abstract class DoubleVertex extends ContinuousVertex<DoubleTensor> implem
     protected abstract DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers);
 
     public void setValue(double value) {
-        super.setValue(DoubleTensor.create(value, getShape()));
+        super.setValue(DoubleTensor.scalar(value));
     }
 
     public void setValue(double[] values) {
-        super.setValue(DoubleTensor.create(values, getShape()));
+        super.setValue(DoubleTensor.create(values));
     }
 
     public void setAndCascade(double value) {
-        super.setAndCascade(DoubleTensor.create(value, getShape()));
+        super.setAndCascade(DoubleTensor.scalar(value));
     }
 
     public void setAndCascade(double[] values) {
-        super.setAndCascade(DoubleTensor.create(values, getShape()));
+        super.setAndCascade(DoubleTensor.create(values));
     }
 
     public void observe(double value) {
-        super.observe(DoubleTensor.create(value, getShape()));
+        super.observe(DoubleTensor.scalar(value));
     }
 
     public void observe(double[] values) {
-        super.observe(DoubleTensor.create(values, getShape()));
+        super.observe(DoubleTensor.create(values));
     }
 
     public double logPdf(double value) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
@@ -106,23 +106,23 @@ public abstract class IntegerVertex extends DiscreteVertex<IntegerTensor> implem
     }
 
     public void setValue(int value) {
-        super.setValue(IntegerTensor.create(value, getShape()));
+        super.setValue(IntegerTensor.scalar(value));
     }
 
     public void setValue(int[] values) {
-        super.setValue(IntegerTensor.create(values, getShape()));
+        super.setValue(IntegerTensor.create(values));
     }
 
     public void setAndCascade(int value) {
-        super.setAndCascade(IntegerTensor.create(value, getShape()));
+        super.setAndCascade(IntegerTensor.scalar(value));
     }
 
     public void setAndCascade(int[] values) {
-        super.setAndCascade(IntegerTensor.create(values, getShape()));
+        super.setAndCascade(IntegerTensor.create(values));
     }
 
     public void observe(int value) {
-        super.observe(IntegerTensor.create(value, getShape()));
+        super.observe(IntegerTensor.scalar(value));
     }
 
     public void observe(int[] values) {

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/BoolVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/BoolVertexTest.java
@@ -125,6 +125,13 @@ public class BoolVertexTest {
         assertArrayEquals(new Boolean[]{true}, flip.getValue().asFlatArray());
     }
 
+    @Test
+    public void canSetAndCascadeAsScalarOnNonScalarVertex() {
+        BoolVertex flip = new Flip(new int[]{2, 1}, 0.5);
+        flip.setAndCascade(true);
+        assertArrayEquals(new Boolean[]{true}, flip.getValue().asFlatArray());
+    }
+
     private double andProbability(double pA, double pB) {
         return pA * pB;
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/BoolVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/BoolVertexTest.java
@@ -4,19 +4,18 @@ import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.sampling.Prior;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.CastBoolVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex;
 import io.improbable.keanu.vertices.bool.probabilistic.Flip;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.ConstantVertex;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class BoolVertexTest {
 
@@ -95,6 +94,36 @@ public class BoolVertexTest {
         assertEquals(priorProbabilityTrue(a, 10000, random), p, 0.01);
     }
 
+    @Test
+    public void canObserveArrayOfValues() {
+        BoolVertex flip = new Flip(0.5);
+        boolean[] observation = new boolean[]{true, false, true};
+        flip.observe(observation);
+        assertArrayEquals(new Boolean[]{true, false, true}, flip.getValue().asFlatArray());
+    }
+
+    @Test
+    public void canSetAndCascadeArrayOfValues() {
+        BoolVertex flip = new Flip(0.5);
+        boolean[] values = new boolean[]{true, false, true};
+        flip.setAndCascade(values);
+        assertArrayEquals(new Boolean[]{true, false, true}, flip.getValue().asFlatArray());
+    }
+
+    @Test
+    public void canSetValueArrayOfValues() {
+        BoolVertex flip = new Flip(0.5);
+        boolean[] values = new boolean[]{true, false, true};
+        flip.setValue(values);
+        assertArrayEquals(new Boolean[]{true, false, true}, flip.getValue().asFlatArray());
+    }
+
+    @Test
+    public void canSetValueAsScalarOnNonScalarVertex() {
+        BoolVertex flip = new Flip(new int[]{2, 1}, 0.5);
+        flip.setValue(true);
+        assertArrayEquals(new Boolean[]{true}, flip.getValue().asFlatArray());
+    }
 
     private double andProbability(double pA, double pB) {
         return pA * pB;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
@@ -1,0 +1,47 @@
+package io.improbable.keanu.vertices.dbl;
+
+import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class DoubleVertexTest {
+
+    @Test
+    public void canObserveArrayOfValues() {
+        DoubleVertex gaussianVertex = new GaussianVertex(0, 1);
+        double[] observation = new double[]{1, 2, 3};
+        gaussianVertex.observe(observation);
+        assertArrayEquals(observation, gaussianVertex.getValue().asFlatDoubleArray(), 0.0);
+    }
+
+    @Test
+    public void canSetAndCascadeArrayOfValues() {
+        DoubleVertex gaussianVertex = new GaussianVertex(0, 1);
+        double[] values = new double[]{1, 2, 3};
+        gaussianVertex.setAndCascade(values);
+        assertArrayEquals(values, gaussianVertex.getValue().asFlatDoubleArray(), 0.0);
+    }
+
+    @Test
+    public void canSetValueArrayOfValues() {
+        DoubleVertex gaussianVertex = new GaussianVertex(0, 1);
+        double[] values = new double[]{1, 2, 3};
+        gaussianVertex.setValue(values);
+        assertArrayEquals(values, gaussianVertex.getValue().asFlatDoubleArray(), 0.0);
+    }
+
+    @Test
+    public void canSetValueAsScalarOnNonScalarVertex() {
+        DoubleVertex gaussianVertex = new GaussianVertex(new int[]{1, 2}, 0, 1);
+        gaussianVertex.setValue(2);
+        assertArrayEquals(new double[]{2}, gaussianVertex.getValue().asFlatDoubleArray(), 0.0);
+    }
+
+    @Test
+    public void canSetAndCascadeAsScalarOnNonScalarVertex() {
+        DoubleVertex gaussianVertex = new GaussianVertex(new int[]{1, 2}, 0, 1);
+        gaussianVertex.setAndCascade(2);
+        assertArrayEquals(new double[]{2}, gaussianVertex.getValue().asFlatDoubleArray(), 0.0);
+    }
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambdaTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambdaTest.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Test;
@@ -12,9 +13,9 @@ public class DoubleBinaryOpLambdaTest {
     public void GIVEN_a_double_tensor_THEN_transform() {
 
         UniformVertex matrix = new UniformVertex(new int[]{2, 2}, 0, 5);
-        matrix.setAndCascade(2.5);
+        matrix.setAndCascade(DoubleTensor.create(2.5, new int[]{2, 2}));
         UniformVertex matrixB = new UniformVertex(new int[]{2, 2}, 0, 5);
-        matrixB.setAndCascade(3.5);
+        matrixB.setAndCascade(DoubleTensor.create(3.5, new int[]{2, 2}));
 
         DoubleVertex matrixLambda = new DoubleBinaryOpLambda<>(
             matrix.getShape(), matrix, matrixB,

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambdaTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambdaTest.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Test;
@@ -12,7 +13,7 @@ public class DoubleUnaryOpLambdaTest {
     public void GIVEN_a_double_tensor_THEN_transform() {
 
         UniformVertex matrix = new UniformVertex(new int[]{2, 2}, 0, 5);
-        matrix.setAndCascade(2.5);
+        matrix.setAndCascade(DoubleTensor.create(2.5, new int[]{2, 2}));
         DoubleVertex matrixLambda = new DoubleUnaryOpLambda<>(matrix.getShape(), matrix, (val) -> val.times(2));
 
         assertArrayEquals(new double[]{5, 5, 5, 5}, matrixLambda.getValue().asFlatDoubleArray(), 0.001);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/IntegerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/IntegerVertexTest.java
@@ -2,14 +2,14 @@ package io.improbable.keanu.vertices.intgr;
 
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.intgr.probabilistic.BinomialVertex;
 import io.improbable.keanu.vertices.intgr.probabilistic.PoissonVertex;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class IntegerVertexTest {
 
@@ -64,6 +64,37 @@ public class IntegerVertexTest {
         result.eval();
         Integer expected = 8;
         assertEquals(result.getValue().scalar(), expected);
+    }
+
+    @Test
+    public void canObserveArrayOfValues() {
+        IntegerVertex binomialVertex = new BinomialVertex(0.5, 20);
+        int[] observation = new int[]{1, 2, 3};
+        binomialVertex.observe(observation);
+        assertArrayEquals(observation, binomialVertex.getValue().asFlatIntegerArray());
+    }
+
+    @Test
+    public void canSetAndCascadeArrayOfValues() {
+        IntegerVertex binomialVertex = new BinomialVertex(0.5, 20);
+        int[] values = new int[]{1, 2, 3};
+        binomialVertex.setAndCascade(values);
+        assertArrayEquals(values, binomialVertex.getValue().asFlatIntegerArray());
+    }
+
+    @Test
+    public void canSetValueAsArrayOfValues() {
+        IntegerVertex binomialVertex = new BinomialVertex(0.5, 20);
+        int[] values = new int[]{1, 2, 3};
+        binomialVertex.setAndCascade(values);
+        assertArrayEquals(values, binomialVertex.getValue().asFlatIntegerArray());
+    }
+
+    @Test
+    public void canSetValueAsScalarOnNonScalarVertex() {
+        IntegerVertex binomialVertex = new BinomialVertex(new int[]{2, 1}, 0.5, 20);
+        binomialVertex.setValue(2);
+        assertArrayEquals(new int[]{2}, binomialVertex.getValue().asFlatIntegerArray());
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/IntegerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/IntegerVertexTest.java
@@ -86,7 +86,7 @@ public class IntegerVertexTest {
     public void canSetValueAsArrayOfValues() {
         IntegerVertex binomialVertex = new BinomialVertex(0.5, 20);
         int[] values = new int[]{1, 2, 3};
-        binomialVertex.setAndCascade(values);
+        binomialVertex.setValue(values);
         assertArrayEquals(values, binomialVertex.getValue().asFlatIntegerArray());
     }
 
@@ -94,6 +94,13 @@ public class IntegerVertexTest {
     public void canSetValueAsScalarOnNonScalarVertex() {
         IntegerVertex binomialVertex = new BinomialVertex(new int[]{2, 1}, 0.5, 20);
         binomialVertex.setValue(2);
+        assertArrayEquals(new int[]{2}, binomialVertex.getValue().asFlatIntegerArray());
+    }
+
+    @Test
+    public void canSetAndCascadeAsScalarOnNonScalarVertex() {
+        IntegerVertex binomialVertex = new BinomialVertex(new int[]{2, 1}, 0.5, 20);
+        binomialVertex.setAndCascade(2);
         assertArrayEquals(new int[]{2}, binomialVertex.getValue().asFlatIntegerArray());
     }
 


### PR DESCRIPTION
Previously, when you observed/setValue/setAndCascade a primitive or array then it would NOT reshape the vertex. This has been confusing to users (and me) and I propose we change the behaviour to be such that anything you set or observe is exactly reflected in the vertex. For example, setting or observing a scalar value would make the shape of the vertex scalar and if you observe an array then the vertex would would be reshaped as a vector.