### PR TITLE
youCanObserveANonProbabilisticVariableAfterCreatingTheNetwork

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -1,25 +1,25 @@
 package io.improbable.keanu.network;
 
-import io.improbable.keanu.algorithms.graphtraversal.TopologicalSort;
-import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.algorithms.graphtraversal.TopologicalSort;
+import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
 public class BayesianNetwork {
 
-    private final List<Vertex> latentAndObservedVertices;
+    private final List<? extends Vertex> vertices;
 
     public BayesianNetwork(Set<? extends Vertex> vertices) {
-        latentAndObservedVertices = vertices.stream()
-            .filter(v -> v.isObserved() || v.isProbabilistic())
-            .collect(Collectors.toList());
+        this.vertices = ImmutableList.copyOf(vertices);
     }
 
     public BayesianNetwork(Collection<? extends Vertex> vertices) {
@@ -27,24 +27,32 @@ public class BayesianNetwork {
     }
 
     public List<Vertex> getLatentAndObservedVertices() {
-        return latentAndObservedVertices;
-    }
-
-    public List<Vertex> getLatentVertices() {
-        return latentAndObservedVertices.stream()
-            .filter(v -> !v.isObserved())
+        return vertices.stream()
+            .filter(v -> v.isProbabilistic() || v.isObserved())
             .collect(Collectors.toList());
     }
 
+    /**
+     * @return All vertices that are latent (i.e. probabilistic non-observed)
+     */
+    public List<Vertex> getLatentVertices() {
+        return vertices.stream()
+            .filter(v -> v.isProbabilistic() && !v.isObserved())
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * @return All vertices that are observed - which may be probabilistic or non-probabilistic
+     */
     public List<Vertex> getObservedVertices() {
-        return latentAndObservedVertices.stream()
+        return vertices.stream()
             .filter(Vertex::isObserved)
             .collect(Collectors.toList());
     }
 
     public double getLogOfMasterP() {
         double sum = 0.0;
-        for (Vertex<?> vertex : latentAndObservedVertices) {
+        for (Vertex<?> vertex : getLatentAndObservedVertices()) {
             sum += vertex.logProbAtValue();
         }
         return sum;

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -10,7 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.improbable.keanu.vertices.bool.BoolVertex;
-import io.improbable.keanu.vertices.bool.probabilistic.Flip;
+import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 
 public class BayesianNetworkTest {
 
@@ -21,8 +21,8 @@ public class BayesianNetworkTest {
 
     @Before
     public void setUpNetwork() {
-        input1 = new Flip(0.25);
-        input2 = new Flip(0.75);
+        input1 = new BernoulliVertex(0.25);
+        input2 = new BernoulliVertex(0.75);
         output = input1.or(input2);
         network = new BayesianNetwork(output.getConnectedGraph());
 

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -1,0 +1,50 @@
+package io.improbable.keanu.network;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.improbable.keanu.vertices.bool.BoolVertex;
+import io.improbable.keanu.vertices.bool.probabilistic.Flip;
+
+public class BayesianNetworkTest {
+
+    BayesianNetwork network;
+    BoolVertex input1;
+    BoolVertex input2;
+    BoolVertex output;
+
+    @Before
+    public void setUpNetwork() {
+        input1 = new Flip(0.25);
+        input2 = new Flip(0.75);
+        output = input1.or(input2);
+        network = new BayesianNetwork(output.getConnectedGraph());
+
+    }
+
+    @Test
+    public void youCanObserveAProbabilisticVariableAfterCreatingTheNetwork() {
+        assertThat(network.getObservedVertices(), is(empty()));
+        input1.observe(true);
+        assertThat(network.getObservedVertices(), contains(input1));
+        input2.observe(true);
+        assertThat(network.getObservedVertices(), containsInAnyOrder(input1, input2));
+        input1.unobserve();
+        assertThat(network.getObservedVertices(), contains(input2));
+    }
+
+    @Test
+    public void youCanObserveANonProbabilisticVariableAfterCreatingTheNetwork() {
+        assertThat(network.getObservedVertices(), is(empty()));
+        output.observe(true);
+        assertThat(network.getObservedVertices(), contains(output));
+        output.unobserve();
+        assertThat(network.getObservedVertices(), is(empty()));
+    }
+}


### PR DESCRIPTION
There was a bug whereby the `BayesianNetwork` stores the latent and observed variables on construction only, which means if you observe a non-probabilistic vertex later it won't be added to this list.

The solution is to calculate the latent and observed variables dynamically. Of course this has an impact on performance in time and space, but we agreed that it's more important at this stage to be correct and to optimise later.

If we want to optimise later, we'd need some kind of callback mechanism whereby a `Vertex` notifies a `BayesianNetwork` when it gets observed.