### PR TITLE
Added a new case to expose issues that can be caused by using a float…

### DIFF
--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
@@ -442,6 +442,12 @@ public class Nd4jIntegerTensorTest {
             new int[]{2, 2}
         );
 
+        /*
+         * Construct a value that has the most significant two bits and the least significant bit set to 1 with all
+         * others set to 0.  This value will stretch any floating point backing representation by requiring at least a
+         * <Num bits> - 1 length Mantissa.  Simply using INT MAX often doesn't work for this test as the closest
+         * floating point value is usually > INT MAX and when converting back, the value will be clamped back to max
+         */
         final int biggestBitRange = (0x3 << Integer.SIZE - 2) + 1;
 
         tensor.plusInPlace(biggestBitRange);

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
@@ -435,4 +435,18 @@ public class Nd4jIntegerTensorTest {
         assertArrayEquals(new int[]{expected, expected, expected, expected}, result.asFlatIntegerArray());
     }
 
+    @Test
+    public void canRepresentAllValues() {
+        IntegerTensor tensor = IntegerTensor.create(
+            new int[]{0,0,0,0},
+            new int[]{2, 2}
+        );
+
+        final int biggestBitRange = (0x3 << Integer.SIZE - 2) + 1;
+
+        tensor.plusInPlace(biggestBitRange);
+        assertArrayEquals(new int[]{biggestBitRange, biggestBitRange, biggestBitRange, biggestBitRange},
+            tensor.asFlatIntegerArray());
+    }
+
 }


### PR DESCRIPTION
…ing point representation to perform integer operations (in particular, where the precision of the float isn't sufficient to cover the full integer range).

The test works by ensuring the range between highest and lowest set bits is as great as possible.