### PR TITLE
Remove location from exponential distribution

### DIFF
--- a/keanu-examples/coalMiningDisasters/src/main/java/com/example/coal/Model.java
+++ b/keanu-examples/coalMiningDisasters/src/main/java/com/example/coal/Model.java
@@ -66,8 +66,8 @@ public class Model {
     private BayesianNetwork buildBayesianNetwork() {
 
         switchpoint = new UniformIntVertex(data.startYear, data.endYear + 1);
-        earlyRate = new ExponentialVertex(1.0, 1.0);
-        lateRate = new ExponentialVertex(1.0, 1.0);
+        earlyRate = new ExponentialVertex(1.0);
+        lateRate = new ExponentialVertex(1.0);
 
         ConstantIntegerVertex years = ConstantVertex.of(data.years);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -1,47 +1,43 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.dual.Diffs.A;
-import static io.improbable.keanu.distributions.dual.Diffs.B;
-import static io.improbable.keanu.distributions.dual.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+import static io.improbable.keanu.distributions.dual.Diffs.LAMBDA;
+import static io.improbable.keanu.distributions.dual.Diffs.X;
+
 public class Exponential implements ContinuousDistribution {
 
-    private final DoubleTensor location;
     private final DoubleTensor lambda;
 
-    public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor lambda) {
-        return new Exponential(location, lambda);
+    public static ContinuousDistribution withParameters(DoubleTensor lambda) {
+        return new Exponential(lambda);
     }
 
-    private Exponential(DoubleTensor location, DoubleTensor lambda) {
-        this.location = location;
+    private Exponential(DoubleTensor lambda) {
         this.lambda = lambda;
     }
 
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
-        return location.minus(random.nextDouble(shape).logInPlace().timesInPlace(lambda));
+        return random.nextDouble(shape).logInPlace().timesInPlace(lambda).unaryMinusInPlace();
     }
 
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
-        final DoubleTensor negXMinusADivB = x.minus(location).unaryMinusInPlace().divInPlace(lambda);
+        final DoubleTensor negXMinusADivB = x.unaryMinus().divInPlace(lambda);
         final DoubleTensor negXMinusADivBMinusLogB = negXMinusADivB.minusInPlace(lambda.log());
-        return negXMinusADivBMinusLogB.setWithMask(x.getLessThanMask(location), Double.NEGATIVE_INFINITY);
+        return negXMinusADivBMinusLogB.setWithMask(x.getLessThanMask(DoubleTensor.ZERO_SCALAR), Double.NEGATIVE_INFINITY);
     }
 
     @Override
     public Diffs dLogProb(DoubleTensor x) {
-        final DoubleTensor dLogPdlocation = lambda.reciprocal();
-        final DoubleTensor dLogPdlambda = x.minus(location).minusInPlace(lambda).divInPlace(lambda.pow(2));
+        final DoubleTensor dLogPdx = lambda.reciprocal().unaryMinusInPlace();
+        final DoubleTensor dLogPdlambda = x.minus(lambda).divInPlace(lambda.pow(2));
         return new Diffs()
-            .put(A, dLogPdlocation)
-            .put(B, dLogPdlambda)
-            .put(X, dLogPdlocation.unaryMinus());
+            .put(LAMBDA, dLogPdlambda)
+            .put(X, dLogPdx);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/dual/Diffs.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/dual/Diffs.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.distributions.dual;
 
+import com.google.common.collect.Sets;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+
 import java.util.NoSuchElementException;
 import java.util.TreeSet;
-
-import com.google.common.collect.Sets;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
 
 public class Diffs {
     public static final ParameterName A = new ParameterName("A");
@@ -19,6 +18,7 @@ public class Diffs {
     public static final ParameterName MU = new ParameterName("MU");
     public static final ParameterName SIGMA = new ParameterName("SIGMA");
     public static final ParameterName THETA = new ParameterName("THETA");
+    public static final ParameterName LAMBDA = new ParameterName("LAMBDA");
 
     private final TreeSet<Diff> diffs = Sets.newTreeSet();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -1,13 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.dual.Diffs.A;
-import static io.improbable.keanu.distributions.dual.Diffs.B;
-import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Map;
-
 import io.improbable.keanu.distributions.continuous.Exponential;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
@@ -18,11 +10,16 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.update.ProbabilisticValueUpdater;
 
+import java.util.Map;
+
+import static io.improbable.keanu.distributions.dual.Diffs.LAMBDA;
+import static io.improbable.keanu.distributions.dual.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class ExponentialVertex extends DoubleVertex implements ProbabilisticDouble {
 
-    private final DoubleVertex location;
     private final DoubleVertex lambda;
 
     /**
@@ -33,19 +30,16 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
      * If all provided parameters are scalar then the proposed shape determines the shape
      *
      * @param tensorShape the desired shape of the vertex
-     * @param location    the horizontal shift of the Exponential with either the same shape as specified
-     *                    for this vertex or location scalar
      * @param lambda      the lambda of the Exponential with either the same shape as specified for this
      *                    vertex or location scalar.
      */
-    public ExponentialVertex(int[] tensorShape, DoubleVertex location, DoubleVertex lambda) {
+    public ExponentialVertex(int[] tensorShape, DoubleVertex lambda) {
         super(new ProbabilisticValueUpdater<>());
 
-        checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, location.getShape(), lambda.getShape());
+        checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, lambda.getShape());
 
-        this.location = location;
         this.lambda = lambda;
-        setParents(location, lambda);
+        setParents(lambda);
         setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
@@ -53,49 +47,36 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
      * One to one constructor for mapping some shape of location and lambda to
      * location matching shaped exponential.
      *
-     * @param location the location of the Exponential with either the same shape as specified for this vertex or location scalar
-     * @param lambda   the lambda of the Exponential with either the same shape as specified for this vertex or location scalar
+     * @param lambda the lambda of the Exponential with either the same shape as specified for this vertex or location scalar
      */
-    public ExponentialVertex(DoubleVertex location, DoubleVertex lambda) {
-        this(checkHasSingleNonScalarShapeOrAllScalar(location.getShape(), lambda.getShape()), location, lambda);
+    public ExponentialVertex(DoubleVertex lambda) {
+        this(checkHasSingleNonScalarShapeOrAllScalar(lambda.getShape()), lambda);
     }
 
-    public ExponentialVertex(DoubleVertex location, double lambda) {
-        this(location, new ConstantDoubleVertex(lambda));
-    }
-
-    public ExponentialVertex(double location, DoubleVertex lambda) {
-        this(new ConstantDoubleVertex(location), lambda);
-    }
-
-    public ExponentialVertex(double location, double lambda) {
-        this(new ConstantDoubleVertex(location), new ConstantDoubleVertex(lambda));
+    public ExponentialVertex(double lambda) {
+        this(new ConstantDoubleVertex(lambda));
     }
 
     @Override
     public double logProb(DoubleTensor value) {
 
-        DoubleTensor locationValues = location.getValue();
         DoubleTensor lambdaValues = lambda.getValue();
 
-        DoubleTensor logPdfs = Exponential.withParameters(locationValues, lambdaValues).logProb(value);
+        DoubleTensor logPdfs = Exponential.withParameters(lambdaValues).logProb(value);
 
         return logPdfs.sum();
     }
 
     @Override
     public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
-        Diffs dlnP = Exponential.withParameters(location.getValue(), lambda.getValue()).dLogProb(value);
-        return convertDualNumbersToDiff(dlnP.get(A).getValue(), dlnP.get(B).getValue(), dlnP.get(X).getValue());
+        Diffs dlnP = Exponential.withParameters(lambda.getValue()).dLogProb(value);
+        return convertDualNumbersToDiff(dlnP.get(LAMBDA).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlocation,
-                                                             DoubleTensor dLogPdlambda,
+    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlambda,
                                                              DoubleTensor dLogPdx) {
 
-        PartialDerivatives dLogPdInputsFromA = location.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlocation);
-        PartialDerivatives dLogPdInputsFromB = lambda.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlambda);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromA.add(dLogPdInputsFromB);
+        PartialDerivatives dLogPdInputs = lambda.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlambda);
 
         if (!this.isObserved()) {
             dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
@@ -109,7 +90,7 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return Exponential.withParameters(location.getValue(), lambda.getValue()).sample(getShape(), random);
+        return Exponential.withParameters(lambda.getValue()).sample(getShape(), random);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -23,15 +23,15 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
     private final DoubleVertex lambda;
 
     /**
-     * One location or lambda or both driving an arbitrarily shaped tensor of Exponential
+     * Lambda driving an arbitrarily shaped tensor of Exponential
      * <p>
      * pdf = lambda * exp(-lambda*x)
      * <p>
      * If all provided parameters are scalar then the proposed shape determines the shape
      *
      * @param tensorShape the desired shape of the vertex
-     * @param lambda      the lambda of the Exponential with either the same shape as specified for this
-     *                    vertex or location scalar.
+     * @param lambda      the lambda of the Exponential with either be the same shape as specified for this
+     *                    vertex or scalar.
      */
     public ExponentialVertex(int[] tensorShape, DoubleVertex lambda) {
         super(new ProbabilisticValueUpdater<>());
@@ -44,10 +44,9 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
     }
 
     /**
-     * One to one constructor for mapping some shape of location and lambda to
-     * location matching shaped exponential.
+     * One to one constructor for mapping some shape of lambda to matching shaped exponential.
      *
-     * @param lambda the lambda of the Exponential with either the same shape as specified for this vertex or location scalar
+     * @param lambda the lambda of the Exponential with either the same shape as specified for this vertex or scalar
      */
     public ExponentialVertex(DoubleVertex lambda) {
         this(checkHasSingleNonScalarShapeOrAllScalar(lambda.getShape()), lambda);

--- a/keanu-project/src/test/java/io/improbable/keanu/distributions/gradient/Exponential.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/distributions/gradient/Exponential.java
@@ -12,18 +12,18 @@ public class Exponential {
     private Exponential() {
     }
 
-    public static Diff dlnPdf(double b, double x) {
-        double dPdb = -(b - x) / Math.pow(b, 2);
-        double dPdx = -(1 / b);
-        return new Diff(dPdb, dPdx);
+    public static Diff dlnPdf(double lambda, double x) {
+        double dPdlambda = -(lambda - x) / Math.pow(lambda, 2);
+        double dPdx = -(1 / lambda);
+        return new Diff(dPdlambda, dPdx);
     }
 
     public static class Diff {
-        public final double dPdb;
+        public final double dPdlambda;
         public final double dPdx;
 
-        public Diff(double dPdb, double dPdx) {
-            this.dPdb = dPdb;
+        public Diff(double dPdlambda, double dPdx) {
+            this.dPdlambda = dPdlambda;
             this.dPdx = dPdx;
         }
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/distributions/gradient/Exponential.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/distributions/gradient/Exponential.java
@@ -1,7 +1,5 @@
 package io.improbable.keanu.distributions.gradient;
 
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-
 /**
  * Computer Generation of Statistical Distributions
  * by Richard Saucier
@@ -14,20 +12,17 @@ public class Exponential {
     private Exponential() {
     }
 
-    public static Diff dlnPdf(double a, double b, double x) {
-        double dPda = 1 / b;
-        double dPdb = -(a + b - x) / Math.pow(b, 2);
-        double dPdx = -dPda;
-        return new Diff(dPda, dPdb, dPdx);
+    public static Diff dlnPdf(double b, double x) {
+        double dPdb = -(b - x) / Math.pow(b, 2);
+        double dPdx = -(1 / b);
+        return new Diff(dPdb, dPdx);
     }
 
     public static class Diff {
-        public final double dPda;
         public final double dPdb;
         public final double dPdx;
 
-        public Diff(double dPda, double dPdb, double dPdx) {
-            this.dPda = dPda;
+        public Diff(double dPdb, double dPdx) {
             this.dPdb = dPdb;
             this.dPdx = dPdx;
         }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -69,7 +69,7 @@ public class ExponentialVertexTest {
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 
-        assertEquals(exponentialLogDiff.dPdb, actual.withRespectTo(bTensor.getId()).scalar(), 1e-5);
+        assertEquals(exponentialLogDiff.dPdlambda, actual.withRespectTo(bTensor.getId()).scalar(), 1e-5);
         assertEquals(exponentialLogDiff.dPdx, actual.withRespectTo(tensorExponentialVertex.getId()).scalar(), 1e-5);
     }
 


### PR DESCRIPTION
The location of a distribution can controlled by just adding an offset. This PR removes the location hyper parameter in the ExponentialVertex that has been confusing people. Mathematically the location is now at 0.0. 