### PR TITLE
pulled out interfaces ContinuousDistribution and DiscreteDistribution

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/ContinuousDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/ContinuousDistribution.java
@@ -1,0 +1,9 @@
+package io.improbable.keanu.distributions;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+
+import java.util.List;
+
+public interface ContinuousDistribution extends Distribution<DoubleTensor> {
+    public List<DoubleTensor> dLogProb(DoubleTensor x);
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/DiscreteDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/DiscreteDistribution.java
@@ -1,0 +1,6 @@
+package io.improbable.keanu.distributions;
+
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
+
+public interface DiscreteDistribution  extends Distribution<IntegerTensor> {
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/Distribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/Distribution.java
@@ -1,0 +1,13 @@
+package io.improbable.keanu.distributions;
+
+import io.improbable.keanu.distributions.continuous.Beta;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.List;
+
+public interface Distribution<T extends Tensor> {
+    T sample(int[] shape, KeanuRandom random);
+    DoubleTensor logProb(T x);
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
@@ -1,26 +1,42 @@
 package io.improbable.keanu.distributions.continuous;
 
+import io.improbable.keanu.distributions.ContinuousDistribution;
+import io.improbable.keanu.distributions.Distribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.special.Gamma;
 
-public class ChiSquared {
+import java.util.List;
+
+public class ChiSquared implements ContinuousDistribution {
 
     private static final double LOG_TWO = Math.log(2);
+    private final IntegerTensor k;
 
-    private ChiSquared() {
+    public static ContinuousDistribution withParameters(IntegerTensor k) {
+        return new ChiSquared(k);
     }
 
-    public static DoubleTensor sample(int[] shape, IntegerTensor k, KeanuRandom random) {
+    private ChiSquared(IntegerTensor k) {
+        this.k = k;
+    }
+
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
         return random.nextGamma(shape, DoubleTensor.ZERO_SCALAR, DoubleTensor.TWO_SCALAR, k.toDouble().div(2));
     }
 
-    public static DoubleTensor logPdf(IntegerTensor k, DoubleTensor x) {
+    @Override
+    public DoubleTensor logProb(DoubleTensor x) {
         DoubleTensor halfK = k.toDouble().div(2);
         DoubleTensor numerator = halfK.minus(1).timesInPlace(x.log()).minusInPlace(x.div(2));
         DoubleTensor denominator = halfK.times(LOG_TWO).plusInPlace(halfK.apply(Gamma::gamma).logInPlace());
         return numerator.minusInPlace(denominator);
     }
 
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor x) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -1,39 +1,43 @@
 package io.improbable.keanu.distributions.continuous;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.distributions.ContinuousDistribution;
+import io.improbable.keanu.distributions.Distribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-public class Exponential {
+import java.util.List;
 
-    private Exponential() {
+public class Exponential implements ContinuousDistribution {
+
+    private final DoubleTensor location;
+    private final DoubleTensor lambda;
+
+    public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor lambda) {
+        return new Exponential(location, lambda);
     }
 
-    public static DoubleTensor sample(int[] shape, DoubleTensor location, DoubleTensor lambda, KeanuRandom random) {
+    private Exponential(DoubleTensor location, DoubleTensor lambda) {
+        this.location = location;
+        this.lambda = lambda;
+    }
+
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
         return location.minus(random.nextDouble(shape).logInPlace().timesInPlace(lambda));
     }
 
-    public static DoubleTensor logPdf(DoubleTensor location, DoubleTensor lambda, DoubleTensor x) {
+    @Override
+    public DoubleTensor logProb(DoubleTensor x) {
         final DoubleTensor negXMinusADivB = x.minus(location).unaryMinusInPlace().divInPlace(lambda);
         final DoubleTensor negXMinusADivBMinusLogB = negXMinusADivB.minusInPlace(lambda.log());
         return negXMinusADivBMinusLogB.setWithMask(x.getLessThanMask(location), Double.NEGATIVE_INFINITY);
     }
 
-    public static Diff dlnPdf(DoubleTensor location, DoubleTensor lambda, DoubleTensor x) {
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor x) {
         final DoubleTensor dPda = lambda.reciprocal();
         final DoubleTensor dPdb = x.minus(location).minusInPlace(lambda).divInPlace(lambda.pow(2));
-        return new Diff(dPda, dPdb, dPda.unaryMinus());
+        return ImmutableList.of(dPda, dPdb, dPda.unaryMinus());
     }
-
-    public static class Diff {
-        public final DoubleTensor dPdlocation;
-        public final DoubleTensor dPdlambda;
-        public final DoubleTensor dPdx;
-
-        public Diff(DoubleTensor dPda, DoubleTensor dPdb, DoubleTensor dPdx) {
-            this.dPdlocation = dPda;
-            this.dPdlambda = dPdb;
-            this.dPdx = dPdx;
-        }
-    }
-
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -1,29 +1,45 @@
 package io.improbable.keanu.distributions.continuous;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.distributions.ContinuousDistribution;
+import io.improbable.keanu.distributions.Distribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-public class Gaussian {
+import java.util.List;
+
+public class Gaussian implements ContinuousDistribution {
 
     public static final double SQRT_2PI = Math.sqrt(Math.PI * 2);
     public static final double LN_SQRT_2PI = Math.log(SQRT_2PI);
+    private final DoubleTensor mu;
+    private final DoubleTensor sigma;
 
-    private Gaussian() {
+    public static ContinuousDistribution withParameters(DoubleTensor mu, DoubleTensor sigma) {
+        return new Gaussian(mu, sigma);
     }
 
-    public static DoubleTensor sample(int[] shape, DoubleTensor mu, DoubleTensor sigma, KeanuRandom random) {
+    private Gaussian(DoubleTensor mu, DoubleTensor sigma) {
+        this.mu = mu;
+        this.sigma = sigma;
+    }
+
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
         DoubleTensor unityGaussian = random.nextGaussian(shape);
         return unityGaussian.timesInPlace(sigma).plusInPlace(mu);
     }
 
-    public static DoubleTensor logPdf(DoubleTensor mu, DoubleTensor sigma, DoubleTensor x) {
+    @Override
+    public DoubleTensor logProb(DoubleTensor x) {
         final DoubleTensor lnSigma = sigma.log();
         final DoubleTensor xMinusMuSquared = x.minus(mu).powInPlace(2);
         final DoubleTensor xMinusMuSquaredOver2Variance = xMinusMuSquared.divInPlace(sigma.pow(2).timesInPlace(2.0));
         return xMinusMuSquaredOver2Variance.plusInPlace(lnSigma).plusInPlace(LN_SQRT_2PI).unaryMinusInPlace();
     }
 
-    public static Diff dlnPdf(DoubleTensor mu, DoubleTensor sigma, DoubleTensor x) {
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor x) {
         final DoubleTensor variance = sigma.pow(2);
         final DoubleTensor xMinusMu = x.minus(mu);
 
@@ -33,18 +49,6 @@ public class Gaussian {
             .divInPlace(variance.timesInPlace(sigma))
             .minusInPlace(sigma.reciprocal());
 
-        return new Diff(dlnP_dmu, dlnP_dsigma, dlnP_dx);
-    }
-
-    public static class Diff {
-        public final DoubleTensor dPdmu;
-        public final DoubleTensor dPdsigma;
-        public final DoubleTensor dPdx;
-
-        public Diff(DoubleTensor dPdmu, DoubleTensor dPdsigma, DoubleTensor dPdx) {
-            this.dPdmu = dPdmu;
-            this.dPdsigma = dPdsigma;
-            this.dPdx = dPdx;
-        }
+        return ImmutableList.of(dlnP_dmu, dlnP_dsigma, dlnP_dx);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
@@ -1,40 +1,47 @@
 package io.improbable.keanu.distributions.continuous;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+import java.util.List;
+
 import static io.improbable.keanu.distributions.continuous.Gaussian.LN_SQRT_2PI;
 
-public class LogNormal {
+public class LogNormal implements ContinuousDistribution {
 
-    private LogNormal() {
-    }
+    private final DoubleTensor mu;
+    private final DoubleTensor sigma;
 
     /**
-     * @param shape  shape of tensor returned
      * @param mu     location parameter (any real number)
      * @param sigma  square root of variance (greater than 0)
-     * @param random source or randomness
-     * @return a sample from the distribution given mu and sigma
      */
-    public static DoubleTensor sample(int[] shape, DoubleTensor mu, DoubleTensor sigma, KeanuRandom random) {
-        return Gaussian.sample(shape, mu, sigma, random).expInPlace();
+    public static ContinuousDistribution withParameters(DoubleTensor mu, DoubleTensor sigma) {
+        return new LogNormal(mu, sigma);
     }
 
-    /**
-     * @param mu    location parameter (any real number)
-     * @param sigma square root of variance (greater than 0)
-     * @param x     at value
-     * @return the natural log of the pdf given mu and sigma at x
-     */
-    public static DoubleTensor logPdf(DoubleTensor mu, DoubleTensor sigma, DoubleTensor x) {
+    private LogNormal(DoubleTensor mu, DoubleTensor sigma) {
+        this.mu = mu;
+        this.sigma = sigma;
+    }
+
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
+        return Gaussian.withParameters(mu, sigma).sample(shape, random).expInPlace();
+    }
+
+    @Override
+    public DoubleTensor logProb(DoubleTensor x) {
         final DoubleTensor lnSigmaX = sigma.times(x).logInPlace();
         final DoubleTensor lnXMinusMuSquared = x.log().minusInPlace(mu).powInPlace(2);
         final DoubleTensor lnXMinusMuSquaredOver2Variance = lnXMinusMuSquared.divInPlace(sigma.pow(2).timesInPlace(2.0));
         return lnXMinusMuSquaredOver2Variance.plusInPlace(lnSigmaX).plusInPlace(LN_SQRT_2PI).unaryMinusInPlace();
     }
 
-    public static LogNormal.Diff dlnPdf(DoubleTensor mu, DoubleTensor sigma, DoubleTensor x) {
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor x) {
         final DoubleTensor variance = sigma.pow(2);
         final DoubleTensor lnXMinusMu = x.log().minusInPlace(mu);
 
@@ -44,18 +51,6 @@ public class LogNormal {
             .divInPlace(variance.timesInPlace(sigma))
             .minusInPlace(sigma.reciprocal());
 
-        return new LogNormal.Diff(dlnP_dmu, dlnP_dsigma, dlnP_dx);
-    }
-
-    public static class Diff {
-        public final DoubleTensor dPdmu;
-        public final DoubleTensor dPdsigma;
-        public final DoubleTensor dPdx;
-
-        public Diff(DoubleTensor dPdmu, DoubleTensor dPdsigma, DoubleTensor dPdx) {
-            this.dPdmu = dPdmu;
-            this.dPdsigma = dPdsigma;
-            this.dPdx = dPdx;
-        }
+        return ImmutableList.of(dlnP_dmu, dlnP_dsigma, dlnP_dx);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
@@ -1,14 +1,32 @@
 package io.improbable.keanu.distributions.continuous;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-public class MultivariateGaussian {
+import java.util.List;
 
-    private MultivariateGaussian() {
+public class MultivariateGaussian implements ContinuousDistribution {
+
+    private final DoubleTensor mu;
+    private final DoubleTensor covariance;
+
+    public static ContinuousDistribution withParameters(DoubleTensor mu, DoubleTensor covariance) {
+        return new MultivariateGaussian(mu, covariance);
+    }
+    private MultivariateGaussian(DoubleTensor mu, DoubleTensor covariance) {
+        this.mu = mu;
+        this.covariance = covariance;
     }
 
-    public static DoubleTensor sample(DoubleTensor mu, DoubleTensor covariance, KeanuRandom random) {
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
+        for (int i = 0; i < shape.length; i++) {
+            Preconditions.checkArgument(mu.getShape()[i] == shape[i],
+                "shape must match mu's shape");
+        }
         final DoubleTensor choleskyCov = covariance.choleskyDecomposition();
         final DoubleTensor variateSamples = random.nextGaussian(mu.getShape());
         final DoubleTensor covTimesVariates = mu.isScalar() ?
@@ -16,7 +34,8 @@ public class MultivariateGaussian {
         return covTimesVariates.plus(mu);
     }
 
-    public static double logPdf(DoubleTensor mu, DoubleTensor covariance, DoubleTensor x) {
+    @Override
+    public DoubleTensor logProb(DoubleTensor x) {
         final double dimensions = mu.getShape()[0];
         final double kLog2Pi = dimensions * Math.log(2 * Math.PI);
         final double logCovDet = Math.log(covariance.determinant());
@@ -28,6 +47,11 @@ public class MultivariateGaussian {
             covInv.times(xMinusMu).times(xMinusMuT).scalar() :
             xMinusMuT.matrixMultiply(covInv.matrixMultiply(xMinusMu)).scalar();
 
-        return -0.5 * (scalar + kLog2Pi + logCovDet);
+        return DoubleTensor.create(-0.5 * (scalar + kLog2Pi + logCovDet), new int[] {1});
+    }
+
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor x) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -1,7 +1,11 @@
 package io.improbable.keanu.distributions.continuous;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.List;
 
 /**
  * The Smooth Uniform distribution is the usual Uniform distribution with the edges
@@ -32,24 +36,32 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
  * A = -2 / (Sw^3 * (Sw + Bw))
  * B = 3 / (Sw^3 * Sw^2*Bw)
  */
-public class SmoothUniform {
+public class SmoothUniform implements ContinuousDistribution {
 
-    private SmoothUniform() {
-    }
+    private final DoubleTensor xMin;
+    private final DoubleTensor xMax;
+    private final double edgeSharpness;
 
     /**
      * Will return samples between xMin and xMax as well as samples from the left and right shoulder.
      * The width of the shoulder is determined by the edgeSharpness as a percentage of the body width,
      * which is (xMax - xMin).
      *
-     * @param shape         result tensor shape
      * @param xMin          min value from body
      * @param xMax          max value from body
      * @param edgeSharpness sharpness as a percentage of the body width
-     * @param random        source of randomness
-     * @return a uniform random number between xMin and xMax
      */
-    public static DoubleTensor sample(int[] shape, DoubleTensor xMin, DoubleTensor xMax, double edgeSharpness, KeanuRandom random) {
+    public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax, double edgeSharpness) {
+        return new SmoothUniform(xMin, xMax, edgeSharpness);
+    }
+    private SmoothUniform(DoubleTensor xMin, DoubleTensor xMax, double edgeSharpness) {
+        this.xMin = xMin;
+        this.xMax = xMax;
+        this.edgeSharpness = edgeSharpness;
+    }
+
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
 
         DoubleTensor r1 = random.nextDouble(shape);
         DoubleTensor r2 = random.nextDouble(shape);
@@ -90,9 +102,10 @@ public class SmoothUniform {
             .plusInPlace(inverseFirstConditional.timesInPlace(secondConditionalFalseNestedFalse).timesInPlace(secondConditionalFalseNestedFalseResult));
     }
 
-    public static DoubleTensor pdf(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor shoulderWidth, DoubleTensor x) {
-
+    @Override
+    public DoubleTensor logProb(DoubleTensor x) {
         final DoubleTensor bodyWidth = xMax.minus(xMin);
+        final DoubleTensor shoulderWidth = bodyWidth.times(edgeSharpness);
         final DoubleTensor rightCutoff = xMax.plus(shoulderWidth);
         final DoubleTensor leftCutoff = xMin.minus(shoulderWidth);
 
@@ -114,8 +127,10 @@ public class SmoothUniform {
             .plusInPlace(thirdConditional.timesInPlace(thirdConditionalResult));
     }
 
-    public static DoubleTensor dlnPdf(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor shoulderWidth, DoubleTensor x) {
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor x) {
         final DoubleTensor bodyWidth = xMax.minus(xMin);
+        final DoubleTensor shoulderWidth = bodyWidth.times(edgeSharpness);
         final DoubleTensor leftCutoff = xMin.minus(shoulderWidth);
         final DoubleTensor rightCutoff = xMax.plus(shoulderWidth);
 
@@ -130,8 +145,8 @@ public class SmoothUniform {
             shoulderWidth.minus(x).plusInPlace(rightCutoff)
         ).unaryMinusInPlace();
 
-        return firstConditional.timesInPlace(firstConditionalResult)
-            .plusInPlace(secondConditional.timesInPlace(secondConditionalResult));
+        return ImmutableList.of(firstConditional.timesInPlace(firstConditionalResult)
+            .plusInPlace(secondConditional.timesInPlace(secondConditionalResult)));
     }
 
     private static DoubleTensor shoulder(DoubleTensor Sw, DoubleTensor Bw, DoubleTensor x) {
@@ -157,5 +172,4 @@ public class SmoothUniform {
     private static DoubleTensor bodyHeight(DoubleTensor shoulderWidth, DoubleTensor bodyWidth) {
         return shoulderWidth.plus(bodyWidth).reciprocalInPlace();
     }
-
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -1,9 +1,13 @@
 package io.improbable.keanu.distributions.continuous;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.special.Gamma;
+
+import java.util.List;
 
 import static java.lang.Math.PI;
 import static java.lang.Math.log;
@@ -12,9 +16,10 @@ import static java.lang.Math.log;
  * Student T Distribution
  * https://en.wikipedia.org/wiki/Student%27s_t-distribution#Sampling_distribution
  */
-public class StudentT {
+public class StudentT implements ContinuousDistribution {
 
     private static final double HALF_LOG_PI = log(PI) / 2;
+    private final IntegerTensor v;
 
     /**
      * Computer Generation of Statistical Distributions
@@ -22,23 +27,24 @@ public class StudentT {
      * ARL-TR-2168 March 2000
      * 5.1.23 page 36
      *
-     * @param shape  tensor shape of returned samples
      * @param v      Degrees of Freedom
-     * @param random random number generator (RNG) seed
-     * @return sample of Student T distribution
      */
-    public static DoubleTensor sample(int[] shape, IntegerTensor v, KeanuRandom random) {
+    public static ContinuousDistribution withParameters(IntegerTensor v) {
+        return new StudentT(v);
+    }
 
-        DoubleTensor chi2Samples = ChiSquared.sample(shape, v, random);
+    private StudentT(IntegerTensor v) {
+        this.v = v;
+    }
+
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
+        DoubleTensor chi2Samples = ChiSquared.withParameters(v).sample(shape, random);
         return random.nextGaussian(shape).divInPlace(chi2Samples.divInPlace(v.toDouble()).sqrtInPlace());
     }
 
-    /**
-     * @param v Degrees of Freedom
-     * @param t random variable
-     * @return Log of the Probability Density Function
-     */
-    public static DoubleTensor logPdf(IntegerTensor v, DoubleTensor t) {
+    @Override
+    public DoubleTensor logProb(DoubleTensor t) {
 
         DoubleTensor vAsDouble = v.toDouble();
         DoubleTensor halfVPlusOne = vAsDouble.plus(1).divInPlace(2);
@@ -58,13 +64,8 @@ public class StudentT {
             );
     }
 
-    /**
-     * @param v Degrees of Freedom
-     * @param t random variable
-     * @return Differential of the Log of the Probability Density Function
-     */
-    public static Diff dLogPdf(IntegerTensor v, DoubleTensor t) {
-
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor t) {
         DoubleTensor vAsDouble = v.toDouble();
         DoubleTensor dPdt = t.unaryMinus()
             .timesInPlace(vAsDouble.plus(1.0))
@@ -72,17 +73,6 @@ public class StudentT {
                 t.pow(2).plusInPlace(vAsDouble)
             );
 
-        return new Diff(dPdt);
-    }
-
-    /**
-     * Differential Equation Class to store result of d/dv and d/dt
-     */
-    public static class Diff {
-        public DoubleTensor dPdt;
-
-        public Diff(DoubleTensor dPdt) {
-            this.dPdt = dPdt;
-        }
+        return ImmutableList.of(dPdt);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
@@ -1,11 +1,30 @@
 package io.improbable.keanu.distributions.continuous;
 
+import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-public class Triangular {
+import java.util.List;
 
-    public static DoubleTensor sample(int[] shape, DoubleTensor xMin, DoubleTensor xMax, DoubleTensor c, KeanuRandom random) {
+public class Triangular implements ContinuousDistribution {
+
+    private final DoubleTensor xMin;
+    private final DoubleTensor xMax;
+    private final DoubleTensor c;
+
+    public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor c) {
+        return new Triangular(xMin, xMax, c);
+    }
+
+    private Triangular(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor c) {
+
+       this.xMin = xMin;
+        this.xMax = xMax;
+        this.c = c;
+    }
+
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
         final DoubleTensor p = random.nextDouble(shape);
         final DoubleTensor q = p.unaryMinus().plusInPlace(1);
         final DoubleTensor range = xMax.minus(xMin);
@@ -21,7 +40,8 @@ public class Triangular {
         return (lessThan.timesInPlace(lessThanMask).plusInPlace(greaterThan.timesInPlace(greaterThanMask)));
     }
 
-    public static DoubleTensor logPdf(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor c, DoubleTensor x) {
+    @Override
+    public DoubleTensor logProb(DoubleTensor x) {
         final DoubleTensor range = xMax.minus(xMin);
 
         final DoubleTensor conditionalFirstHalf = x.getGreaterThanMask(xMin);
@@ -37,5 +57,9 @@ public class Triangular {
         return (conditionalResult.timesInPlace(conditionalAnd).plusInPlace(elseIfConditionalResult.timesInPlace(elseIfConditionalAnd))).logInPlace();
     }
 
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor x) {
+        throw new UnsupportedOperationException();
+    }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.distributions.continuous;
 
+import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.List;
 
 /**
  * Computer Generation of Statistical Distributions
@@ -9,28 +12,40 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
  * ARL-TR-2168 March 2000
  * 5.1.8 page 48
  */
-public class Uniform {
+public class Uniform implements ContinuousDistribution {
 
-    private Uniform() {
-    }
+    private final DoubleTensor xMin;
+    private final DoubleTensor xMax;
 
     /**
-     * @param shape  requested sample shape
      * @param xMin   minimum x value
      * @param xMax   maximum x value
-     * @param random source of randomness
-     * @return a random number from the Uniform distribution
      */
-    public static DoubleTensor sample(int[] shape, DoubleTensor xMin, DoubleTensor xMax, KeanuRandom random) {
+    public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax) {
+        return new Uniform(xMin, xMax);
+    }
+    private Uniform(DoubleTensor xMin, DoubleTensor xMax) {
+        this.xMin = xMin;
+        this.xMax = xMax;
+    }
+
+    @Override
+    public DoubleTensor sample(int[] shape, KeanuRandom random) {
         return random.nextDouble(shape).timesInPlace(xMax.minus(xMin)).plusInPlace(xMin);
     }
 
-    public static DoubleTensor logPdf(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor x) {
+    @Override
+    public DoubleTensor logProb(DoubleTensor x) {
 
         DoubleTensor logOfWithinBounds = xMax.minus(xMin).logInPlace().unaryMinusInPlace();
         logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(x.getGreaterThanMask(xMax), Double.NEGATIVE_INFINITY);
         logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(x.getLessThanOrEqualToMask(xMin), Double.NEGATIVE_INFINITY);
 
         return logOfWithinBounds;
+    }
+
+    @Override
+    public List<DoubleTensor> dLogProb(DoubleTensor x) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
@@ -1,5 +1,7 @@
 package io.improbable.keanu.distributions.discrete;
 
+import io.improbable.keanu.distributions.DiscreteDistribution;
+import io.improbable.keanu.distributions.Distribution;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
@@ -7,10 +9,23 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.util.CombinatoricsUtils;
 import org.nd4j.linalg.util.ArrayUtil;
 
-public class Binomial {
+import java.util.List;
 
-    public static IntegerTensor sample(int[] shape, DoubleTensor p, IntegerTensor n, KeanuRandom random) {
+public class Binomial implements DiscreteDistribution {
 
+    private final DoubleTensor p;
+    private final IntegerTensor n;
+
+    public static DiscreteDistribution withParameters(DoubleTensor p, IntegerTensor n) {
+        return new Binomial(p, n);
+    }
+
+    private Binomial(DoubleTensor p, IntegerTensor n) {
+        this.p = p;
+        this.n = n;
+    }
+    @Override
+    public IntegerTensor sample(int[] shape, KeanuRandom random) {
         Tensor.FlattenedView<Double> pWrapped = p.getFlattenedView();
         Tensor.FlattenedView<Integer> nWrapped = n.getFlattenedView();
 
@@ -23,7 +38,7 @@ public class Binomial {
         return IntegerTensor.create(samples, shape);
     }
 
-    public static int sample(double p, int n, KeanuRandom random) {
+    private static int sample(double p, int n, KeanuRandom random) {
         int sum = 0;
         for (int i = 0; i < n; i++) {
             if (random.nextDouble() < p) {
@@ -33,8 +48,8 @@ public class Binomial {
         return sum;
     }
 
-    public static DoubleTensor logPmf(IntegerTensor k, DoubleTensor p, IntegerTensor n) {
-
+    @Override
+    public DoubleTensor logProb(IntegerTensor k) {
         DoubleTensor logBinomialCoefficient = getLogBinomialCoefficient(k, n);
 
         DoubleTensor logBinomial = p.pow(k.toDouble())

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.distributions.discrete;
 
+import io.improbable.keanu.distributions.DiscreteDistribution;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
@@ -14,10 +15,20 @@ import static org.apache.commons.math3.util.CombinatoricsUtils.factorial;
  * ARL-TR-2168 March 2000
  * 5.2.8 page 49
  */
-public class Poisson {
+public class Poisson implements DiscreteDistribution {
 
-    public static IntegerTensor sample(int[] shape, DoubleTensor mu, KeanuRandom random) {
+    private final DoubleTensor mu;
 
+    public static DiscreteDistribution withParamters(DoubleTensor mu) {
+        return new Poisson(mu);
+    }
+
+    private Poisson(DoubleTensor mu) {
+        this.mu = mu;
+    }
+
+    @Override
+    public IntegerTensor sample(int[] shape, KeanuRandom random) {
         Tensor.FlattenedView<Double> muWrapped = mu.getFlattenedView();
 
         int length = ArrayUtil.prod(shape);
@@ -29,7 +40,7 @@ public class Poisson {
         return IntegerTensor.create(samples, shape);
     }
 
-    public static int sample(double mu, KeanuRandom random) {
+    private static int sample(double mu, KeanuRandom random) {
         if (mu <= 0.) {
             throw new IllegalArgumentException("Invalid value for mu: " + mu);
         }
@@ -45,8 +56,8 @@ public class Poisson {
         return i - 1;
     }
 
-    public static DoubleTensor logPmf(DoubleTensor mu, IntegerTensor k) {
-
+    @Override
+    public DoubleTensor logProb(IntegerTensor k) {
         Tensor.FlattenedView<Double> muFlattenedView = mu.getFlattenedView();
         Tensor.FlattenedView<Integer> kFlattenedView = k.getFlattenedView();
 
@@ -58,7 +69,7 @@ public class Poisson {
         return DoubleTensor.create(result, k.getShape());
     }
 
-    public static double pmf(double mu, int k) {
+    private static double pmf(double mu, int k) {
         if (k >= 0 && k < 20) {
             return (Math.pow(mu, k) / factorial(k)) * Math.exp(-mu);
         } else if (k >= 20) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/KeanuRandom.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/KeanuRandom.java
@@ -75,11 +75,11 @@ public class KeanuRandom {
     }
 
     public DoubleTensor nextGamma(int[] shape, DoubleTensor a, DoubleTensor theta, DoubleTensor k) {
-        return Gamma.sample(shape, a, theta, k, this);
+        return Gamma.withParameters(a, theta, k).sample(shape, this);
     }
 
     public DoubleTensor nextLaplace(int[] shape, DoubleTensor mu, DoubleTensor beta) {
-        return Laplace.sample(shape, mu, beta, this);
+        return Laplace.withParameters(mu, beta).sample(shape, this);
     }
 
     public double nextGaussian() {
@@ -99,7 +99,7 @@ public class KeanuRandom {
     }
 
     public IntegerTensor nextPoisson(int[] shape, DoubleTensor mu) {
-        return Poisson.sample(shape, mu, this);
+        return Poisson.withParamters(mu).sample(shape, this);
 
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -52,12 +52,12 @@ public class ChiSquaredVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return ChiSquared.sample(getShape(), k.getValue(), random);
+        return ChiSquared.withParameters(k.getValue()).sample(getShape(), random);
     }
 
     @Override
     public double logPdf(DoubleTensor value) {
-        return ChiSquared.logPdf(k.getValue(), value).sum();
+        return ChiSquared.withParameters(k.getValue()).logProb(value).sum();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -7,6 +7,7 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
+import java.util.List;
 import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
@@ -69,15 +70,15 @@ public class ExponentialVertex extends ProbabilisticDouble {
         DoubleTensor locationValues = location.getValue();
         DoubleTensor lambdaValues = lambda.getValue();
 
-        DoubleTensor logPdfs = Exponential.logPdf(locationValues, lambdaValues, value);
+        DoubleTensor logPdfs = Exponential.withParameters(locationValues, lambdaValues).logProb(value);
 
         return logPdfs.sum();
     }
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        Exponential.Diff dlnP = Exponential.dlnPdf(location.getValue(), lambda.getValue(), value);
-        return convertDualNumbersToDiff(dlnP.dPdlocation, dlnP.dPdlambda, dlnP.dPdx);
+        List<DoubleTensor> dlnP = Exponential.withParameters(location.getValue(), lambda.getValue()).dLogProb(value);
+        return convertDualNumbersToDiff(dlnP.get(0), dlnP.get(1), dlnP.get(2));
     }
 
     private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdlocation,
@@ -97,7 +98,7 @@ public class ExponentialVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return Exponential.sample(getShape(), location.getValue(), lambda.getValue(), random);
+        return Exponential.withParameters(location.getValue(), lambda.getValue()).sample(getShape(), random);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -114,7 +114,7 @@ public class GammaVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return Gamma.sample(getShape(), location.getValue(), theta.getValue(), k.getValue(), random);
+        return Gamma.withParameters(location.getValue(), theta.getValue(), k.getValue()).sample(getShape(), random);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -7,6 +7,7 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
+import java.util.List;
 import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
@@ -78,15 +79,15 @@ public class GaussianVertex extends ProbabilisticDouble {
         DoubleTensor muValues = mu.getValue();
         DoubleTensor sigmaValues = sigma.getValue();
 
-        DoubleTensor logPdfs = Gaussian.logPdf(muValues, sigmaValues, value);
+        DoubleTensor logPdfs = Gaussian.withParameters(muValues, sigmaValues).logProb(value);
 
         return logPdfs.sum();
     }
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        Gaussian.Diff dlnP = Gaussian.dlnPdf(mu.getValue(), sigma.getValue(), value);
-        return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPdsigma, dlnP.dPdx);
+        List<DoubleTensor> dlnP = Gaussian.withParameters(mu.getValue(), sigma.getValue()).dLogProb(value);
+        return convertDualNumbersToDiff(dlnP.get(0), dlnP.get(1), dlnP.get(2));
     }
 
     private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdmu,
@@ -106,7 +107,7 @@ public class GaussianVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return Gaussian.sample(getShape(), mu.getValue(), sigma.getValue(), random);
+        return Gaussian.withParameters(mu.getValue(), sigma.getValue()).sample(getShape(), random);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -7,6 +7,7 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
+import java.util.List;
 import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
@@ -75,15 +76,15 @@ public class InverseGammaVertex extends ProbabilisticDouble {
         DoubleTensor alphaValues = alpha.getValue();
         DoubleTensor betaValues = beta.getValue();
 
-        DoubleTensor logPdfs = InverseGamma.logPdf(alphaValues, betaValues, value);
+        DoubleTensor logPdfs = InverseGamma.withParameters(alphaValues, betaValues).logProb(value);
         return logPdfs.sum();
     }
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        InverseGamma.Diff dlnP = InverseGamma.dlnPdf(alpha.getValue(), beta.getValue(), value);
+        List<DoubleTensor> dlnP = InverseGamma.withParameters(alpha.getValue(), beta.getValue()).dLogProb(value);
 
-        return convertDualNumbersToDiff(dlnP.dPdalpha, dlnP.dPdbeta, dlnP.dPdx);
+        return convertDualNumbersToDiff(dlnP.get(0), dlnP.get(1), dlnP.get(2));
     }
 
     private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdalpha,
@@ -103,7 +104,7 @@ public class InverseGammaVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return InverseGamma.sample(getShape(), alpha.getValue(), beta.getValue(), random);
+        return InverseGamma.withParameters(alpha.getValue(), beta.getValue()).sample(getShape(), random);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -7,6 +7,7 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
+import java.util.List;
 import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
@@ -65,15 +66,15 @@ public class LaplaceVertex extends ProbabilisticDouble {
         DoubleTensor muValues = mu.getValue();
         DoubleTensor betaValues = beta.getValue();
 
-        DoubleTensor logPdfs = Laplace.logPdf(muValues, betaValues, value);
+        DoubleTensor logPdfs = Laplace.withParameters(muValues, betaValues).logProb(value);
 
         return logPdfs.sum();
     }
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        Laplace.Diff dlnP = Laplace.dlnPdf(mu.getValue(), beta.getValue(), value);
-        return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPdbeta, dlnP.dPdx);
+        List<DoubleTensor> dlnP = Laplace.withParameters(mu.getValue(), beta.getValue()).dLogProb(value);
+        return convertDualNumbersToDiff(dlnP.get(0), dlnP.get(1), dlnP.get(2));
     }
 
     private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdmu,
@@ -93,7 +94,7 @@ public class LaplaceVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return Laplace.sample(getShape(), mu.getValue(), beta.getValue(), random);
+        return Laplace.withParameters(mu.getValue(), beta.getValue()).sample(getShape(), random);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -7,6 +7,7 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
+import java.util.List;
 import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
@@ -69,15 +70,15 @@ public class LogNormalVertex extends ProbabilisticDouble {
         DoubleTensor muValues = mu.getValue();
         DoubleTensor sigmaValues = sigma.getValue();
 
-        DoubleTensor logPdfs = LogNormal.logPdf(muValues, sigmaValues, value);
+        DoubleTensor logPdfs = LogNormal.withParameters(muValues, sigmaValues).logProb(value);
 
         return logPdfs.sum();
     }
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        LogNormal.Diff dlnP = LogNormal.dlnPdf(mu.getValue(), sigma.getValue(), value);
-        return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPdsigma, dlnP.dPdx);
+        List<DoubleTensor> dlnP = LogNormal.withParameters(mu.getValue(), sigma.getValue()).dLogProb(value);
+        return convertDualNumbersToDiff(dlnP.get(0), dlnP.get(1), dlnP.get(2));
     }
 
     private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdmu,
@@ -97,6 +98,6 @@ public class LogNormalVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return LogNormal.sample(getShape(), mu.getValue(), sigma.getValue(), random);
+        return LogNormal.withParameters(mu.getValue(), sigma.getValue()).sample(getShape(), random);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -7,6 +7,7 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
+import java.util.List;
 import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
@@ -57,15 +58,15 @@ public class LogisticVertex extends ProbabilisticDouble {
         DoubleTensor muValues = mu.getValue();
         DoubleTensor sValues = s.getValue();
 
-        DoubleTensor logPdfs = Logistic.logPdf(muValues, sValues, value);
+        DoubleTensor logPdfs = Logistic.withParameters(muValues, sValues).logProb(value);
 
         return logPdfs.sum();
     }
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor value) {
-        Logistic.Diff dlnP = Logistic.dlnPdf(mu.getValue(), s.getValue(), value);
-        return convertDualNumbersToDiff(dlnP.dPdmu, dlnP.dPds, dlnP.dPdx);
+        List<DoubleTensor> dlnP = Logistic.withParameters(mu.getValue(), s.getValue()).dLogProb(value);
+        return convertDualNumbersToDiff(dlnP.get(0), dlnP.get(1), dlnP.get(2));
     }
 
     private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dPdmu,
@@ -85,6 +86,6 @@ public class LogisticVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return Logistic.sample(getShape(), mu.getValue(), s.getValue(), random);
+        return Logistic.withParameters(mu.getValue(), s.getValue()).sample(getShape(), random);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussian.java
@@ -62,7 +62,7 @@ public class MultivariateGaussian extends ProbabilisticDouble {
         DoubleTensor muValues = mu.getValue();
         DoubleTensor covarianceValues = covariance.getValue();
 
-        return io.improbable.keanu.distributions.continuous.MultivariateGaussian.logPdf(muValues, covarianceValues, value);
+        return io.improbable.keanu.distributions.continuous.MultivariateGaussian.withParameters(muValues, covarianceValues).logProb(value).scalar();
     }
 
     @Override
@@ -72,7 +72,7 @@ public class MultivariateGaussian extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return io.improbable.keanu.distributions.continuous.MultivariateGaussian.sample(mu.getValue(), covariance.getValue(), random);
+        return io.improbable.keanu.distributions.continuous.MultivariateGaussian.withParameters(mu.getValue(), covariance.getValue()).sample(mu.getShape(), random);
     }
 
     private static int[] checkValidMultivariateShape(int[] muShape, int[] covarianceShape) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -8,6 +8,7 @@ import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
@@ -49,19 +50,19 @@ public class StudentTVertex extends ProbabilisticDouble {
 
     @Override
     public double logPdf(DoubleTensor t) {
-        return StudentT.logPdf(v.getValue(), t).sum();
+        return StudentT.withParameters(v.getValue()).logProb(t).sum();
     }
 
     @Override
     public Map<Long, DoubleTensor> dLogPdf(DoubleTensor t) {
-        StudentT.Diff diff = StudentT.dLogPdf(v.getValue(), t);
+        List<DoubleTensor> diff = StudentT.withParameters(v.getValue()).dLogProb(t);
         Map<Long, DoubleTensor> m = new HashMap<>();
-        m.put(getId(), diff.dPdt);
+        m.put(getId(), diff.get(0));
         return m;
     }
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return StudentT.sample(getShape(), v.getValue(), random);
+        return StudentT.withParameters(v.getValue()).sample(getShape(), random);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -103,7 +103,7 @@ public class TriangularVertex extends ProbabilisticDouble {
         DoubleTensor xMaxValues = xMax.getValue();
         DoubleTensor cValues = c.getValue();
 
-        DoubleTensor logPdfs = Triangular.logPdf(xMinValues, xMaxValues, cValues, value);
+        DoubleTensor logPdfs = Triangular.withParameters(xMinValues, xMaxValues, cValues).logProb(value);
         return logPdfs.sum();
     }
 
@@ -114,6 +114,6 @@ public class TriangularVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return Triangular.sample(getShape(), xMin.getValue(), xMax.getValue(), c.getValue(), random);
+        return Triangular.withParameters(xMin.getValue(), xMax.getValue(), c.getValue()).sample(getShape(), random);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -81,7 +81,7 @@ public class UniformVertex extends ProbabilisticDouble {
 
     @Override
     public double logPdf(DoubleTensor value) {
-        return Uniform.logPdf(xMin.getValue(), xMax.getValue(), value).sum();
+        return Uniform.withParameters(xMin.getValue(), xMax.getValue()).logProb(value).sum();
     }
 
     @Override
@@ -96,7 +96,7 @@ public class UniformVertex extends ProbabilisticDouble {
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return Uniform.sample(getShape(), xMin.getValue(), xMax.getValue(), random);
+        return Uniform.withParameters(xMin.getValue(), xMax.getValue()).sample(getShape(), random);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
@@ -57,7 +57,7 @@ public class BinomialVertex extends ProbabilisticInteger {
 
     @Override
     public double logPmf(IntegerTensor kTensor) {
-        return Binomial.logPmf(kTensor, p.getValue(), n.getValue()).sum();
+        return Binomial.withParameters(p.getValue(), n.getValue()).logProb(kTensor).sum();
     }
 
     @Override
@@ -67,6 +67,6 @@ public class BinomialVertex extends ProbabilisticInteger {
 
     @Override
     public IntegerTensor sample(KeanuRandom random) {
-        return Binomial.sample(getShape(), p.getValue(), n.getValue(), random);
+        return Binomial.withParameters(p.getValue(), n.getValue()).sample(getShape(), random);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -64,7 +64,7 @@ public class PoissonVertex extends ProbabilisticInteger {
 
     @Override
     public double logPmf(IntegerTensor value) {
-        return Poisson.logPmf(mu.getValue(), value).sum();
+        return Poisson.withParamters(mu.getValue()).logProb(value).sum();
     }
 
     @Override
@@ -74,6 +74,6 @@ public class PoissonVertex extends ProbabilisticInteger {
 
     @Override
     public IntegerTensor sample(KeanuRandom random) {
-        return Poisson.sample(getShape(), mu.getValue(), random);
+        return Poisson.withParamters(mu.getValue()).sample(getShape(), random);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -36,7 +36,7 @@ public class ExponentialVertexTest {
         DoubleTensor matrixA = Nd4jDoubleTensor.create(new double[]{1, 4}, new int[]{2, 1});
         DoubleTensor matrixX = Nd4jDoubleTensor.create(new double[]{2, 2}, new int[]{2, 1});
 
-        DoubleTensor maskResult = Exponential.logPdf(matrixA, new ScalarDoubleTensor(1.0), matrixX);
+        DoubleTensor maskResult = Exponential.withParameters(matrixA, new ScalarDoubleTensor(1.0)).logProb(matrixX);
         assertArrayEquals(new double[]{-1, Double.NEGATIVE_INFINITY}, maskResult.asFlatDoubleArray(), 0.0);
     }
 


### PR DESCRIPTION
This PR creates an interface for the Distribution classes. It will also help to make my next refactor job easier (Vertex classes).

There are 2 interfaces, `DiscreteDistribution` and `ContinuousDistribution`. The latter has an extra method `dLogProb`.

There is a consistent static factory method for each class, `withParameters`. 