### PR TITLE
Vertex concatenation

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
@@ -94,13 +94,24 @@ public class TensorShapeValidation {
     }
 
     public static int[] checkShapesCanBeConcatenated(int dimension, int[]... shapes) {
-        int[][] trimmedShapes = new int[shapes.length][];
-        for (int i = 0; i < shapes.length; i++) {
-            int[] trimmedShape = new int[shapes[i].length - 1];
-            System.arraycopy(shapes[i], dimension + 1, trimmedShape, dimension, shapes[i].length - 1 - dimension);
-            trimmedShapes[i] = trimmedShape;
+        int[] concatShape = Arrays.copyOf(shapes[0], shapes[0].length);
+        
+        for (int i = 1; i < shapes.length; i++) {
+            if (shapes[i].length != concatShape.length) {
+                throw new IllegalArgumentException("Cannot concat shapes of different ranks");
+            }
+
+            for (int dim = 0; dim < shapes[i].length; dim++) {
+                if (dim == dimension) {
+                    concatShape[dim] += shapes[i][dim];
+                } else {
+                    if (shapes[i][dim] != concatShape[dim]) {
+                        throw new IllegalArgumentException("Cannot concat mismatched shapes");
+                    }
+                }
+            }
         }
-        return checkAllShapesMatch(trimmedShapes);
+        return concatShape;
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.tensor;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -88,6 +91,16 @@ public class TensorShapeValidation {
         }
 
         return uniqueShapes.iterator().next().getShape();
+    }
+
+    public static int[] checkShapesCanBeConcatenated(int dimension, int[]... shapes) {
+        int[][] trimmedShapes = new int[shapes.length][];
+        for (int i = 0; i < shapes.length; i++) {
+            int[] trimmedShape = new int[shapes[i].length - 1];
+            System.arraycopy(shapes[i], dimension + 1, trimmedShape, dimension, shapes[i].length - 1 - dimension);
+            trimmedShapes[i] = trimmedShape;
+        }
+        return checkAllShapesMatch(trimmedShapes);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/BooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/BooleanTensor.java
@@ -57,4 +57,6 @@ public interface BooleanTensor extends Tensor<Boolean> {
 
     IntegerTensor toIntegerMask();
 
+    BooleanTensor concat(int dimension, BooleanTensor... those);
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
@@ -201,6 +201,26 @@ public class SimpleBooleanTensor implements BooleanTensor {
     }
 
     @Override
+    public BooleanTensor concat(int dimension, BooleanTensor... those) {
+        DoubleTensor[] toDoubles = new DoubleTensor[those.length];
+        DoubleTensor primary = this.toDoubleMask();
+
+        for (int i = 0; i < those.length; i++) {
+            toDoubles[i] = those[i].toDoubleMask();
+        }
+
+        DoubleTensor concat = primary.concat(dimension, toDoubles);
+        double[] concatFlat = concat.asFlatDoubleArray();
+        boolean[] data = new boolean[concat.asFlatDoubleArray().length];
+
+        for (int i = 0; i < data.length; i++) {
+            data[i] = concatFlat[i] == 1.0;
+        }
+
+        return new SimpleBooleanTensor(data, concat.getShape());
+    }
+
+    @Override
     public int getRank() {
         return shape.length;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -174,6 +174,8 @@ public interface DoubleTensor extends NumberTensor<Double> {
 
     double determinant();
 
+    DoubleTensor concat(int dimension, DoubleTensor... those);
+
     //In place Ops and Transforms. These mutate the source vertex (i.e. this).
 
     DoubleTensor reciprocalInPlace();

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.tensor.dbl;
 import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
 
 import java.util.Arrays;
 import java.util.function.Function;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -772,6 +772,18 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         return new LUDecomposition(matrix).getDeterminant();
     }
 
+    @Override
+    public DoubleTensor concat(int dimension, DoubleTensor... those) {
+        INDArray dup = tensor.dup();
+        INDArray[] toConcat = new INDArray[those.length + 1];
+        toConcat[0] = dup;
+        for (int i = 1; i <= those.length; i++) {
+            toConcat[i] = unsafeGetNd4J(those[i - 1]);
+        }
+        INDArray concat = Nd4j.concat(dimension, toConcat);
+        return new Nd4jDoubleTensor(concat);
+    }
+
     // Comparisons
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -395,8 +395,7 @@ public class ScalarDoubleTensor implements DoubleTensor {
 
     @Override
     public DoubleTensor concat(int dimension, DoubleTensor... those) {
-        //todo
-        return null;
+        return Nd4jDoubleTensor.scalar(value).concat(dimension, those);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -394,6 +394,12 @@ public class ScalarDoubleTensor implements DoubleTensor {
     }
 
     @Override
+    public DoubleTensor concat(int dimension, DoubleTensor... those) {
+        //todo
+        return null;
+    }
+
+    @Override
     public DoubleTensor reciprocalInPlace() {
         value = 1.0 / value;
         return this;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
@@ -121,6 +121,8 @@ public interface IntegerTensor extends NumberTensor<Integer>, IntegerOperators<I
 
     IntegerTensor apply(Function<Integer, Integer> function);
 
+    IntegerTensor concat(int dimension, IntegerTensor... those);
+
     // In Place
 
     IntegerTensor minusInPlace(int value);

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -282,6 +282,18 @@ public class Nd4jIntegerTensor implements IntegerTensor {
     }
 
     @Override
+    public IntegerTensor concat(int dimension, IntegerTensor... those) {
+        INDArray dup = tensor.dup();
+        INDArray[] toConcat = new INDArray[those.length + 1];
+        toConcat[0] = dup;
+        for (int i = 1; i <= those.length; i++) {
+            toConcat[i] = unsafeGetNd4J(those[i - 1]);
+        }
+        INDArray concat = Nd4j.concat(dimension, toConcat);
+        return new Nd4jIntegerTensor(concat);
+    }
+
+    @Override
     public IntegerTensor minusInPlace(int value) {
         tensor.subi(value);
         return this;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -29,7 +29,7 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         return new Nd4jIntegerTensor(values, shape);
     }
 
-    public static Nd4jIntegerTensor create(double value, int[] shape) {
+    public static Nd4jIntegerTensor create(int value, int[] shape) {
         return new Nd4jIntegerTensor(Nd4j.valueArrayOf(shape, value));
     }
 
@@ -583,7 +583,7 @@ public class Nd4jIntegerTensor implements IntegerTensor {
 
     private INDArray unsafeGetNd4J(IntegerTensor that) {
         if (that.isScalar()) {
-            Nd4j.scalar(that.scalar().doubleValue()).reshape(that.getShape());
+            return Nd4j.scalar(that.scalar().doubleValue()).reshape(that.getShape());
         }
         return ((Nd4jIntegerTensor) that).tensor;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensor.java
@@ -245,6 +245,11 @@ public class ScalarIntegerTensor implements IntegerTensor {
     }
 
     @Override
+    public IntegerTensor concat(int dimension, IntegerTensor... those) {
+        return Nd4jIntegerTensor.scalar(value).concat(dimension, those);
+    }
+
+    @Override
     public IntegerTensor minusInPlace(int that) {
         value = value - that;
         return this;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertex.java
@@ -41,8 +41,9 @@ public class BoolConcatenationVertex extends NonProbabilisticBool {
     }
 
     protected BooleanTensor op(BooleanTensor... inputs) {
+        BooleanTensor primary = inputs[0];
         BooleanTensor[] toConcat = Arrays.copyOfRange(inputs, 1, inputs.length);
-        return inputs[0].concat(dimension, toConcat);
+        return primary.concat(dimension, toConcat);
     }
 
     private BooleanTensor[] extractFromInputs(Function<Integer, BooleanTensor> func) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertex.java
@@ -1,0 +1,56 @@
+package io.improbable.keanu.vertices.bool.nonprobabilistic.operators.multiple;
+
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.vertices.bool.BoolVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.NonProbabilisticBool;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
+
+public class BoolConcatenationVertex extends NonProbabilisticBool {
+
+    private final int dimension;
+    private final BoolVertex[] input;
+
+    /**
+     * A vertex that can concatenate any amount of vertices along a given dimension.
+     *
+     * @param dimension the dimension to concatenate on. This is the only dimension in which sizes may be different.
+     * @param input the input vertices to concatenate
+     */
+    public BoolConcatenationVertex(int dimension, BoolVertex... input) {
+        this.dimension = dimension;
+        this.input = input;
+        setParents(input);
+        int[][] shapes = new int[input.length][];
+        for (int i = 0; i < input.length; i++) shapes[i] = input[i].getShape();
+        setValue(BooleanTensor.placeHolder(checkShapesCanBeConcatenated(dimension, shapes)));
+    }
+
+    @Override
+    public BooleanTensor getDerivedValue() {
+        return op(extractFromInputs(i -> input[i].getValue()));
+    }
+
+    @Override
+    public BooleanTensor sample(KeanuRandom random) {
+        return op(extractFromInputs(i -> input[i].sample()));
+    }
+
+    protected BooleanTensor op(BooleanTensor... inputs) {
+        BooleanTensor[] toConcat = Arrays.copyOfRange(inputs, 1, inputs.length);
+        return inputs[0].concat(dimension, toConcat);
+    }
+
+    private BooleanTensor[] extractFromInputs(Function<Integer, BooleanTensor> func) {
+        BooleanTensor[] extract = new BooleanTensor[input.length];
+        for (int i = 0; i < input.length; i++) {
+            extract[i] = func.apply(i);
+        }
+        return extract;
+    }
+
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
@@ -2,9 +2,9 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
 
 public class DualNumber {
 
@@ -286,5 +286,28 @@ public class DualNumber {
         PartialDerivatives reshapedPartialDerivatives = this.partialDerivatives.reshape(getValue().getRank(), proposedShape);
         return new DualNumber(value.reshape(proposedShape), reshapedPartialDerivatives);
     }
+
+    public DualNumber concat(int dimension, Map<Long, List<DoubleTensor>> combinedPartialDerivatives, DoubleTensor... toConcat) {
+        Map<Long, DoubleTensor> concatenatedPartialDerivates = new HashMap<>();
+
+        for (Map.Entry<Long, List<DoubleTensor>> partials : combinedPartialDerivatives.entrySet()) {
+            concatenatedPartialDerivates.put(partials.getKey(), concatPartialDerivates(dimension, partials.getValue()));
+        }
+
+        DoubleTensor concatValue = this.getValue().concat(dimension, toConcat);
+        return new DualNumber(concatValue, concatenatedPartialDerivates);
+
+    }
+
+    private DoubleTensor concatPartialDerivates(int dimension, List<DoubleTensor> partialDerivates) {
+        if (partialDerivates.size() == 1) {
+            return partialDerivates.get(0);
+        } else {
+            DoubleTensor primaryTensor = partialDerivates.remove(0);
+            DoubleTensor[] derivativesToConcat = new DoubleTensor[partialDerivates.size()];
+            return primaryTensor.concat(dimension, partialDerivates.toArray(derivativesToConcat));
+        }
+    }
+
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -268,4 +269,5 @@ public class PartialDerivatives {
             TensorShape.shapeDesiredToRankByAppendingOnes(lowRankTensor.getShape(), desiredRank)
         );
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -1,0 +1,54 @@
+package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.NonProbabilisticDouble;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class ConcatenationVertex extends NonProbabilisticDouble {
+
+    private final int dimension;
+    private final DoubleVertex[] input;
+
+    public ConcatenationVertex(int dimension, DoubleVertex... input) {
+        this.dimension = dimension;
+        this.input = input;
+        setParents(input);
+        //todo - calc shape
+        setValue(DoubleTensor.placeHolder(new int[]{5, 4}));
+    }
+
+    @Override
+    public DoubleTensor getDerivedValue() {
+        DoubleTensor[] tensors = new DoubleTensor[input.length];
+        for (int i = 0; i < input.length; i++) {
+            tensors[i] = input[i].getValue();
+        }
+        DoubleTensor value = op(tensors);
+        return value;
+    }
+
+    @Override
+    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+        return null;
+    }
+
+    @Override
+    public DoubleTensor sample(KeanuRandom random) {
+        DoubleTensor[] tensors = new DoubleTensor[input.length];
+        for (int i = 0; i < input.length; i++) {
+            tensors[i] = input[i].sample(random);
+        }
+        return op(tensors);
+    }
+
+    protected DoubleTensor op(DoubleTensor... inputs) {
+        DoubleTensor[] toConcat = Arrays.copyOfRange(inputs, 1, inputs.length);
+        return inputs[0].concat(dimension, toConcat);
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -48,8 +48,8 @@ public class ConcatenationVertex extends NonProbabilisticDouble {
             }
         }
 
-        for (Map.Entry<Long, List<DoubleTensor>> partial : partialDerivates.entrySet()) {
-            concatDerivates.put(partial.getKey(), concatPartialDerivates(partial.getValue()));
+        for (Map.Entry<Long, List<DoubleTensor>> partials : partialDerivates.entrySet()) {
+            concatDerivates.put(partials.getKey(), concatPartialDerivates(partials.getValue()));
         }
 
         return new DualNumber(dualNumbers.get(input[0]).getValue(), concatDerivates);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertex.java
@@ -13,14 +13,14 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class DoubleReduceVertex extends NonProbabilisticDouble {
+public class ReduceVertex extends NonProbabilisticDouble {
     private final List<? extends Vertex<DoubleTensor>> inputs;
     private final BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f;
     private final Supplier<DualNumber> dualNumberSupplier;
 
-    public DoubleReduceVertex(int[] shape, Collection<? extends Vertex<DoubleTensor>> inputs, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f, Supplier<DualNumber> dualNumberSupplier) {
+    public ReduceVertex(int[] shape, Collection<? extends Vertex<DoubleTensor>> inputs, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f, Supplier<DualNumber> dualNumberSupplier) {
         if (inputs.size() < 2) {
-            throw new IllegalArgumentException("DoubleReduceVertex should have at least two input vertices, called with " + inputs.size());
+            throw new IllegalArgumentException("ReduceVertex should have at least two input vertices, called with " + inputs.size());
         }
 
         this.inputs = new ArrayList<>(inputs);
@@ -30,11 +30,11 @@ public class DoubleReduceVertex extends NonProbabilisticDouble {
         setValue(DoubleTensor.placeHolder(shape));
     }
 
-    public DoubleReduceVertex(int[] shape, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f, Supplier<DualNumber> dualNumberSupplier, Vertex<DoubleTensor>... input) {
+    public ReduceVertex(int[] shape, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f, Supplier<DualNumber> dualNumberSupplier, Vertex<DoubleTensor>... input) {
         this(shape, Arrays.asList(input), f, dualNumberSupplier);
     }
 
-    public DoubleReduceVertex(int[] shape, List<? extends Vertex<DoubleTensor>> inputs, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f) {
+    public ReduceVertex(int[] shape, List<? extends Vertex<DoubleTensor>> inputs, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f) {
         this(shape, inputs, f, null);
     }
 
@@ -45,7 +45,7 @@ public class DoubleReduceVertex extends NonProbabilisticDouble {
      * @param dualNumberSupplier auto diff supplier
      * @param input              input vertices to reduce
      */
-    public DoubleReduceVertex(BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f, Supplier<DualNumber> dualNumberSupplier, Vertex<DoubleTensor>... input) {
+    public ReduceVertex(BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f, Supplier<DualNumber> dualNumberSupplier, Vertex<DoubleTensor>... input) {
         this(TensorShapeValidation.checkAllShapesMatch(Arrays.stream(input).map(Vertex::getShape).collect(Collectors.toList())),
             Arrays.asList(input), f, dualNumberSupplier);
     }
@@ -56,7 +56,7 @@ public class DoubleReduceVertex extends NonProbabilisticDouble {
      * @param f      reduce function
      * @param inputs input vertices to reduce
      */
-    public DoubleReduceVertex(List<? extends Vertex<DoubleTensor>> inputs, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f) {
+    public ReduceVertex(List<? extends Vertex<DoubleTensor>> inputs, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> f) {
         this(TensorShapeValidation.checkAllShapesMatch(inputs.stream().map(Vertex::getShape).collect(Collectors.toList())),
             inputs, f, null
         );

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertex.java
@@ -41,8 +41,9 @@ public class IntegerConcatenationVertex extends NonProbabilisticInteger {
     }
 
     protected IntegerTensor op(IntegerTensor... inputs) {
+        IntegerTensor primary = inputs[0];
         IntegerTensor[] toConcat = Arrays.copyOfRange(inputs, 1, inputs.length);
-        return inputs[0].concat(dimension, toConcat);
+        return primary.concat(dimension, toConcat);
     }
 
     private IntegerTensor[] extractFromInputs(Function<Integer, IntegerTensor> func) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertex.java
@@ -1,0 +1,56 @@
+package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.multiple;
+
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.intgr.IntegerVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.NonProbabilisticInteger;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
+
+public class IntegerConcatenationVertex extends NonProbabilisticInteger {
+
+    private final int dimension;
+    private final IntegerVertex[] input;
+
+    /**
+     * A vertex that can concatenate any amount of vertices along a given dimension.
+     *
+     * @param dimension the dimension to concatenate on. This is the only dimension in which sizes may be different.
+     * @param input the input vertices to concatenate
+     */
+    public IntegerConcatenationVertex(int dimension, IntegerVertex... input) {
+        this.dimension = dimension;
+        this.input = input;
+        setParents(input);
+        int[][] shapes = new int[input.length][];
+        for (int i = 0; i < input.length; i++) shapes[i] = input[i].getShape();
+        setValue(IntegerTensor.placeHolder(checkShapesCanBeConcatenated(dimension, shapes)));
+    }
+
+    @Override
+    public IntegerTensor getDerivedValue() {
+        return op(extractFromInputs(i -> input[i].getValue()));
+    }
+
+    @Override
+    public IntegerTensor sample(KeanuRandom random) {
+        return op(extractFromInputs(i -> input[i].sample()));
+    }
+
+    protected IntegerTensor op(IntegerTensor... inputs) {
+        IntegerTensor[] toConcat = Arrays.copyOfRange(inputs, 1, inputs.length);
+        return inputs[0].concat(dimension, toConcat);
+    }
+
+    private IntegerTensor[] extractFromInputs(Function<Integer, IntegerTensor> func) {
+        IntegerTensor[] extract = new IntegerTensor[input.length];
+        for (int i = 0; i < input.length; i++) {
+            extract[i] = func.apply(i);
+        }
+        return extract;
+    }
+
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertexTest.java
@@ -1,0 +1,108 @@
+package io.improbable.keanu.vertices.bool.nonprobabilistic.operators.multiple;
+
+import io.improbable.keanu.tensor.bool.SimpleBooleanTensor;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BoolConcatenationVertexTest {
+
+    @Test
+    public void canConcatVectorsOfSameSize() {
+        ConstantBoolVertex a = new ConstantBoolVertex(new boolean[]{true, true, true});
+        ConstantBoolVertex b = new ConstantBoolVertex(new boolean[]{false, false, false});
+        ConstantBoolVertex c = new ConstantBoolVertex(new boolean[]{true, true, true});
+
+        BoolConcatenationVertex concatZero = new BoolConcatenationVertex(0, a, b);
+        BoolConcatenationVertex concatOne = new BoolConcatenationVertex(1, a, b, c);
+
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0, 1, 1, 1}, concatOne.getValue().asFlatDoubleArray(), 0.001);
+
+        Assert.assertArrayEquals(new int[]{2, 3}, concatZero.getShape());
+        Assert.assertArrayEquals(new int[]{1, 9}, concatOne.getShape());
+    }
+
+    @Test
+    public void canConcatVectorsOfDifferentSize() {
+        ConstantBoolVertex a = new ConstantBoolVertex(new boolean[]{true, true, true});
+        ConstantBoolVertex b = new ConstantBoolVertex(new boolean[]{false, false, false, false, false, false});
+
+        BoolConcatenationVertex concatZero = new BoolConcatenationVertex(1, a, b);
+
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{1, 9}, concatZero.getShape());
+    }
+
+    @Test
+    public void canConcatScalarToVector() {
+        ConstantBoolVertex a = new ConstantBoolVertex(new boolean[]{true, true, true});
+        ConstantBoolVertex b = new ConstantBoolVertex(false);
+
+        BoolConcatenationVertex concat = new BoolConcatenationVertex(1, a, b);
+
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 0}, concat.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+    }
+
+    @Test
+    public void canConcatVectorToScalar() {
+        ConstantBoolVertex a = new ConstantBoolVertex(false);
+        ConstantBoolVertex b = new ConstantBoolVertex(new boolean[]{true, true, true});
+
+        BoolConcatenationVertex concat = new BoolConcatenationVertex(1, a, b);
+
+        Assert.assertArrayEquals(new double[]{0, 1, 1, 1}, concat.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void errorThrownOnConcatOfWrongSize() {
+        ConstantBoolVertex a = new ConstantBoolVertex(new boolean[]{true, true, true});
+        ConstantBoolVertex b = new ConstantBoolVertex(new boolean[]{false, false});
+
+        new BoolConcatenationVertex(0, a, b);
+    }
+
+    @Test
+    public void canConcatMatricesOfSameSize() {
+        ConstantBoolVertex m = new ConstantBoolVertex(new SimpleBooleanTensor(new boolean[]{true, true, true, true}, new int[]{2, 2}));
+        ConstantBoolVertex a = new ConstantBoolVertex(new SimpleBooleanTensor(new boolean[]{false, false, false, false}, new int[]{2, 2}));
+
+        BoolConcatenationVertex concatZero = new BoolConcatenationVertex(0, m, a);
+
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 1, 0, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{4, 2}, concatZero.getShape());
+
+        BoolConcatenationVertex concatOne = new BoolConcatenationVertex(1, m, a);
+
+        Assert.assertArrayEquals(new double[]{1, 1, 0, 0, 1, 1, 0, 0}, concatOne.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{2, 4}, concatOne.getShape());
+    }
+
+    @Test
+    public void canConcatHighDimensionalShapes() {
+        ConstantBoolVertex a = new ConstantBoolVertex(
+            new SimpleBooleanTensor(new boolean[]{true, true, true, true, true, true, true, true}, new int[]{2, 2, 2}));
+        ConstantBoolVertex b = new ConstantBoolVertex(
+            new SimpleBooleanTensor(new boolean[]{false, false, false, false, false, false, false, false}, new int[]{2, 2, 2}));
+
+        BoolConcatenationVertex concatZero = new BoolConcatenationVertex(0, a, b);
+
+        Assert.assertArrayEquals(
+            new double[]{1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+            concatZero.getValue().asFlatDoubleArray(),
+            0.001
+        );
+        Assert.assertArrayEquals(new int[]{4, 2, 2}, concatZero.getShape());
+
+        BoolConcatenationVertex concatThree = new BoolConcatenationVertex(2, a, b);
+        Assert.assertArrayEquals(
+            new double[]{1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0},
+            concatThree.getValue().asFlatDoubleArray(),
+            0.001
+        );
+        Assert.assertArrayEquals(new int[]{2, 2, 4}, concatThree.getShape());
+    }
+
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertexTest.java
@@ -16,11 +16,11 @@ public class BoolConcatenationVertexTest {
         BoolConcatenationVertex concatZero = new BoolConcatenationVertex(0, a, b);
         BoolConcatenationVertex concatOne = new BoolConcatenationVertex(1, a, b, c);
 
-        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
-        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0, 1, 1, 1}, concatOne.getValue().asFlatDoubleArray(), 0.001);
-
         Assert.assertArrayEquals(new int[]{2, 3}, concatZero.getShape());
         Assert.assertArrayEquals(new int[]{1, 9}, concatOne.getShape());
+
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0, 1, 1, 1}, concatOne.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -30,8 +30,8 @@ public class BoolConcatenationVertexTest {
 
         BoolConcatenationVertex concatZero = new BoolConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 9}, concatZero.getShape());
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 0, 0, 0, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -41,8 +41,8 @@ public class BoolConcatenationVertexTest {
 
         BoolConcatenationVertex concat = new BoolConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 1, 1, 0}, concat.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 0}, concat.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -52,8 +52,8 @@ public class BoolConcatenationVertexTest {
 
         BoolConcatenationVertex concat = new BoolConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{0, 1, 1, 1}, concat.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+        Assert.assertArrayEquals(new double[]{0, 1, 1, 1}, concat.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -71,13 +71,13 @@ public class BoolConcatenationVertexTest {
 
         BoolConcatenationVertex concatZero = new BoolConcatenationVertex(0, m, a);
 
-        Assert.assertArrayEquals(new double[]{1, 1, 1, 1, 0, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{4, 2}, concatZero.getShape());
+        Assert.assertArrayEquals(new double[]{1, 1, 1, 1, 0, 0, 0, 0}, concatZero.getValue().asFlatDoubleArray(), 0.001);
 
         BoolConcatenationVertex concatOne = new BoolConcatenationVertex(1, m, a);
 
-        Assert.assertArrayEquals(new double[]{1, 1, 0, 0, 1, 1, 0, 0}, concatOne.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{2, 4}, concatOne.getShape());
+        Assert.assertArrayEquals(new double[]{1, 1, 0, 0, 1, 1, 0, 0}, concatOne.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -89,20 +89,21 @@ public class BoolConcatenationVertexTest {
 
         BoolConcatenationVertex concatZero = new BoolConcatenationVertex(0, a, b);
 
+        Assert.assertArrayEquals(new int[]{4, 2, 2}, concatZero.getShape());
         Assert.assertArrayEquals(
             new double[]{1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0},
             concatZero.getValue().asFlatDoubleArray(),
             0.001
         );
-        Assert.assertArrayEquals(new int[]{4, 2, 2}, concatZero.getShape());
 
         BoolConcatenationVertex concatThree = new BoolConcatenationVertex(2, a, b);
+
+        Assert.assertArrayEquals(new int[]{2, 2, 4}, concatThree.getShape());
         Assert.assertArrayEquals(
             new double[]{1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0},
             concatThree.getValue().asFlatDoubleArray(),
             0.001
         );
-        Assert.assertArrayEquals(new int[]{2, 2, 4}, concatThree.getShape());
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -1,7 +1,9 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.ScalarDoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
@@ -45,6 +47,32 @@ public class ConcatenationVertexTest {
 
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 9}, concatZero.getShape());
+    }
+
+    @Test
+    public void canConcatScalarToVector() {
+        UniformVertex a = new UniformVertex(0.0, 1.0);
+        a.setValue(new double[]{1, 2, 3});
+
+        DoubleVertex b = new ConstantDoubleVertex(4.0);
+
+        ConcatenationVertex concat = new ConcatenationVertex(1, a, b);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+    }
+
+    @Test
+    public void canConcatVectorToScalar() {
+        DoubleVertex a = new ConstantDoubleVertex(1.0);
+
+        UniformVertex b = new UniformVertex(0.0, 1.0);
+        b.setValue(new double[]{2, 3, 4});
+
+        ConcatenationVertex concat = new ConcatenationVertex(1, a, b);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
     }
 
     @Test (expected = IllegalArgumentException.class)

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 public class ConcatenationVertexTest {
 
     @Test
-    public void canConcatVectors() {
+    public void canConcatVectorsOfSameSize() {
         UniformVertex a = new UniformVertex(0.0, 1.0);
         a.setValue(new double[]{1, 2, 3});
 
@@ -26,6 +26,36 @@ public class ConcatenationVertexTest {
 
         Assert.assertArrayEquals(new int[]{2, 3}, concatAlongZero.getShape());
         Assert.assertArrayEquals(new int[]{1, 9}, concatAlongOne.getShape());
+    }
+
+    @Test
+    public void canConcatVectorsOfDifferentSize() {
+        UniformVertex a = new UniformVertex(0.0, 1.0);
+        a.setValue(new double[]{1, 2, 3});
+
+        UniformVertex a1 = new UniformVertex(0.0, 1.0);
+        a1.setValue(new double[]{4, 5, 6, 7, 8, 9});
+
+        ConcatenationVertex concatAlongZero = new ConcatenationVertex(1, a, a1);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatAlongZero.getValue().asFlatDoubleArray(), 0.001);
+
+        Assert.assertArrayEquals(new int[]{1, 9}, concatAlongZero.getShape());
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void errorThrownOnConcatOfWrongSize() {
+        UniformVertex a = new UniformVertex(0.0, 1.0);
+        a.setValue(new double[]{1, 2, 3});
+
+        UniformVertex a1 = new UniformVertex(0.0, 1.0);
+        a1.setValue(new double[]{4, 5, 6, 7, 8, 9});
+
+        ConcatenationVertex concatAlongZero = new ConcatenationVertex(0, a, a1);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatAlongZero.getValue().asFlatDoubleArray(), 0.001);
+
+        Assert.assertArrayEquals(new int[]{1, 9}, concatAlongZero.getShape());
     }
 
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -1,5 +1,8 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Assert;
@@ -39,7 +42,6 @@ public class ConcatenationVertexTest {
         ConcatenationVertex concatAlongZero = new ConcatenationVertex(1, a, a1);
 
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatAlongZero.getValue().asFlatDoubleArray(), 0.001);
-
         Assert.assertArrayEquals(new int[]{1, 9}, concatAlongZero.getShape());
     }
 
@@ -54,10 +56,130 @@ public class ConcatenationVertexTest {
         ConcatenationVertex concatAlongZero = new ConcatenationVertex(0, a, a1);
 
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatAlongZero.getValue().asFlatDoubleArray(), 0.001);
-
         Assert.assertArrayEquals(new int[]{1, 9}, concatAlongZero.getShape());
     }
 
+    @Test
+    public void canConcatMatricesOfSameSize() {
+        DoubleVertex m = new UniformVertex(0, 10);
+        m.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+
+        DoubleVertex a = new UniformVertex(0, 10);
+        a.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
+
+        ConcatenationVertex concatZero = new ConcatenationVertex(0, m, a);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 10, 15, 20, 25}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{4, 2}, concatZero.getShape());
+
+        ConcatenationVertex concatOne = new ConcatenationVertex(1, m, a);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 10, 15, 3, 4, 20, 25}, concatOne.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{2, 4}, concatOne.getShape());
+
+    }
+
+    @Test
+    public void canConcatenateSimpleAutoDiff() {
+        DoubleVertex a = new UniformVertex(0, 10);
+        a.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
+
+        DoubleVertex b = new UniformVertex(0, 10);
+        b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
+
+        DoubleVertex c = a.times(b);
+        DoubleVertex d = a.plus(b);
+
+        ConcatenationVertex concat = new ConcatenationVertex(0, c, d);
+        PartialDerivatives concatPartial = concat.getDualNumber().getPartialDerivatives();
+
+        PartialDerivatives cPartial = c.getDualNumber().getPartialDerivatives();
+        PartialDerivatives dPartial = d.getDualNumber().getPartialDerivatives();
+
+        Assert.assertArrayEquals(
+            cPartial.withRespectTo(a).concat(0, dPartial.withRespectTo(a)).asFlatDoubleArray(),
+            concatPartial.withRespectTo(a).asFlatDoubleArray(),
+            0.0001
+        );
+        Assert.assertArrayEquals(
+            cPartial.withRespectTo(b).concat(0, dPartial.withRespectTo(b)).asFlatDoubleArray(),
+            concatPartial.withRespectTo(b).asFlatDoubleArray(),
+            0.0001
+        );
+    }
 
 
+    @Test
+    public void canConcatenateAutoDiffMatricesAlongDimensionZero() {
+        DoubleVertex sharedMatrix = new UniformVertex(0, 10);
+        sharedMatrix.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+
+        DoubleVertex a = new UniformVertex(0, 10);
+        a.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
+
+        DoubleVertex b = new UniformVertex(0, 10);
+        b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
+
+        DoubleVertex c = sharedMatrix.matrixMultiply(a);
+        DoubleVertex d = sharedMatrix.matrixMultiply(b);
+
+        DoubleTensor dCdshared = c.getDualNumber().getPartialDerivatives().withRespectTo(sharedMatrix);
+        DoubleTensor dDdshared = d.getDualNumber().getPartialDerivatives().withRespectTo(sharedMatrix);
+
+        ConcatenationVertex concat = new ConcatenationVertex(0, c, d);
+        PartialDerivatives concatPartial = concat.getDualNumber().getPartialDerivatives();
+
+        Assert.assertArrayEquals(
+            dCdshared.concat(0, dDdshared).asFlatDoubleArray(),
+            concatPartial.withRespectTo(sharedMatrix).asFlatDoubleArray(),
+            0.0001
+        );
+        Assert.assertArrayEquals(
+            c.getDualNumber().getPartialDerivatives().withRespectTo(a).asFlatDoubleArray(),
+            concatPartial.withRespectTo(a).asFlatDoubleArray(),
+            0.0001
+        );
+        Assert.assertArrayEquals(
+            d.getDualNumber().getPartialDerivatives().withRespectTo(b).asFlatDoubleArray(),
+            concatPartial.withRespectTo(b).asFlatDoubleArray(),
+            0.0001
+        );
+    }
+
+    @Test
+    public void canConcatenateAutoDiffMatricesAlongDimensionOne() {
+        DoubleVertex sharedMatrix = new UniformVertex(0, 10);
+        sharedMatrix.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+
+        DoubleVertex a = new UniformVertex(0, 10);
+        a.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
+
+        DoubleVertex b = new UniformVertex(0, 10);
+        b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
+
+        DoubleVertex c = sharedMatrix.matrixMultiply(a);
+        DoubleVertex d = sharedMatrix.matrixMultiply(b);
+
+        DoubleTensor dCdshared = c.getDualNumber().getPartialDerivatives().withRespectTo(sharedMatrix);
+        DoubleTensor dDdshared = d.getDualNumber().getPartialDerivatives().withRespectTo(sharedMatrix);
+
+        ConcatenationVertex concat = new ConcatenationVertex(1, c, d);
+        PartialDerivatives concatPartial = concat.getDualNumber().getPartialDerivatives();
+
+        Assert.assertArrayEquals(
+            dCdshared.concat(1, dDdshared).asFlatDoubleArray(),
+            concatPartial.withRespectTo(sharedMatrix).asFlatDoubleArray(),
+            0.0001
+        );
+        Assert.assertArrayEquals(
+            c.getDualNumber().getPartialDerivatives().withRespectTo(a).asFlatDoubleArray(),
+            concatPartial.withRespectTo(a).asFlatDoubleArray(),
+            0.0001
+        );
+        Assert.assertArrayEquals(
+            d.getDualNumber().getPartialDerivatives().withRespectTo(b).asFlatDoubleArray(),
+            concatPartial.withRespectTo(b).asFlatDoubleArray(),
+            0.0001
+        );
+    }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -83,7 +83,7 @@ public class ConcatenationVertexTest {
         UniformVertex a1 = new UniformVertex(0.0, 1.0);
         a1.setValue(new double[]{4, 5, 6, 7, 8, 9});
 
-        ConcatenationVertex concatZero = new ConcatenationVertex(0, a, a1);
+        new ConcatenationVertex(0, a, a1);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -1,0 +1,33 @@
+package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
+
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConcatenationVertexTest {
+
+    @Test
+    public void canConcatVectors() {
+        UniformVertex a = new UniformVertex(0.0, 1.0);
+        a.setValue(new double[]{1, 2, 3});
+
+        UniformVertex a1 = new UniformVertex(0.0, 1.0);
+        a1.setValue(new double[]{4, 5, 6});
+
+        UniformVertex a2 = new UniformVertex(0.0, 1.0);
+        a2.setValue(new double[]{7, 8, 9});
+
+        ConcatenationVertex concatAlongZero = new ConcatenationVertex(0, a, a1);
+        ConcatenationVertex concatAlongOne = new ConcatenationVertex(1, a, a1, a2);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6}, concatAlongZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatAlongOne.getValue().asFlatDoubleArray(), 0.001);
+
+        Assert.assertArrayEquals(new int[]{2, 3}, concatAlongZero.getShape());
+        Assert.assertArrayEquals(new int[]{1, 9}, concatAlongOne.getShape());
+    }
+
+
+
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -84,9 +84,6 @@ public class ConcatenationVertexTest {
         a1.setValue(new double[]{4, 5, 6, 7, 8, 9});
 
         ConcatenationVertex concatZero = new ConcatenationVertex(0, a, a1);
-
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatZero.getValue().asFlatDoubleArray(), 0.001);
-        Assert.assertArrayEquals(new int[]{1, 9}, concatZero.getShape());
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -19,14 +19,14 @@ public class ConcatenationVertexTest {
         UniformVertex a = new UniformVertex(0.0, 1.0);
         a.setValue(new double[]{1, 2, 3});
 
-        UniformVertex a1 = new UniformVertex(0.0, 1.0);
-        a1.setValue(new double[]{4, 5, 6});
+        UniformVertex b = new UniformVertex(0.0, 1.0);
+        b.setValue(new double[]{4, 5, 6});
 
-        UniformVertex a2 = new UniformVertex(0.0, 1.0);
-        a2.setValue(new double[]{7, 8, 9});
+        UniformVertex c = new UniformVertex(0.0, 1.0);
+        c.setValue(new double[]{7, 8, 9});
 
-        ConcatenationVertex concatZero = new ConcatenationVertex(0, a, a1);
-        ConcatenationVertex concatOne = new ConcatenationVertex(1, a, a1, a2);
+        ConcatenationVertex concatZero = new ConcatenationVertex(0, a, b);
+        ConcatenationVertex concatOne = new ConcatenationVertex(1, a, b, c);
 
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatOne.getValue().asFlatDoubleArray(), 0.001);
@@ -40,10 +40,10 @@ public class ConcatenationVertexTest {
         UniformVertex a = new UniformVertex(0.0, 1.0);
         a.setValue(new double[]{1, 2, 3});
 
-        UniformVertex a1 = new UniformVertex(0.0, 1.0);
-        a1.setValue(new double[]{4, 5, 6, 7, 8, 9});
+        UniformVertex b = new UniformVertex(0.0, 1.0);
+        b.setValue(new double[]{4, 5, 6, 7, 8, 9});
 
-        ConcatenationVertex concatZero = new ConcatenationVertex(1, a, a1);
+        ConcatenationVertex concatZero = new ConcatenationVertex(1, a, b);
 
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 9}, concatZero.getShape());
@@ -88,18 +88,18 @@ public class ConcatenationVertexTest {
 
     @Test
     public void canConcatMatricesOfSameSize() {
-        DoubleVertex m = new UniformVertex(0, 10);
-        m.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
-
         DoubleVertex a = new UniformVertex(0, 10);
-        a.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
+        a.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
 
-        ConcatenationVertex concatZero = new ConcatenationVertex(0, m, a);
+        DoubleVertex b = new UniformVertex(0, 10);
+        b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
+
+        ConcatenationVertex concatZero = new ConcatenationVertex(0, a, b);
 
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 10, 15, 20, 25}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{4, 2}, concatZero.getShape());
 
-        ConcatenationVertex concatOne = new ConcatenationVertex(1, m, a);
+        ConcatenationVertex concatOne = new ConcatenationVertex(1, a, b);
 
         Assert.assertArrayEquals(new double[]{1, 2, 10, 15, 3, 4, 20, 25}, concatOne.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{2, 4}, concatOne.getShape());
@@ -122,11 +122,7 @@ public class ConcatenationVertexTest {
         );
         Assert.assertArrayEquals(new int[]{4, 2, 2}, concatZero.getShape());
 
-        System.out.println(concatZero.getValue());
-        ConcatenationVertex concatTwo = new ConcatenationVertex(1, a, b);
-        System.out.println(concatTwo.getValue());
         ConcatenationVertex concatThree = new ConcatenationVertex(2, a, b);
-        System.out.println(concatThree.getValue());
         Assert.assertArrayEquals(
             new double[]{1, 2, 10, 20, 3, 4, 30, 40, 5, 6, 50, 60, 7, 8, 70, 80},
             concatThree.getValue().asFlatDoubleArray(),
@@ -160,6 +156,27 @@ public class ConcatenationVertexTest {
         Assert.assertArrayEquals(
             cPartial.withRespectTo(b).concat(0, dPartial.withRespectTo(b)).asFlatDoubleArray(),
             concatPartial.withRespectTo(b).asFlatDoubleArray(),
+            0.0001
+        );
+    }
+
+    @Test
+    public void canCalculateValueOfConcatenated() {
+        DoubleVertex a = new UniformVertex(0, 10);
+        a.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
+
+        DoubleVertex b = new UniformVertex(0, 10);
+        b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
+
+        DoubleVertex c = a.times(b);
+        DoubleVertex d = a.plus(b);
+
+        ConcatenationVertex concat = new ConcatenationVertex(0, c, d);
+        DoubleTensor dualNumberValue = concat.getDualNumber().getValue();
+
+        Assert.assertArrayEquals(
+            new double[]{50, 90, 140, 200, 15, 21, 27, 33},
+            dualNumberValue.asFlatDoubleArray(),
             0.0001
         );
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -28,11 +28,11 @@ public class ConcatenationVertexTest {
         ConcatenationVertex concatZero = new ConcatenationVertex(0, a, b);
         ConcatenationVertex concatOne = new ConcatenationVertex(1, a, b, c);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6}, concatZero.getValue().asFlatDoubleArray(), 0.001);
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatOne.getValue().asFlatDoubleArray(), 0.001);
-
         Assert.assertArrayEquals(new int[]{2, 3}, concatZero.getShape());
         Assert.assertArrayEquals(new int[]{1, 9}, concatOne.getShape());
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatOne.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -45,8 +45,8 @@ public class ConcatenationVertexTest {
 
         ConcatenationVertex concatZero = new ConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 9}, concatZero.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatZero.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -58,8 +58,8 @@ public class ConcatenationVertexTest {
 
         ConcatenationVertex concat = new ConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -71,8 +71,8 @@ public class ConcatenationVertexTest {
 
         ConcatenationVertex concat = new ConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -96,13 +96,13 @@ public class ConcatenationVertexTest {
 
         ConcatenationVertex concatZero = new ConcatenationVertex(0, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 10, 15, 20, 25}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{4, 2}, concatZero.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 10, 15, 20, 25}, concatZero.getValue().asFlatDoubleArray(), 0.001);
 
         ConcatenationVertex concatOne = new ConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 10, 15, 3, 4, 20, 25}, concatOne.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{2, 4}, concatOne.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 10, 15, 3, 4, 20, 25}, concatOne.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertexTest.java
@@ -30,41 +30,41 @@ public class ReduceVertexTest {
 
     @Test
     public void calculatesSumCorrectly() {
-        DoubleVertex sum = new DoubleReduceVertex(verts, (a, b) -> (a.plus(b)));
+        DoubleVertex sum = new ReduceVertex(verts, (a, b) -> (a.plus(b)));
         assertEquals(sum.eval().scalar(), total, 0.0001);
     }
 
     @Test
     public void calculatesMaxCorrectly() {
-        DoubleVertex max = new DoubleReduceVertex(verts, DoubleTensor::max);
+        DoubleVertex max = new ReduceVertex(verts, DoubleTensor::max);
         assertEquals(max.eval().scalar(), maxValue, 0.0001);
     }
 
     @Test
     public void calculatesMinCorrectly() {
-        DoubleVertex min = new DoubleReduceVertex(verts, DoubleTensor::min);
+        DoubleVertex min = new ReduceVertex(verts, DoubleTensor::min);
         assertEquals(min.eval().scalar(), minValue, 0.0001);
     }
 
     @Test
     public void varargsConstrution() {
-        DoubleVertex max = new DoubleReduceVertex(DoubleTensor::max, null, verts.get(0), verts.get(1));
+        DoubleVertex max = new ReduceVertex(DoubleTensor::max, null, verts.get(0), verts.get(1));
         assertEquals(max.eval().scalar(), Math.max(verts.get(0).eval().scalar(), verts.get(1).eval().scalar()), 0.0001);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void zeroArgThrowsException() {
-        DoubleVertex min = new DoubleReduceVertex(DoubleTensor::max, null);
+        DoubleVertex min = new ReduceVertex(DoubleTensor::max, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void singleArgThrowsException() {
-        DoubleVertex min = new DoubleReduceVertex(DoubleTensor::max, null, verts.get(0));
+        DoubleVertex min = new ReduceVertex(DoubleTensor::max, null, verts.get(0));
     }
 
     @Test
     public void doubleArgExecutesAsExpected() {
-        DoubleVertex min = new DoubleReduceVertex(DoubleTensor::max, null, verts.get(0), verts.get(1));
+        DoubleVertex min = new ReduceVertex(DoubleTensor::max, null, verts.get(0), verts.get(1));
         assertEquals(min.eval().scalar(), Math.max(verts.get(0).eval().scalar(), verts.get(1).eval().scalar()), 0.0);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertexTest.java
@@ -1,0 +1,113 @@
+package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.multiple;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.intgr.Nd4jIntegerTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import io.improbable.keanu.vertices.intgr.IntegerVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IntegerConcatenationVertexTest {
+
+    @Test
+    public void canConcatVectorsOfSameSize() {
+        ConstantIntegerVertex a = new ConstantIntegerVertex(new int[]{1, 2, 3});
+        ConstantIntegerVertex b = new ConstantIntegerVertex(new int[]{4, 5, 6});
+        ConstantIntegerVertex c = new ConstantIntegerVertex(new int[]{7, 8, 9});
+
+        IntegerConcatenationVertex concatZero = new IntegerConcatenationVertex(0, a, b);
+        IntegerConcatenationVertex concatOne = new IntegerConcatenationVertex(1, a, b, c);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatOne.getValue().asFlatDoubleArray(), 0.001);
+
+        Assert.assertArrayEquals(new int[]{2, 3}, concatZero.getShape());
+        Assert.assertArrayEquals(new int[]{1, 9}, concatOne.getShape());
+    }
+
+    @Test
+    public void canConcatVectorsOfDifferentSize() {
+        ConstantIntegerVertex a = new ConstantIntegerVertex(new int[]{1, 2, 3});
+        ConstantIntegerVertex b = new ConstantIntegerVertex(new int[]{4, 5, 6, 7, 8, 9});
+
+        IntegerConcatenationVertex concatZero = new IntegerConcatenationVertex(1, a, b);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{1, 9}, concatZero.getShape());
+    }
+
+    @Test
+    public void canConcatScalarToVector() {
+        ConstantIntegerVertex a = new ConstantIntegerVertex(new int[]{1, 2, 3});
+        ConstantIntegerVertex b = new ConstantIntegerVertex(4);
+
+        IntegerConcatenationVertex concat = new IntegerConcatenationVertex(1, a, b);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+    }
+
+    @Test
+    public void canConcatVectorToScalar() {
+        ConstantIntegerVertex a = new ConstantIntegerVertex(1);
+        ConstantIntegerVertex b = new ConstantIntegerVertex(new int[]{2, 3, 4});
+
+        IntegerConcatenationVertex concat = new IntegerConcatenationVertex(1, a, b);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void errorThrownOnConcatOfWrongSize() {
+        ConstantIntegerVertex a = new ConstantIntegerVertex(new int[]{1, 2, 3});
+        ConstantIntegerVertex b = new ConstantIntegerVertex(new int[]{4, 5, 6, 7, 8, 9});
+
+        new IntegerConcatenationVertex(0, a, b);
+    }
+
+    @Test
+    public void canConcatMatricesOfSameSize() {
+        IntegerVertex m = new ConstantIntegerVertex(Nd4jIntegerTensor.create(new int[]{1, 2, 3, 4}, new int[]{2, 2}));
+        IntegerVertex a = new ConstantIntegerVertex(Nd4jIntegerTensor.create(new int[]{10, 15, 20, 25}, new int[]{2, 2}));
+
+        IntegerConcatenationVertex concatZero = new IntegerConcatenationVertex(0, m, a);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 10, 15, 20, 25}, concatZero.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{4, 2}, concatZero.getShape());
+
+        IntegerConcatenationVertex concatOne = new IntegerConcatenationVertex(1, m, a);
+
+        Assert.assertArrayEquals(new double[]{1, 2, 10, 15, 3, 4, 20, 25}, concatOne.getValue().asFlatDoubleArray(), 0.001);
+        Assert.assertArrayEquals(new int[]{2, 4}, concatOne.getShape());
+    }
+
+    @Test
+    public void canConcatHighDimensionalShapes() {
+        IntegerVertex a = new ConstantIntegerVertex(Nd4jIntegerTensor.create(new int[]{1, 2, 3, 4, 5, 6, 7, 8}, new int[]{2, 2, 2}));
+        IntegerVertex b = new ConstantIntegerVertex(Nd4jIntegerTensor.create(new int[]{10, 20, 30, 40, 50, 60, 70, 80}, new int[]{2, 2, 2}));
+
+        IntegerConcatenationVertex concatZero = new IntegerConcatenationVertex(0, a, b);
+
+        Assert.assertArrayEquals(
+            new double[]{1, 2, 3, 4, 5, 6, 7, 8, 10, 20, 30, 40, 50, 60, 70, 80},
+            concatZero.getValue().asFlatDoubleArray(),
+            0.001
+        );
+        Assert.assertArrayEquals(new int[]{4, 2, 2}, concatZero.getShape());
+
+        IntegerConcatenationVertex concatThree = new IntegerConcatenationVertex(2, a, b);
+        Assert.assertArrayEquals(
+            new double[]{1, 2, 10, 20, 3, 4, 30, 40, 5, 6, 50, 60, 7, 8, 70, 80},
+            concatThree.getValue().asFlatDoubleArray(),
+            0.001
+        );
+        Assert.assertArrayEquals(new int[]{2, 2, 4}, concatThree.getShape());
+    }
+
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertexTest.java
@@ -1,12 +1,6 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.multiple;
 
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.Nd4jIntegerTensor;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
 import org.junit.Assert;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertexTest.java
@@ -17,11 +17,12 @@ public class IntegerConcatenationVertexTest {
         IntegerConcatenationVertex concatZero = new IntegerConcatenationVertex(0, a, b);
         IntegerConcatenationVertex concatOne = new IntegerConcatenationVertex(1, a, b, c);
 
+        Assert.assertArrayEquals(new int[]{2, 3}, concatZero.getShape());
+        Assert.assertArrayEquals(new int[]{1, 9}, concatOne.getShape());
+
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatOne.getValue().asFlatDoubleArray(), 0.001);
 
-        Assert.assertArrayEquals(new int[]{2, 3}, concatZero.getShape());
-        Assert.assertArrayEquals(new int[]{1, 9}, concatOne.getShape());
     }
 
     @Test
@@ -31,8 +32,8 @@ public class IntegerConcatenationVertexTest {
 
         IntegerConcatenationVertex concatZero = new IntegerConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 9}, concatZero.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9}, concatZero.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -42,8 +43,8 @@ public class IntegerConcatenationVertexTest {
 
         IntegerConcatenationVertex concat = new IntegerConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -53,8 +54,8 @@ public class IntegerConcatenationVertexTest {
 
         IntegerConcatenationVertex concat = new IntegerConcatenationVertex(1, a, b);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{1, 4}, concat.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4}, concat.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test (expected = IllegalArgumentException.class)
@@ -72,13 +73,13 @@ public class IntegerConcatenationVertexTest {
 
         IntegerConcatenationVertex concatZero = new IntegerConcatenationVertex(0, m, a);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 10, 15, 20, 25}, concatZero.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{4, 2}, concatZero.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 3, 4, 10, 15, 20, 25}, concatZero.getValue().asFlatDoubleArray(), 0.001);
 
         IntegerConcatenationVertex concatOne = new IntegerConcatenationVertex(1, m, a);
 
-        Assert.assertArrayEquals(new double[]{1, 2, 10, 15, 3, 4, 20, 25}, concatOne.getValue().asFlatDoubleArray(), 0.001);
         Assert.assertArrayEquals(new int[]{2, 4}, concatOne.getShape());
+        Assert.assertArrayEquals(new double[]{1, 2, 10, 15, 3, 4, 20, 25}, concatOne.getValue().asFlatDoubleArray(), 0.001);
     }
 
     @Test
@@ -88,20 +89,20 @@ public class IntegerConcatenationVertexTest {
 
         IntegerConcatenationVertex concatZero = new IntegerConcatenationVertex(0, a, b);
 
+        Assert.assertArrayEquals(new int[]{4, 2, 2}, concatZero.getShape());
         Assert.assertArrayEquals(
             new double[]{1, 2, 3, 4, 5, 6, 7, 8, 10, 20, 30, 40, 50, 60, 70, 80},
             concatZero.getValue().asFlatDoubleArray(),
             0.001
         );
-        Assert.assertArrayEquals(new int[]{4, 2, 2}, concatZero.getShape());
 
         IntegerConcatenationVertex concatThree = new IntegerConcatenationVertex(2, a, b);
+        Assert.assertArrayEquals(new int[]{2, 2, 4}, concatThree.getShape());
         Assert.assertArrayEquals(
             new double[]{1, 2, 10, 20, 3, 4, 30, 40, 5, 6, 50, 60, 7, 8, 70, 80},
             concatThree.getValue().asFlatDoubleArray(),
             0.001
         );
-        Assert.assertArrayEquals(new int[]{2, 2, 4}, concatThree.getShape());
     }
 
 }


### PR DESCRIPTION
Tensor vertex concatenation for double / integer and boolean. Also renamed DoubleReduceVertex to ReduceVertex to match the naming convention.

A ticket has been added to the backlog to finish the Generic Concatenation as this is a bit of a chunk of work in itself.