### PR TITLE
Added access to internal representation of Nd4j tensors

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -972,4 +972,8 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     public Double[] asFlatArray() {
         return ArrayUtils.toObject(asFlatDoubleArray());
     }
+
+    public INDArray getInternalRepresentation(){
+        return tensor;
+    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -635,4 +635,7 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         return ArrayUtils.toObject(asFlatIntegerArray());
     }
 
+    public INDArray getInternalRepresentation(){
+        return tensor;
+    }
 }


### PR DESCRIPTION
This is to allow other code to do something like:
```java
if ( tensor instanceof Nd4jDoubleTensor){
  Nd4jDoubleTensor internal = (Nd4jDoubleTensor)internal;
  INDArray represntation = internal.getInternalRepresentation();
  // do something efficient
}else{
  // do something inefficient
}
```
Likely to be primarily in extensions such as new vertices that can be written to be more performant with direct access tot he Nd4j tensor represnetation.