### PR TITLE
Feature/vertex labelling

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -17,13 +17,22 @@ public class BayesianNetwork {
     private final List<? extends Vertex> vertices;
     private final HashMap<String, Vertex> labelSet;
 
+    private void addLabels(Set<? extends Vertex>vertices) {
+        for (Vertex v : vertices) {
+            String label = v.getLabel();
+            if (label != null && labelSet.containsKey(label)) {
+                throw new IllegalArgumentException("Vertex Label Repeated: " + label);
+            } else {
+                labelSet.put(label, v);
+            }
+        }
+    }
+
     public BayesianNetwork(Set<? extends Vertex> vertices) {
         this.vertices = ImmutableList.copyOf(vertices);
         this.labelSet = new HashMap<>();
 
-        vertices.stream()
-            .filter(v -> v.getLabel() != null)
-            .forEach(v -> this.labelSet.put(v.getLabel(), v));
+        addLabels(vertices);
     }
 
     public BayesianNetwork(Collection<? extends Vertex> vertices) {

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -1,6 +1,11 @@
 package io.improbable.keanu.network;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
@@ -10,30 +15,31 @@ import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ProbabilityCalculator;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class BayesianNetwork {
 
     private final List<? extends Vertex> vertices;
-    private final Map<String, Vertex> vertexLabels;
+    private final Map<VertexLabel, Vertex> vertexLabels;
 
     public BayesianNetwork(Set<? extends Vertex> vertices) {
         this.vertices = ImmutableList.copyOf(vertices);
-        this.vertexLabels = getLabels(vertices);
+        this.vertexLabels = buildLabelMap(vertices);
     }
 
     public BayesianNetwork(Collection<? extends Vertex> vertices) {
         this(new HashSet<>(vertices));
     }
 
-    public Vertex getVertexByLabel(String label) {
+    public Vertex getVertexByLabel(VertexLabel label) {
         return vertexLabels.get(label);
     }
 
-    private Map<String, Vertex> getLabels(Set<? extends Vertex>vertices) {
-        Map<String, Vertex> labelMap = new HashMap<>();
+    private static Map<VertexLabel, Vertex> buildLabelMap(Set<? extends Vertex> vertices) {
+        Map<VertexLabel, Vertex> labelMap = new HashMap<>();
         for (Vertex v : vertices) {
-            String label = v.getLabel();
+            VertexLabel label = v.getLabel();
             if (label != null && labelMap.containsKey(label)) {
                 throw new IllegalArgumentException("Vertex Label Repeated: " + label);
             } else {

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -1,9 +1,6 @@
 package io.improbable.keanu.network;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
@@ -18,13 +15,23 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 public class BayesianNetwork {
 
     private final List<? extends Vertex> vertices;
+    private final HashMap<String, Vertex> labelSet;
 
     public BayesianNetwork(Set<? extends Vertex> vertices) {
         this.vertices = ImmutableList.copyOf(vertices);
+        this.labelSet = new HashMap<>();
+
+        vertices.stream()
+            .filter(v -> v.getLabel() != null)
+            .forEach(v -> this.labelSet.put(v.getLabel(), v));
     }
 
     public BayesianNetwork(Collection<? extends Vertex> vertices) {
         this(new HashSet<>(vertices));
+    }
+
+    public Vertex getVertexByLabel(String label) {
+        return labelSet.get(label);
     }
 
     public List<Vertex> getLatentAndObservedVertices() {

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -40,10 +40,12 @@ public class BayesianNetwork {
         Map<VertexLabel, Vertex> labelMap = new HashMap<>();
         for (Vertex v : vertices) {
             VertexLabel label = v.getLabel();
-            if (label != null && labelMap.containsKey(label)) {
-                throw new IllegalArgumentException("Vertex Label Repeated: " + label);
-            } else {
-                labelMap.put(label, v);
+            if (label != null) {
+                if (labelMap.containsKey(label)) {
+                    throw new IllegalArgumentException("Vertex Label Repeated: " + label);
+                } else {
+                    labelMap.put(label, v);
+                }
             }
         }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -15,24 +15,11 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 public class BayesianNetwork {
 
     private final List<? extends Vertex> vertices;
-    private final HashMap<String, Vertex> labelSet;
-
-    private void addLabels(Set<? extends Vertex>vertices) {
-        for (Vertex v : vertices) {
-            String label = v.getLabel();
-            if (label != null && labelSet.containsKey(label)) {
-                throw new IllegalArgumentException("Vertex Label Repeated: " + label);
-            } else {
-                labelSet.put(label, v);
-            }
-        }
-    }
+    private final Map<String, Vertex> vertexLabels;
 
     public BayesianNetwork(Set<? extends Vertex> vertices) {
         this.vertices = ImmutableList.copyOf(vertices);
-        this.labelSet = new HashMap<>();
-
-        addLabels(vertices);
+        this.vertexLabels = getLabels(vertices);
     }
 
     public BayesianNetwork(Collection<? extends Vertex> vertices) {
@@ -40,7 +27,21 @@ public class BayesianNetwork {
     }
 
     public Vertex getVertexByLabel(String label) {
-        return labelSet.get(label);
+        return vertexLabels.get(label);
+    }
+
+    private Map<String, Vertex> getLabels(Set<? extends Vertex>vertices) {
+        Map<String, Vertex> labelMap = new HashMap<>();
+        for (Vertex v : vertices) {
+            String label = v.getLabel();
+            if (label != null && labelMap.containsKey(label)) {
+                throw new IllegalArgumentException("Vertex Label Repeated: " + label);
+            } else {
+                labelMap.put(label, v);
+            }
+        }
+
+        return labelMap;
     }
 
     public List<Vertex> getLatentAndObservedVertices() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -24,7 +24,7 @@ public abstract class Vertex<T> implements Observable<T> {
     private T value;
     private final ValueUpdater<T> valueUpdater;
     private final Observable<T> observation;
-    private String label = null;
+    private VertexLabel label = null;
 
     public Vertex(ValueUpdater<T> valueUpdater) {
         this.valueUpdater = valueUpdater;
@@ -35,11 +35,11 @@ public abstract class Vertex<T> implements Observable<T> {
      * Set a label for this vertex.  This allows easy retrieval of this vertex using nothing but a label name.
      * @param label The label to apply to this vertex.  Uniqueness is only enforced on instantiation of a Bayes Net
      */
-    public void setLabel(String label) {
+    public void setLabel(VertexLabel label) {
         this.label = label;
     }
 
-    public String getLabel() {
+    public VertexLabel getLabel() {
         return this.label;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -24,10 +24,23 @@ public abstract class Vertex<T> implements Observable<T> {
     private T value;
     private final ValueUpdater<T> valueUpdater;
     private final Observable<T> observation;
+    private String label = null;
 
     public Vertex(ValueUpdater<T> valueUpdater) {
         this.valueUpdater = valueUpdater;
         this.observation = Observable.observableTypeFor(this.getClass());
+    }
+
+    /**
+     * Set a label for this vertex.  This allows easy retrieval of this vertex using nothing but a label name.
+     * @param label The label to apply to this vertex.  Uniqueness is only enforced on instantiation of a Bayes Net
+     */
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return this.label;
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexLabel.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexLabel.java
@@ -1,0 +1,30 @@
+package io.improbable.keanu.vertices;
+
+import java.util.Objects;
+
+public class VertexLabel {
+    private final String label;
+
+    public VertexLabel(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VertexLabel that = (VertexLabel) o;
+        return Objects.equals(label, that.label);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(label);
+    }
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -58,6 +59,7 @@ public class BayesianNetworkTest {
         BoolVertex a = new BernoulliVertex(0.5);
         BoolVertex b = new BernoulliVertex(0.5);
         BoolVertex ored = a.or(b);
+        BoolVertex or2 = ored.or(a);
         Vertex retrieved;
         VertexLabel labelA = new VertexLabel(LABEL_A);
         VertexLabel labelB = new VertexLabel(LABEL_B);
@@ -74,6 +76,8 @@ public class BayesianNetworkTest {
         assertThat(retrieved, is(b));
         retrieved = net.getVertexByLabel(labelOr);
         assertThat(retrieved, is(ored));
+        retrieved = net.getVertexByLabel(null);
+        assertThat(retrieved, nullValue());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
+import io.improbable.keanu.vertices.Vertex;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,5 +47,29 @@ public class BayesianNetworkTest {
         assertThat(network.getObservedVertices(), contains(output));
         output.unobserve();
         assertThat(network.getObservedVertices(), is(empty()));
+    }
+
+    @Test
+    public void youCanLabelVertices() {
+        BoolVertex a = new BernoulliVertex(0.5);
+        BoolVertex b = new BernoulliVertex(0.5);
+        BoolVertex ored = a.or(b);
+        BayesianNetwork net;
+        Vertex retrieved;
+        final String LABEL_A = "Label A";
+        final String LABEL_B = "Label B";
+        final String LABEL_ORED = "Output";
+
+        a.setLabel(LABEL_A);
+        b.setLabel(LABEL_B);
+        ored.setLabel(LABEL_ORED);
+
+        net = new BayesianNetwork(a.getConnectedGraph());
+        retrieved = net.getVertexByLabel(LABEL_A);
+        assertThat(retrieved, is(a));
+        retrieved = net.getVertexByLabel(LABEL_B);
+        assertThat(retrieved, is(b));
+        retrieved = net.getVertexByLabel(LABEL_ORED);
+        assertThat(retrieved, is(ored));
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -57,14 +57,13 @@ public class BayesianNetworkTest {
         BoolVertex a = new BernoulliVertex(0.5);
         BoolVertex b = new BernoulliVertex(0.5);
         BoolVertex ored = a.or(b);
-        BayesianNetwork net;
         Vertex retrieved;
 
         a.setLabel(LABEL_A);
         b.setLabel(LABEL_B);
         ored.setLabel(LABEL_ORED);
 
-        net = new BayesianNetwork(a.getConnectedGraph());
+        BayesianNetwork net = new BayesianNetwork(a.getConnectedGraph());
         retrieved = net.getVertexByLabel(LABEL_A);
         assertThat(retrieved, is(a));
         retrieved = net.getVertexByLabel(LABEL_B);
@@ -78,11 +77,10 @@ public class BayesianNetworkTest {
         BoolVertex a = new BernoulliVertex(0.5);
         BoolVertex b = new BernoulliVertex(0.5);
         BoolVertex ored = a.or(b);
-        BayesianNetwork net;
 
         a.setLabel(LABEL_A);
         b.setLabel(LABEL_A);
 
-        net = new BayesianNetwork(a.getConnectedGraph());
+        BayesianNetwork net = new BayesianNetwork(a.getConnectedGraph());
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -6,10 +6,11 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-import io.improbable.keanu.vertices.Vertex;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 
@@ -58,17 +59,20 @@ public class BayesianNetworkTest {
         BoolVertex b = new BernoulliVertex(0.5);
         BoolVertex ored = a.or(b);
         Vertex retrieved;
+        VertexLabel labelA = new VertexLabel(LABEL_A);
+        VertexLabel labelB = new VertexLabel(LABEL_B);
+        VertexLabel labelOr = new VertexLabel(LABEL_ORED);
 
-        a.setLabel(LABEL_A);
-        b.setLabel(LABEL_B);
-        ored.setLabel(LABEL_ORED);
+        a.setLabel(labelA);
+        b.setLabel(labelB);
+        ored.setLabel(labelOr);
 
         BayesianNetwork net = new BayesianNetwork(a.getConnectedGraph());
-        retrieved = net.getVertexByLabel(LABEL_A);
+        retrieved = net.getVertexByLabel(labelA);
         assertThat(retrieved, is(a));
-        retrieved = net.getVertexByLabel(LABEL_B);
+        retrieved = net.getVertexByLabel(labelB);
         assertThat(retrieved, is(b));
-        retrieved = net.getVertexByLabel(LABEL_ORED);
+        retrieved = net.getVertexByLabel(labelOr);
         assertThat(retrieved, is(ored));
     }
 
@@ -78,8 +82,8 @@ public class BayesianNetworkTest {
         BoolVertex b = new BernoulliVertex(0.5);
         BoolVertex ored = a.or(b);
 
-        a.setLabel(LABEL_A);
-        b.setLabel(LABEL_A);
+        a.setLabel(new VertexLabel(LABEL_A));
+        b.setLabel(new VertexLabel(LABEL_A));
 
         BayesianNetwork net = new BayesianNetwork(a.getConnectedGraph());
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -59,7 +59,7 @@ public class BayesianNetworkTest {
         BoolVertex a = new BernoulliVertex(0.5);
         BoolVertex b = new BernoulliVertex(0.5);
         BoolVertex ored = a.or(b);
-        BoolVertex or2 = ored.or(a);
+        BoolVertex unlabelled = ored.or(a);
         Vertex retrieved;
         VertexLabel labelA = new VertexLabel(LABEL_A);
         VertexLabel labelB = new VertexLabel(LABEL_B);

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -19,6 +19,9 @@ public class BayesianNetworkTest {
     BoolVertex input1;
     BoolVertex input2;
     BoolVertex output;
+    final String LABEL_A = "Label A";
+    final String LABEL_B = "Label B";
+    final String LABEL_ORED = "Output";
 
     @Before
     public void setUpNetwork() {
@@ -56,9 +59,6 @@ public class BayesianNetworkTest {
         BoolVertex ored = a.or(b);
         BayesianNetwork net;
         Vertex retrieved;
-        final String LABEL_A = "Label A";
-        final String LABEL_B = "Label B";
-        final String LABEL_ORED = "Output";
 
         a.setLabel(LABEL_A);
         b.setLabel(LABEL_B);
@@ -71,5 +71,18 @@ public class BayesianNetworkTest {
         assertThat(retrieved, is(b));
         retrieved = net.getVertexByLabel(LABEL_ORED);
         assertThat(retrieved, is(ored));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void labelErrorsDetected() {
+        BoolVertex a = new BernoulliVertex(0.5);
+        BoolVertex b = new BernoulliVertex(0.5);
+        BoolVertex ored = a.or(b);
+        BayesianNetwork net;
+
+        a.setLabel(LABEL_A);
+        b.setLabel(LABEL_A);
+
+        net = new BayesianNetwork(a.getConnectedGraph());
     }
 }


### PR DESCRIPTION
Add the ability to Label Vertices and retrieve them from a BayesNet via the label.  Will detect repeated labels on Bayesnet creation and throw an exception.