### PR TITLE
Feature/no gradient on discrete

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -47,7 +47,7 @@ public class GradientOptimizer implements Optimizer {
 
         if (numIntegerVertices != 0) {
             throw new UnsupportedOperationException("Gradient Optimization unsupported on Networks containing " +
-                "Discrete Latents");
+                "Discrete Latents (" + numIntegerVertices + " found)");
         }
 
         return GradientOptimizer.builder()

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import org.apache.commons.math3.optim.InitialGuess;
 import org.apache.commons.math3.optim.MaxEval;
 import org.apache.commons.math3.optim.PointValuePair;
@@ -40,6 +41,15 @@ public class GradientOptimizer implements Optimizer {
     }
 
     public static GradientOptimizer of(BayesianNetwork bayesNet) {
+        long numIntegerVertices = bayesNet.getDiscreteLatentVertices().stream()
+            .filter(v -> v instanceof IntegerVertex)
+            .count();
+
+        if (numIntegerVertices != 0) {
+            throw new UnsupportedOperationException("Gradient Optimisation unsupported on Networks containing " +
+                "Discrete latents");
+        }
+
         return GradientOptimizer.builder()
             .bayesianNetwork(bayesNet)
             .build();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -1,14 +1,11 @@
 package io.improbable.keanu.algorithms.variational.optimizer.gradient;
 
-import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.BiConsumer;
-
-import io.improbable.keanu.vertices.intgr.IntegerVertex;
+import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
+import io.improbable.keanu.algorithms.variational.optimizer.nongradient.FitnessFunction;
+import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.vertices.Vertex;
+import lombok.Builder;
+import lombok.Getter;
 import org.apache.commons.math3.optim.InitialGuess;
 import org.apache.commons.math3.optim.MaxEval;
 import org.apache.commons.math3.optim.PointValuePair;
@@ -17,12 +14,13 @@ import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunction;
 import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunctionGradient;
 import org.apache.commons.math3.optim.nonlinear.scalar.gradient.NonLinearConjugateGradientOptimizer;
 
-import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
-import io.improbable.keanu.algorithms.variational.optimizer.nongradient.FitnessFunction;
-import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.vertices.Vertex;
-import lombok.Builder;
-import lombok.Getter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
 
 @Builder
 public class GradientOptimizer implements Optimizer {
@@ -41,13 +39,12 @@ public class GradientOptimizer implements Optimizer {
     }
 
     public static GradientOptimizer of(BayesianNetwork bayesNet) {
-        long numIntegerVertices = bayesNet.getDiscreteLatentVertices().stream()
-            .filter(v -> v instanceof IntegerVertex)
-            .count();
+        List<Vertex> discreteLatentVertices = bayesNet.getDiscreteLatentVertices();
+        boolean containsDiscreteLatents = !discreteLatentVertices.isEmpty();
 
-        if (numIntegerVertices != 0) {
+        if (containsDiscreteLatents) {
             throw new UnsupportedOperationException("Gradient Optimization unsupported on Networks containing " +
-                "Discrete Latents (" + numIntegerVertices + " found)");
+                "Discrete Latents (" + discreteLatentVertices.size() + " found)");
         }
 
         return GradientOptimizer.builder()

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -46,8 +46,8 @@ public class GradientOptimizer implements Optimizer {
             .count();
 
         if (numIntegerVertices != 0) {
-            throw new UnsupportedOperationException("Gradient Optimisation unsupported on Networks containing " +
-                "Discrete latents");
+            throw new UnsupportedOperationException("Gradient Optimization unsupported on Networks containing " +
+                "Discrete Latents");
         }
 
         return GradientOptimizer.builder()

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -1,11 +1,13 @@
 package io.improbable.keanu.algorithms.variational.optimizer.gradient;
 
-import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
-import io.improbable.keanu.algorithms.variational.optimizer.nongradient.FitnessFunction;
-import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.vertices.Vertex;
-import lombok.Builder;
-import lombok.Getter;
+import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+
 import org.apache.commons.math3.optim.InitialGuess;
 import org.apache.commons.math3.optim.MaxEval;
 import org.apache.commons.math3.optim.PointValuePair;
@@ -14,13 +16,12 @@ import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunction;
 import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunctionGradient;
 import org.apache.commons.math3.optim.nonlinear.scalar.gradient.NonLinearConjugateGradientOptimizer;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.BiConsumer;
-
-import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
+import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
+import io.improbable.keanu.algorithms.variational.optimizer.nongradient.FitnessFunction;
+import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.vertices.Vertex;
+import lombok.Builder;
+import lombok.Getter;
 
 @Builder
 public class GradientOptimizer implements Optimizer {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
@@ -9,7 +9,7 @@ public class Categorical<T> {
 
     private final Map<T, DoubleVertex> selectableValues;
 
-    public static <T> Categorical withParameters(Map<T, DoubleVertex> selectableValues) {
+    public static <T> Categorical<T> withParameters(Map<T, DoubleVertex> selectableValues) {
         return new Categorical<>(selectableValues);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.bool.probabilistic;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
+import java.util.Collections;
 import java.util.Map;
 
 import io.improbable.keanu.distributions.discrete.Bernoulli;
@@ -63,7 +64,7 @@ public class BernoulliVertex extends BoolVertex implements ProbabilisticBoolean 
 
     @Override
     public Map<Long, DoubleTensor> dLogProb(BooleanTensor value) {
-        throw new UnsupportedOperationException();
+        return Collections.emptyMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.generic.probabilistic.discrete;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -52,7 +53,7 @@ public class CategoricalVertex<T> extends Vertex<T> implements Probabilistic<T> 
 
     @Override
     public Map<Long, DoubleTensor> dLogProb(T value) {
-        throw new UnsupportedOperationException();
+        return Collections.emptyMap();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.intgr.probabilistic;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
+import java.util.Collections;
 import java.util.Map;
 
 import io.improbable.keanu.distributions.discrete.Binomial;
@@ -65,7 +66,7 @@ public class BinomialVertex extends IntegerVertex implements ProbabilisticIntege
 
     @Override
     public Map<Long, DoubleTensor> dLogProb(IntegerTensor value) {
-        throw new UnsupportedOperationException();
+        return Collections.emptyMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
+import java.util.Collections;
 import java.util.Map;
 
 import io.improbable.keanu.distributions.discrete.Poisson;
@@ -72,7 +73,7 @@ public class PoissonVertex extends IntegerVertex implements ProbabilisticInteger
 
     @Override
     public Map<Long, DoubleTensor> dLogProb(IntegerTensor value) {
-        throw new UnsupportedOperationException();
+        return Collections.emptyMap();
     }
 
     @Override

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizerTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizerTest.java
@@ -1,6 +1,9 @@
 package io.improbable.keanu.algorithms.variational.optimizer.gradient;
 
+import io.improbable.keanu.distributions.discrete.Poisson;
+import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import io.improbable.keanu.vertices.intgr.probabilistic.PoissonVertex;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -22,5 +25,13 @@ public class GradientOptimizerTest {
 
         assertTrue(fitnessTimesCalled.get() > 0);
         assertTrue(gradientTimesCalled.get() > 0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void errorOnDiscreteLatents() {
+        PoissonVertex v1 = new PoissonVertex(15);
+        PoissonVertex v2 = new PoissonVertex(v1);
+
+        GradientOptimizer optimizer = GradientOptimizer.ofConnectedGraph(v1);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
@@ -190,8 +190,8 @@ public class DoubleIfVertexTest {
 
         BoolVertex leftFlip = new BernoulliVertex(0.5);
         BoolVertex rightFlip = new BernoulliVertex(0.5);
-        leftFlip.setValue(false);
-        rightFlip.setValue(true);
+        leftFlip.observe(false);
+        rightFlip.observe(true);
 
         DoubleVertex ifVertex = If.isTrue(leftFlip.or(rightFlip))
             .then(a)
@@ -220,8 +220,8 @@ public class DoubleIfVertexTest {
 
         BoolVertex leftFlip = new BernoulliVertex(0.5);
         BoolVertex rightFlip = new BernoulliVertex(0.5);
-        leftFlip.setValue(false);
-        rightFlip.setValue(false);
+        leftFlip.observe(false);
+        rightFlip.observe(false);
 
         DoubleVertex ifVertex = If.isTrue(leftFlip.or(rightFlip))
             .then(a)

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertexTest.java
@@ -1,18 +1,19 @@
 package io.improbable.keanu.vertices.generic.probabilistic.discrete;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.ConstantVertex;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class CategoricalVertexTest {
     private final Logger log = LoggerFactory.getLogger(CategoricalVertexTest.class);


### PR DESCRIPTION
Fix for issue #91 

Simply throw an exception when you try and construct the GradientOptimiser when the graph contains latent Integer Vertices.  Simply looking for *any* Discrete Latent doesn't work as we need to be able to run the Gradient Optimiser over 'If' Vertices (and there are tests that rely on this).