### PR TITLE
Feature/fix coverage

### DIFF
--- a/keanu-project/build.gradle
+++ b/keanu-project/build.gradle
@@ -14,6 +14,9 @@ plugins {
     id 'maven'
 }
 
+apply plugin: 'java'
+apply plugin: 'jacoco'
+
 group = 'io.improbable'
 archivesBaseName = "keanu"
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,4 @@ sonar.sources=keanu-project/src/main
 sonar.tests=keanu-project/src/test
 sonar.java.binaries=keanu-project/build/classes/java/main
 sonar.test.binaries=keanu-project/build/classes/java/test
+sonar.jacoco.reportPaths=keanu-project/build/jacoco/test.exec


### PR DESCRIPTION
I *think* this should be sufficient for Travis to now upload coverage data to SonarCloud, so we'll be able to track things on there.  Unfortunately I can't test it fully as Sonarcloud only seems to display coverage information for long lived branches, but in the travis logs - I *do* see it analysing the Jacoco coverage data now so fingers crossed!