### PR TITLE
pulled out Differentiable interface

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/VertexValuePropagation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/VertexValuePropagation.java
@@ -1,8 +1,16 @@
 package io.improbable.keanu.algorithms.graphtraversal;
 
-import io.improbable.keanu.vertices.Vertex;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.PriorityQueue;
+import java.util.Set;
 
-import java.util.*;
+import io.improbable.keanu.vertices.Vertex;
 
 /**
  * This class enables efficient propagation of vertex updates.
@@ -78,7 +86,7 @@ public class VertexValuePropagation {
         }
     }
 
-    private static Set<Vertex<?>> parentsThatAreNotCalculated(Set<Vertex<?>> calculated, Set<Vertex> parents) {
+    private static Set<Vertex<?>> parentsThatAreNotCalculated(Set<Vertex<?>> calculated, Collection<Vertex> parents) {
         Set<Vertex<?>> notCalculatedParents = new HashSet<>();
         for (Vertex<?> next : parents) {
             if (!calculated.contains(next)) {
@@ -116,7 +124,7 @@ public class VertexValuePropagation {
         }
     }
 
-    private static Set<Vertex<?>> parentsThatAreNotCalculated(Set<Vertex> parents) {
+    private static Set<Vertex<?>> parentsThatAreNotCalculated(Collection<Vertex> parents) {
         Set<Vertex<?>> notCalculatedParents = new HashSet<>();
         for (Vertex<?> next : parents) {
             if (!next.hasValue()) {

--- a/keanu-project/src/main/java/io/improbable/keanu/network/LambdaSection.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/LambdaSection.java
@@ -1,15 +1,16 @@
 package io.improbable.keanu.network;
 
-import io.improbable.keanu.vertices.Vertex;
-import lombok.Value;
-
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import io.improbable.keanu.vertices.Vertex;
+import lombok.Value;
 
 /**
  * A Lambda Section is defined as a given vertex and all the vertices that it affects (downstream) OR
@@ -90,7 +91,7 @@ public class LambdaSection {
      * @return A Set of vertices that are in the direction implied by nextVertices and filtered by shouldAdd
      */
     private static Set<Vertex> getVerticesDepthFirst(Vertex vertex,
-                                                     Function<Vertex, Set<Vertex>> nextVertices,
+                                                     Function<Vertex, Collection<Vertex>> nextVertices,
                                                      Predicate<Vertex> shouldAdd) {
 
         Set<Vertex> visited = new HashSet<>();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -2,7 +2,7 @@ package io.improbable.keanu.vertices;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -20,8 +20,8 @@ public abstract class Vertex<T> {
     public static final AtomicLong ID_GENERATOR = new AtomicLong(0L);
 
     private long uuid = ID_GENERATOR.getAndIncrement();
-    private Set<Vertex> children = new HashSet<>();
-    private Set<Vertex> parents = new HashSet<>();
+    private Set<Vertex> children = Collections.emptySet();
+    private Set<Vertex> parents = Collections.emptySet();
     private T value;
     private boolean observed;
 
@@ -186,15 +186,15 @@ public abstract class Vertex<T> {
     }
 
     public Set<Vertex> getChildren() {
-        return ImmutableSet.copyOf(children);
+        return children;
     }
 
     public void addChild(Vertex<?> v) {
-        children.add(v);
+        children = ImmutableSet.<Vertex>builder().addAll(children).add(v).build();
     }
 
     public void setParents(Collection<? extends Vertex> parents) {
-        this.parents = new HashSet<>();
+        this.parents = Collections.emptySet();
         addParents(parents);
     }
 
@@ -203,16 +203,16 @@ public abstract class Vertex<T> {
     }
 
     public void addParents(Collection<? extends Vertex> parents) {
-        parents.forEach(this::addParent);
+        this.parents = ImmutableSet.<Vertex>builder().addAll(this.getParents()).addAll(parents).build();
+        parents.forEach(p -> p.addChild(this));
     }
 
     public void addParent(Vertex<?> parent) {
-        this.parents.add(parent);
-        parent.addChild(this);
+        addParents(ImmutableSet.of(parent));
     }
 
     public Set<Vertex> getParents() {
-        return ImmutableSet.copyOf(this.parents);
+        return parents;
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -1,14 +1,13 @@
 package io.improbable.keanu.vertices;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import io.improbable.keanu.algorithms.graphtraversal.DiscoverGraph;
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
@@ -21,8 +20,8 @@ public abstract class Vertex<T> {
     public static final AtomicLong ID_GENERATOR = new AtomicLong(0L);
 
     private long uuid = ID_GENERATOR.getAndIncrement();
-    private List<Vertex> children = new ArrayList<>();
-    private List<Vertex> parents = new ArrayList<>();
+    private Set<Vertex> children = new HashSet<>();
+    private Set<Vertex> parents = new HashSet<>();
     private T value;
     private boolean observed;
 
@@ -186,8 +185,8 @@ public abstract class Vertex<T> {
         return uuid;
     }
 
-    public List<Vertex> getChildren() {
-        return ImmutableList.copyOf(children);
+    public Set<Vertex> getChildren() {
+        return ImmutableSet.copyOf(children);
     }
 
     public void addChild(Vertex<?> v) {
@@ -195,7 +194,7 @@ public abstract class Vertex<T> {
     }
 
     public void setParents(Collection<? extends Vertex> parents) {
-        this.parents = new ArrayList<>();
+        this.parents = new HashSet<>();
         addParents(parents);
     }
 
@@ -212,8 +211,8 @@ public abstract class Vertex<T> {
         parent.addChild(this);
     }
 
-    public List<Vertex> getParents() {
-        return ImmutableList.copyOf(this.parents);
+    public Set<Vertex> getParents() {
+        return ImmutableSet.copyOf(this.parents);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -1,21 +1,28 @@
 package io.improbable.keanu.vertices;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.collect.ImmutableList;
+
 import io.improbable.keanu.algorithms.graphtraversal.DiscoverGraph;
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
-
 public abstract class Vertex<T> {
 
     public static final AtomicLong ID_GENERATOR = new AtomicLong(0L);
 
     private long uuid = ID_GENERATOR.getAndIncrement();
-    private Set<Vertex> children = new HashSet<>();
-    private Set<Vertex> parents = new HashSet<>();
+    private List<Vertex> children = new ArrayList<>();
+    private List<Vertex> parents = new ArrayList<>();
     private T value;
     private boolean observed;
 
@@ -179,8 +186,8 @@ public abstract class Vertex<T> {
         return uuid;
     }
 
-    public Set<Vertex> getChildren() {
-        return children;
+    public List<Vertex> getChildren() {
+        return ImmutableList.copyOf(children);
     }
 
     public void addChild(Vertex<?> v) {
@@ -188,7 +195,7 @@ public abstract class Vertex<T> {
     }
 
     public void setParents(Collection<? extends Vertex> parents) {
-        this.parents = new HashSet<>();
+        this.parents = new ArrayList<>();
         addParents(parents);
     }
 
@@ -205,8 +212,8 @@ public abstract class Vertex<T> {
         parent.addChild(this);
     }
 
-    public Set<Vertex> getParents() {
-        return this.parents;
+    public List<Vertex> getParents() {
+        return ImmutableList.copyOf(this.parents);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
@@ -1,4 +1,4 @@
-package io.improbable.keanu.vertices.dbl.probabilistic;
+package io.improbable.keanu.vertices.dbl;
 
 import java.util.List;
 import java.util.Map;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
@@ -16,7 +16,7 @@ public interface Differentiable {
         return Differentiator.calculateDual((Vertex & Differentiable) this);
     }
 
-    static <V extends Vertex & Differentiable> List<V> filter(List<? extends Vertex<?>> vertices) {
+    static <V extends Vertex & Differentiable> List<V> keepOnlyDifferentiableVertices(List<? extends Vertex<?>> vertices) {
         ImmutableList.Builder<V> differentiableVertices = ImmutableList.builder();
         for (Vertex v : vertices) {
             if (v instanceof Differentiable) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
@@ -1,4 +1,4 @@
-package io.improbable.keanu.vertices.dbl.probabilistic;
+package io.improbable.keanu.vertices.dbl;
 
 import java.util.ArrayDeque;
 import java.util.Collection;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -34,7 +34,6 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SinVert
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SliceVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TanVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.Differentiable;
 
 public abstract class DoubleVertex extends ContinuousVertex<DoubleTensor> implements DoubleOperators<DoubleVertex>, Differentiable {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -1,19 +1,42 @@
 package io.improbable.keanu.vertices.dbl;
 
 
+import java.util.Map;
+import java.util.function.Function;
+
 import io.improbable.keanu.kotlin.DoubleOperators;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ContinuousVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.*;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.*;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.AdditionVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.ArcTan2Vertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DifferenceVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DivisionVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MatrixMultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.PowerVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.AbsVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ArcCosVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ArcSinVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ArcTanVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.CeilVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.CosVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpLambda;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ExpVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.FloorVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.LogVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.PluckVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.RoundVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SigmoidVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SinVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SliceVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TanVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.Differentiable;
 
-import java.util.*;
-import java.util.function.Function;
-
-public abstract class DoubleVertex extends ContinuousVertex<DoubleTensor> implements DoubleOperators<DoubleVertex> {
+public abstract class DoubleVertex extends ContinuousVertex<DoubleTensor> implements DoubleOperators<DoubleVertex>, Differentiable {
 
     public DoubleVertex minus(DoubleVertex that) {
         return new DifferenceVertex(this, that);
@@ -151,51 +174,6 @@ public abstract class DoubleVertex extends ContinuousVertex<DoubleTensor> implem
     public DoubleVertex slice(int dimension, int index) {
         return new SliceVertex(this, dimension, index);
     }
-
-    public final DualNumber getDualNumber() {
-        Map<Vertex, DualNumber> dualNumbers = new HashMap<>();
-        Deque<DoubleVertex> stack = new ArrayDeque<>();
-        stack.push(this);
-
-        while (!stack.isEmpty()) {
-
-            DoubleVertex head = stack.peek();
-            Set<Vertex> parentsThatDualNumberIsNotCalculated = parentsThatDualNumberIsNotCalculated(dualNumbers, head.getParents());
-
-            if (parentsThatDualNumberIsNotCalculated.isEmpty()) {
-
-                DoubleVertex top = stack.pop();
-                DualNumber dual = top.calculateDualNumber(dualNumbers);
-                dualNumbers.put(top, dual);
-
-            } else {
-
-                for (Vertex vertex : parentsThatDualNumberIsNotCalculated) {
-                    if (vertex instanceof DoubleVertex) {
-                        stack.push((DoubleVertex) vertex);
-                    } else {
-                        throw new IllegalArgumentException("Can only calculate Diff Numbers on a graph made of Doubles");
-                    }
-                }
-
-            }
-
-        }
-
-        return dualNumbers.get(this);
-    }
-
-    private Set<Vertex> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, Set<Vertex> parents) {
-        Set<Vertex> notCalculatedParents = new HashSet<>();
-        for (Vertex<?> next : parents) {
-            if (!dualNumbers.containsKey(next)) {
-                notCalculatedParents.add(next);
-            }
-        }
-        return notCalculatedParents;
-    }
-
-    protected abstract DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers);
 
     public void setValue(double value) {
         super.setValue(DoubleTensor.scalar(value));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
@@ -23,7 +23,7 @@ public class ConstantDoubleVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return new DualNumber(getValue(), Collections.emptyMap());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
@@ -41,7 +41,7 @@ public class DoubleIfVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException("if is non-differentiable");
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
@@ -28,7 +28,7 @@ public class ArcTan2Vertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         DualNumber leftDual = dualNumbers.get(left);
         DualNumber rightDual = dualNumbers.get(right);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -58,7 +58,7 @@ public class DoubleBinaryOpLambda<A, B> extends NonProbabilisticDouble {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         if (dualNumberCalculation != null) {
             return dualNumberCalculation.apply(dualNumbers);
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
@@ -27,7 +27,7 @@ public class PowerVertex extends DoubleBinaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         DualNumber leftDual = dualNumbers.get(left);
         DualNumber rightDual = dualNumbers.get(right);
         return leftDual.pow(rightDual);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -1,17 +1,20 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple;
 
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.NonProbabilisticDouble;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
-
-import java.lang.reflect.Array;
-import java.util.*;
-import java.util.function.Function;
-
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
 
 public class ConcatenationVertex extends NonProbabilisticDouble {
 
@@ -38,7 +41,7 @@ public class ConcatenationVertex extends NonProbabilisticDouble {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         List<DualNumber> duals = new ArrayList<>();
 
         for (DoubleVertex vertex : input) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
@@ -25,7 +25,7 @@ public class AbsVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
@@ -24,7 +24,7 @@ public class ArcCosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).acos();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
@@ -24,7 +24,7 @@ public class ArcSinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).asin();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
@@ -24,7 +24,7 @@ public class ArcTanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).atan();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
@@ -25,7 +25,7 @@ public class CeilVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
@@ -24,7 +24,7 @@ public class CosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).cos();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
@@ -46,7 +46,7 @@ public class DoubleUnaryOpLambda<IN> extends NonProbabilisticDouble {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         if (dualNumberSupplier != null) {
             return dualNumberSupplier.apply(dualNumbers);
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
@@ -24,7 +24,7 @@ public class ExpVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).exp();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
@@ -25,7 +25,7 @@ public class FloorVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
@@ -23,7 +23,7 @@ public class LogVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).log();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/PluckVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/PluckVertex.java
@@ -31,7 +31,7 @@ public class PluckVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).pluck(index);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertex.java
@@ -25,7 +25,7 @@ public class ReshapeVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).reshape(proposedShape);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/RoundVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/RoundVertex.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import java.util.Map;
+
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
-
-import java.util.Map;
 
 public class RoundVertex extends DoubleUnaryOpVertex {
 
@@ -25,7 +25,7 @@ public class RoundVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
@@ -26,7 +26,7 @@ public class SigmoidVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         DualNumber dualNumber = dualNumbers.get(inputVertex);
         DoubleTensor x = dualNumber.getValue();
         DoubleTensor xExp = x.exp();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
@@ -24,7 +24,7 @@ public class SinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).sin();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SliceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SliceVertex.java
@@ -28,7 +28,7 @@ public class SliceVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).slice(dimension, index);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
@@ -25,7 +25,7 @@ public class SumVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).sum();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
@@ -24,7 +24,7 @@ public class TanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(inputVertex).tan();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiable.java
@@ -1,0 +1,28 @@
+package io.improbable.keanu.vertices.dbl.probabilistic;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+public interface Differentiable {
+
+    DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers);
+
+    default DualNumber getDualNumber() {
+        return new Differentiator().calculateDual((Vertex & Differentiable) this);
+    }
+
+    static <V extends Vertex & Differentiable> List<V> filter(List<? extends Vertex<?>> vertices) {
+        ImmutableList.Builder<V> differentiableVertices = ImmutableList.builder();
+        for (Vertex v : vertices) {
+            if (v instanceof Differentiable) {
+                differentiableVertices.add((V) v);
+            }
+        }
+        return differentiableVertices.build();
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiable.java
@@ -13,7 +13,7 @@ public interface Differentiable {
     DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers);
 
     default DualNumber getDualNumber() {
-        return new Differentiator().calculateDual((Vertex & Differentiable) this);
+        return Differentiator.calculateDual((Vertex & Differentiable) this);
     }
 
     static <V extends Vertex & Differentiable> List<V> filter(List<? extends Vertex<?>> vertices) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiator.java
@@ -12,7 +12,9 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 
 public class Differentiator {
-    public <V extends Vertex & Differentiable> DualNumber calculateDual(V vertex) {
+    private Differentiator() {}
+
+    public static <V extends Vertex & Differentiable> DualNumber calculateDual(V vertex) {
         Map<Vertex, DualNumber> dualNumbers = new HashMap<>();
         Deque<V> stack = new ArrayDeque<>();
         stack.push(vertex);
@@ -40,7 +42,7 @@ public class Differentiator {
         return dualNumbers.get(vertex);
     }
 
-    private Set<Vertex> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, List<? extends Vertex> parents) {
+    private static Set<Vertex> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, List<? extends Vertex> parents) {
         Set<Vertex> notCalculatedParents = new HashSet<>();
         for (Vertex next : parents) {
             if (!dualNumbers.containsKey(next)) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiator.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,7 +42,7 @@ public class Differentiator {
         return dualNumbers.get(vertex);
     }
 
-    private static Set<Vertex> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, List<? extends Vertex> parents) {
+    private static Set<Vertex> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, Collection<? extends Vertex> parents) {
         Set<Vertex> notCalculatedParents = new HashSet<>();
         for (Vertex next : parents) {
             if (!dualNumbers.containsKey(next)) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/Differentiator.java
@@ -1,0 +1,52 @@
+package io.improbable.keanu.vertices.dbl.probabilistic;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+
+public class Differentiator {
+    public <V extends Vertex & Differentiable> DualNumber calculateDual(V vertex) {
+        Map<Vertex, DualNumber> dualNumbers = new HashMap<>();
+        Deque<V> stack = new ArrayDeque<>();
+        stack.push(vertex);
+
+        while (!stack.isEmpty()) {
+
+            V head = stack.peek();
+            Set<Vertex> parentsThatDualNumberIsNotCalculated = parentsThatDualNumberIsNotCalculated(dualNumbers, head.getParents());
+
+            if (parentsThatDualNumberIsNotCalculated.isEmpty()) {
+                V top = stack.pop();
+                DualNumber dual = top.calculateDualNumber(dualNumbers);
+                dualNumbers.put(top, dual);
+            } else {
+                for (Vertex parent : parentsThatDualNumberIsNotCalculated) {
+                    if (parent instanceof Differentiable) {
+                        stack.push((V) parent);
+                    } else {
+                        throw new IllegalArgumentException("Can only calculate Dual Numbers on a graph made of Differentiable vertices");
+                    }
+                }
+            }
+        }
+
+        return dualNumbers.get(vertex);
+    }
+
+    private Set<Vertex> parentsThatDualNumberIsNotCalculated(Map<Vertex, DualNumber> dualNumbers, List<? extends Vertex> parents) {
+        Set<Vertex> notCalculatedParents = new HashSet<>();
+        for (Vertex next : parents) {
+            if (!dualNumbers.containsKey(next)) {
+                notCalculatedParents.add(next);
+            }
+        }
+        return notCalculatedParents;
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
+import java.util.Map;
+
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
-
-import java.util.Map;
 
 public abstract class ProbabilisticDouble extends DoubleVertex {
 
@@ -23,7 +23,7 @@ public abstract class ProbabilisticDouble extends DoubleVertex {
     }
 
     @Override
-    protected DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
+    public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         if (isObserved()) {
             return DualNumber.createConstant(getValue());
         } else {


### PR DESCRIPTION
also made getParents and getChildren return a List instead of a Set (which I will need later for refactoring the probabilistic vertex classes
also made getParents and getChildren return a defensive copy