### PR TITLE
Some work on `withParameters` API for distributions

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -29,6 +29,7 @@ public class Beta implements ContinuousDistribution {
      * @param beta  shape parameter (not to be confused with tensor shape)
      * @param xMin  minimum value of random variable x
      * @param xMax  maximum value of random variable x
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor alpha, DoubleTensor beta, DoubleTensor xMin, DoubleTensor xMax) {
         return new Beta(alpha, beta, xMin, xMax);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -11,6 +11,12 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.2 page 14"
+ */
 public class Beta implements ContinuousDistribution {
 
     private final DoubleTensor alpha;
@@ -19,16 +25,10 @@ public class Beta implements ContinuousDistribution {
     private final DoubleTensor xMax;
 
     /**
-     * <h3>Beta Distribution</h3>
-     *
      * @param alpha shape parameter (not to be confused with tensor shape)
      * @param beta  shape parameter (not to be confused with tensor shape)
      * @param xMin  minimum value of random variable x
      * @param xMax  maximum value of random variable x
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.2 page 14"
      */
     public static ContinuousDistribution withParameters(DoubleTensor alpha, DoubleTensor beta, DoubleTensor xMin, DoubleTensor xMax) {
         return new Beta(alpha, beta, xMin, xMax);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -19,25 +19,25 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
  */
 public class Beta implements ContinuousDistribution {
 
-    private final DoubleTensor alpha;
-    private final DoubleTensor beta;
+    private final DoubleTensor distributionShape1;
+    private final DoubleTensor distributionShape2;
     private final DoubleTensor xMin;
     private final DoubleTensor xMax;
 
     /**
-     * @param alpha shape parameter (not to be confused with tensor shape)
-     * @param beta  shape parameter (not to be confused with tensor shape)
-     * @param xMin  minimum value of random variable x
-     * @param xMax  maximum value of random variable x
+     * @param distributionShape1 shape parameter (not to be confused with tensor shape)
+     * @param distributionShape2 shape parameter (not to be confused with tensor shape)
+     * @param xMin               minimum value of random variable x
+     * @param xMax               maximum value of random variable x
      * @return an instance of {@link ContinuousDistribution}
      */
-    public static ContinuousDistribution withParameters(DoubleTensor alpha, DoubleTensor beta, DoubleTensor xMin, DoubleTensor xMax) {
-        return new Beta(alpha, beta, xMin, xMax);
+    public static ContinuousDistribution withParameters(DoubleTensor distributionShape1, DoubleTensor distributionShape2, DoubleTensor xMin, DoubleTensor xMax) {
+        return new Beta(distributionShape1, distributionShape2, xMin, xMax);
     }
 
-    private Beta(DoubleTensor alpha, DoubleTensor beta, DoubleTensor xMin, DoubleTensor xMax) {
-        this.alpha = alpha;
-        this.beta = beta;
+    private Beta(DoubleTensor distributionShape1, DoubleTensor distributionShape2, DoubleTensor xMin, DoubleTensor xMax) {
+        this.distributionShape1 = distributionShape1;
+        this.distributionShape2 = distributionShape2;
         this.xMin = xMin;
         this.xMax = xMax;
     }
@@ -45,8 +45,8 @@ public class Beta implements ContinuousDistribution {
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
 
-        final DoubleTensor y1 = random.nextGamma(shape, DoubleTensor.ONE_SCALAR, alpha);
-        final DoubleTensor y2 = random.nextGamma(shape, DoubleTensor.ONE_SCALAR, beta);
+        final DoubleTensor y1 = random.nextGamma(shape, DoubleTensor.ONE_SCALAR, distributionShape1);
+        final DoubleTensor y2 = random.nextGamma(shape, DoubleTensor.ONE_SCALAR, distributionShape2);
 
         final DoubleTensor range = xMax.minus(xMin);
         final DoubleTensor y1PlusY2 = y1.plus(y2);
@@ -54,19 +54,19 @@ public class Beta implements ContinuousDistribution {
         final DoubleTensor lessThan = xMax.minus(y2.div(y1PlusY2).timesInPlace(range));
         final DoubleTensor greaterThan = xMin.plus(y1.div(y1PlusY2).timesInPlace(range));
 
-        final DoubleTensor lessMask = alpha.getLessThanMask(beta);
-        final DoubleTensor greaterMask = alpha.getGreaterThanOrEqualToMask(beta);
+        final DoubleTensor lessMask = distributionShape1.getLessThanMask(distributionShape2);
+        final DoubleTensor greaterMask = distributionShape1.getGreaterThanOrEqualToMask(distributionShape2);
 
         return lessMask.timesInPlace(lessThan).plusInPlace(greaterMask.timesInPlace(greaterThan));
     }
 
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
-        final DoubleTensor lnGammaAlpha = alpha.apply(Gamma::logGamma);
-        final DoubleTensor lnGammaBeta = beta.apply(Gamma::logGamma);
-        final DoubleTensor alphaPlusBetaLnGamma = (alpha.plus(beta)).applyInPlace(Gamma::logGamma);
-        final DoubleTensor alphaMinusOneTimesLnX = x.log().timesInPlace(alpha.minus(1));
-        final DoubleTensor betaMinusOneTimesOneMinusXLn = x.unaryMinus().plusInPlace(1).logInPlace().timesInPlace(beta.minus(1));
+        final DoubleTensor lnGammaAlpha = distributionShape1.apply(Gamma::logGamma);
+        final DoubleTensor lnGammaBeta = distributionShape2.apply(Gamma::logGamma);
+        final DoubleTensor alphaPlusBetaLnGamma = (distributionShape1.plus(distributionShape2)).applyInPlace(Gamma::logGamma);
+        final DoubleTensor alphaMinusOneTimesLnX = x.log().timesInPlace(distributionShape1.minus(1));
+        final DoubleTensor betaMinusOneTimesOneMinusXLn = x.unaryMinus().plusInPlace(1).logInPlace().timesInPlace(distributionShape2.minus(1));
 
         final DoubleTensor betaFunction = lnGammaAlpha.plusInPlace(lnGammaBeta).minusInPlace(alphaPlusBetaLnGamma);
 
@@ -76,12 +76,12 @@ public class Beta implements ContinuousDistribution {
     @Override
     public Diffs dLogProb(DoubleTensor x) {
         final DoubleTensor oneMinusX = x.unaryMinus().plusInPlace(1);
-        final DoubleTensor digammaAlphaPlusBeta = alpha.plus(beta).applyInPlace(Gamma::digamma);
-        final DoubleTensor alphaMinusOneDivX = x.reciprocal().timesInPlace(alpha.minus(1));
+        final DoubleTensor digammaAlphaPlusBeta = distributionShape1.plus(distributionShape2).applyInPlace(Gamma::digamma);
+        final DoubleTensor alphaMinusOneDivX = x.reciprocal().timesInPlace(distributionShape1.minus(1));
 
-        final DoubleTensor dLogPdx = alphaMinusOneDivX.minusInPlace(oneMinusX.reciprocal().timesInPlace(beta.minus(1)));
-        final DoubleTensor dLogPda = x.log().plusInPlace(digammaAlphaPlusBeta.minus(alpha.apply(Gamma::digamma)));
-        final DoubleTensor dLogPdb = oneMinusX.logInPlace().plusInPlace(digammaAlphaPlusBeta.minusInPlace(beta.apply(Gamma::digamma)));
+        final DoubleTensor dLogPdx = alphaMinusOneDivX.minusInPlace(oneMinusX.reciprocal().timesInPlace(distributionShape2.minus(1)));
+        final DoubleTensor dLogPda = x.log().plusInPlace(digammaAlphaPlusBeta.minus(distributionShape1.apply(Gamma::digamma)));
+        final DoubleTensor dLogPdb = oneMinusX.logInPlace().plusInPlace(digammaAlphaPlusBeta.minusInPlace(distributionShape2.apply(Gamma::digamma)));
 
         return new Diffs()
             .put(A, dLogPda)

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -18,6 +18,18 @@ public class Beta implements ContinuousDistribution {
     private final DoubleTensor xMin;
     private final DoubleTensor xMax;
 
+    /**
+     * <h3>Beta Distribution</h3>
+     *
+     * @param alpha shape parameter (not to be confused with tensor shape)
+     * @param beta  shape parameter (not to be confused with tensor shape)
+     * @param xMin  minimum value of random variable x
+     * @param xMax  maximum value of random variable x
+     * @see "Computer Generation of Statistical Distributions
+     * by Richard Saucier
+     * ARL-TR-2168 March 2000
+     * 5.1.2 page 14"
+     */
     public static ContinuousDistribution withParameters(DoubleTensor alpha, DoubleTensor beta, DoubleTensor xMin, DoubleTensor xMax) {
         return new Beta(alpha, beta, xMin, xMax);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Cauchy.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Cauchy.java
@@ -25,6 +25,7 @@ public class Cauchy implements ContinuousDistribution {
     /**
      * @param location shifts the distribution
      * @param scale    stretches/shrinks the distribution, must be greater than 0
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new Cauchy(location, scale);
@@ -36,7 +37,11 @@ public class Cauchy implements ContinuousDistribution {
     }
 
     /**
-     * @throws IllegalArgumentException if non-positive scale was passed to {@link #withParameters(DoubleTensor location, DoubleTensor scale)}
+     * @param shape  an integer array describing the shape of the tensors to be sampled
+     * @param random {@link KeanuRandom}
+     * @return an instance of {@link DoubleTensor}
+     * @throws IllegalArgumentException if <code>scale</code> passed to {@link #withParameters(DoubleTensor location, DoubleTensor scale)}
+     *                                  is less than or equal to 0
      */
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Cauchy.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Cauchy.java
@@ -16,6 +16,16 @@ public class Cauchy implements ContinuousDistribution {
     private final DoubleTensor location;
     private final DoubleTensor scale;
 
+    /**
+     * <h3>Cauchy (Lorentz) Distribution</h3>
+     *
+     * @param location shifts the distribution
+     * @param scale    stretches/shrinks the distribution, must be greater than 0
+     * @see "Computer Generation of Statistical Distributions
+     * by Richard Saucier,
+     * ARL-TR-2168 March 2000,
+     * 5.1.3 page 15"
+     */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new Cauchy(location, scale);
     }
@@ -25,6 +35,9 @@ public class Cauchy implements ContinuousDistribution {
         this.scale = scale;
     }
 
+    /**
+     * @throws IllegalArgumentException if non-positive scale was passed to {@link #withParameters(DoubleTensor location, DoubleTensor scale)}
+     */
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
         if (!scale.greaterThan(0.0).allTrue()) {
@@ -61,4 +74,5 @@ public class Cauchy implements ContinuousDistribution {
             .put(S, dLogPdscale)
             .put(X, dLogPdx);
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Cauchy.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Cauchy.java
@@ -10,6 +10,12 @@ import static io.improbable.keanu.distributions.dual.Diffs.L;
 import static io.improbable.keanu.distributions.dual.Diffs.S;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.3 page 15"
+ */
 public class Cauchy implements ContinuousDistribution {
 
     private static final double NEG_LOG_PI = -Math.log(Math.PI);
@@ -17,14 +23,8 @@ public class Cauchy implements ContinuousDistribution {
     private final DoubleTensor scale;
 
     /**
-     * <h3>Cauchy (Lorentz) Distribution</h3>
-     *
      * @param location shifts the distribution
      * @param scale    stretches/shrinks the distribution, must be greater than 0
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.3 page 15"
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new Cauchy(location, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
@@ -21,6 +21,7 @@ public class ChiSquared implements ContinuousDistribution {
 
     /**
      * @param alpha shape parameter (not to be confused with tensor shape); number of degrees of freedom
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(IntegerTensor alpha) {
         return new ChiSquared(alpha);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
@@ -8,19 +8,19 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.4 page 16"
+ */
 public class ChiSquared implements ContinuousDistribution {
 
     private static final double LOG_TWO = Math.log(2);
     private final IntegerTensor alpha;
 
     /**
-     * <h3>Chi-Square Distribution</h3>
-     *
      * @param alpha shape parameter (not to be confused with tensor shape); number of degrees of freedom
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.4 page 16"
      */
     public static ContinuousDistribution withParameters(IntegerTensor alpha) {
         return new ChiSquared(alpha);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
@@ -17,30 +17,30 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 public class ChiSquared implements ContinuousDistribution {
 
     private static final double LOG_TWO = Math.log(2);
-    private final IntegerTensor alpha;
+    private final IntegerTensor degreesOfFreedom;
 
     /**
-     * @param alpha shape parameter (not to be confused with tensor shape); number of degrees of freedom
+     * @param degreesOfFreedom number of degrees of freedom
      * @return an instance of {@link ContinuousDistribution}
      */
-    public static ContinuousDistribution withParameters(IntegerTensor alpha) {
-        return new ChiSquared(alpha);
+    public static ContinuousDistribution withParameters(IntegerTensor degreesOfFreedom) {
+        return new ChiSquared(degreesOfFreedom);
     }
 
-    private ChiSquared(IntegerTensor alpha) {
-        this.alpha = alpha;
+    private ChiSquared(IntegerTensor degreesOfFreedom) {
+        this.degreesOfFreedom = degreesOfFreedom;
     }
 
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
-        return random.nextGamma(shape, DoubleTensor.TWO_SCALAR, alpha.toDouble().div(2));
+        return random.nextGamma(shape, DoubleTensor.TWO_SCALAR, degreesOfFreedom.toDouble().div(2));
     }
 
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
-        DoubleTensor halfDof = alpha.toDouble().div(2);
-        DoubleTensor numerator = halfDof.minus(1).timesInPlace(x.log()).minusInPlace(x.div(2));
-        DoubleTensor denominator = halfDof.times(LOG_TWO).plusInPlace(halfDof.apply(Gamma::gamma).logInPlace());
+        DoubleTensor halfK = degreesOfFreedom.toDouble().div(2);
+        DoubleTensor numerator = halfK.minus(1).timesInPlace(x.log()).minusInPlace(x.div(2));
+        DoubleTensor denominator = halfK.times(LOG_TWO).plusInPlace(halfK.apply(Gamma::gamma).logInPlace());
         return numerator.minusInPlace(denominator);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
@@ -11,26 +11,35 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 public class ChiSquared implements ContinuousDistribution {
 
     private static final double LOG_TWO = Math.log(2);
-    private final IntegerTensor k;
+    private final IntegerTensor alpha;
 
-    public static ContinuousDistribution withParameters(IntegerTensor k) {
-        return new ChiSquared(k);
+    /**
+     * <h3>Chi-Square Distribution</h3>
+     *
+     * @param alpha shape parameter (not to be confused with tensor shape); number of degrees of freedom
+     * @see "Computer Generation of Statistical Distributions
+     * by Richard Saucier,
+     * ARL-TR-2168 March 2000,
+     * 5.1.4 page 16"
+     */
+    public static ContinuousDistribution withParameters(IntegerTensor alpha) {
+        return new ChiSquared(alpha);
     }
 
-    private ChiSquared(IntegerTensor k) {
-        this.k = k;
+    private ChiSquared(IntegerTensor alpha) {
+        this.alpha = alpha;
     }
 
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
-        return random.nextGamma(shape, DoubleTensor.TWO_SCALAR, k.toDouble().div(2));
+        return random.nextGamma(shape, DoubleTensor.TWO_SCALAR, alpha.toDouble().div(2));
     }
 
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
-        DoubleTensor halfK = k.toDouble().div(2);
-        DoubleTensor numerator = halfK.minus(1).timesInPlace(x.log()).minusInPlace(x.div(2));
-        DoubleTensor denominator = halfK.times(LOG_TWO).plusInPlace(halfK.apply(Gamma::gamma).logInPlace());
+        DoubleTensor halfDof = alpha.toDouble().div(2);
+        DoubleTensor numerator = halfDof.minus(1).timesInPlace(x.log()).minusInPlace(x.div(2));
+        DoubleTensor denominator = halfDof.times(LOG_TWO).plusInPlace(halfDof.apply(Gamma::gamma).logInPlace());
         return numerator.minusInPlace(denominator);
     }
 
@@ -38,4 +47,5 @@ public class ChiSquared implements ContinuousDistribution {
     public Diffs dLogProb(DoubleTensor x) {
         throw new UnsupportedOperationException();
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
@@ -13,6 +13,13 @@ public class Dirichlet implements ContinuousDistribution {
     private static final double EPSILON =  0.00001;
     private final DoubleTensor concentration;
 
+    /**
+     * <h3>Dirichlet Distribution</h3>
+     *
+     * @param concentration a type of numerical parameter of parametric family of probability distributions,
+     *                      sum of values must equal to 1
+     * @see <a href="https://en.wikipedia.org/wiki/Dirichlet_distribution">Wikipedia</a>
+     */
     public static ContinuousDistribution withParameters(DoubleTensor concentration) {
         return new Dirichlet(concentration);
     }
@@ -31,6 +38,10 @@ public class Dirichlet implements ContinuousDistribution {
         return normalise(gammaSamples);
     }
 
+    /**
+     * @throws IllegalArgumentException if sum of values in concentration passed to
+     *                                  {@link #withParameters(DoubleTensor concentration)} does not equal to 1
+     */
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
         if (Math.abs(x.sum() - 1.0) > EPSILON) {
@@ -58,4 +69,5 @@ public class Dirichlet implements ContinuousDistribution {
         double sum = gammaSamples.sum();
         return gammaSamples.div(sum);
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
@@ -19,6 +19,7 @@ public class Dirichlet implements ContinuousDistribution {
     /**
      * @param concentration a type of numerical parameter of parametric family of probability distributions,
      *                      sum of values must equal to 1
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor concentration) {
         return new Dirichlet(concentration);
@@ -39,7 +40,9 @@ public class Dirichlet implements ContinuousDistribution {
     }
 
     /**
-     * @throws IllegalArgumentException if sum of values in concentration passed to
+     * @param x {@link DoubleTensor}
+     * @return the log probability
+     * @throws IllegalArgumentException if sum of values in <code>concentration</code> passed to
      *                                  {@link #withParameters(DoubleTensor concentration)} does not equal to 1
      */
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
@@ -8,17 +8,17 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import static io.improbable.keanu.distributions.dual.Diffs.C;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 
+/**
+ * @see <a href="https://en.wikipedia.org/wiki/Dirichlet_distribution">Wikipedia</a>
+ */
 public class Dirichlet implements ContinuousDistribution {
 
     private static final double EPSILON =  0.00001;
     private final DoubleTensor concentration;
 
     /**
-     * <h3>Dirichlet Distribution</h3>
-     *
      * @param concentration a type of numerical parameter of parametric family of probability distributions,
      *                      sum of values must equal to 1
-     * @see <a href="https://en.wikipedia.org/wiki/Dirichlet_distribution">Wikipedia</a>
      */
     public static ContinuousDistribution withParameters(DoubleTensor concentration) {
         return new Dirichlet(concentration);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -45,9 +45,9 @@ public class Exponential implements ContinuousDistribution {
     @Override
     public Diffs dLogProb(DoubleTensor x) {
         final DoubleTensor dLogPdx = rate.reciprocal().unaryMinusInPlace();
-        final DoubleTensor dLogPdrate = x.minus(rate).divInPlace(rate.pow(2));
+        final DoubleTensor dLogPdlambda = x.minus(rate).divInPlace(rate.pow(2));
         return new Diffs()
-            .put(LAMBDA, dLogPdrate)
+            .put(LAMBDA, dLogPdlambda)
             .put(X, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -20,6 +20,7 @@ public class Exponential implements ContinuousDistribution {
 
     /**
      * @param rate inverse scale
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor rate) {
         return new Exponential(rate);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -10,34 +10,44 @@ import static io.improbable.keanu.distributions.dual.Diffs.X;
 
 public class Exponential implements ContinuousDistribution {
 
-    private final DoubleTensor lambda;
+    private final DoubleTensor rate;
 
-    public static ContinuousDistribution withParameters(DoubleTensor lambda) {
-        return new Exponential(lambda);
+    /**
+     * <h3>Exponential Distribution</h3>
+     *
+     * @param rate inverse scale
+     * @see "Computer Generation of Statistical Distributions
+     * by Richard Saucier,
+     * ARL-TR-2168 March 2000,
+     * 5.1.8 page 20"
+     */
+    public static ContinuousDistribution withParameters(DoubleTensor rate) {
+        return new Exponential(rate);
     }
 
-    private Exponential(DoubleTensor lambda) {
-        this.lambda = lambda;
+    private Exponential(DoubleTensor rate) {
+        this.rate = rate;
     }
 
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
-        return random.nextDouble(shape).logInPlace().timesInPlace(lambda).unaryMinusInPlace();
+        return random.nextDouble(shape).logInPlace().timesInPlace(rate).unaryMinusInPlace();
     }
 
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
-        final DoubleTensor negXMinusADivB = x.unaryMinus().divInPlace(lambda);
-        final DoubleTensor negXMinusADivBMinusLogB = negXMinusADivB.minusInPlace(lambda.log());
+        final DoubleTensor negXMinusADivB = x.unaryMinus().divInPlace(rate);
+        final DoubleTensor negXMinusADivBMinusLogB = negXMinusADivB.minusInPlace(rate.log());
         return negXMinusADivBMinusLogB.setWithMask(x.getLessThanMask(DoubleTensor.ZERO_SCALAR), Double.NEGATIVE_INFINITY);
     }
 
     @Override
     public Diffs dLogProb(DoubleTensor x) {
-        final DoubleTensor dLogPdx = lambda.reciprocal().unaryMinusInPlace();
-        final DoubleTensor dLogPdlambda = x.minus(lambda).divInPlace(lambda.pow(2));
+        final DoubleTensor dLogPdx = rate.reciprocal().unaryMinusInPlace();
+        final DoubleTensor dLogPdrate = x.minus(rate).divInPlace(rate.pow(2));
         return new Diffs()
-            .put(LAMBDA, dLogPdlambda)
+            .put(LAMBDA, dLogPdrate)
             .put(X, dLogPdx);
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -8,18 +8,18 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import static io.improbable.keanu.distributions.dual.Diffs.LAMBDA;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.8 page 20"
+ */
 public class Exponential implements ContinuousDistribution {
 
     private final DoubleTensor rate;
 
     /**
-     * <h3>Exponential Distribution</h3>
-     *
      * @param rate inverse scale
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.8 page 20"
      */
     public static ContinuousDistribution withParameters(DoubleTensor rate) {
         return new Exponential(rate);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -106,8 +106,8 @@ public class Gamma implements ContinuousDistribution {
         }
     }
 
-    private static double exponentialSample(double alpha, KeanuRandom random) {
-        return -alpha * Math.log(random.nextDouble());
+    private static double exponentialSample(double scale, KeanuRandom random) {
+        return -scale * Math.log(random.nextDouble());
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -31,10 +31,9 @@ public class Gamma implements ContinuousDistribution {
     private final DoubleTensor alpha;
 
     /**
-     * <h3>Gamma Distribution</h3>
-     *
      * @param scale    stretches/shrinks the distribution, must be greater than 0
      * @param alpha    shape parameter (not to be confused with tensor shape)
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor scale, DoubleTensor alpha) {
         return new Gamma(scale, alpha);
@@ -46,7 +45,10 @@ public class Gamma implements ContinuousDistribution {
     }
 
     /**
-     * @throws IllegalArgumentException if scale or alpha passed to {@link #withParameters(DoubleTensor scale, DoubleTensor alpha)}
+     * @param shape  an integer array describing the shape of the tensors to be sampled
+     * @param random {@link KeanuRandom}
+     * @return an instance of {@link DoubleTensor}
+     * @throws IllegalArgumentException if <code>scale</code> passed to {@link #withParameters(DoubleTensor location, DoubleTensor scale)}
      *                                  is less than or equal to 0
      */
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -17,6 +17,12 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.11 page 23"
+ */
 public class Gamma implements ContinuousDistribution {
 
     private static final double M_E = 0.577215664901532860606512090082;
@@ -29,10 +35,6 @@ public class Gamma implements ContinuousDistribution {
      *
      * @param scale    stretches/shrinks the distribution, must be greater than 0
      * @param alpha    shape parameter (not to be confused with tensor shape)
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.11 page 23"
      */
     public static ContinuousDistribution withParameters(DoubleTensor scale, DoubleTensor alpha) {
         return new Gamma(scale, alpha);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -55,7 +55,7 @@ public class Gaussian implements ContinuousDistribution {
         final DoubleTensor variance = standardDeviation.pow(2);
         final DoubleTensor xMinusMu = x.minus(mean);
 
-        final DoubleTensor dLogPdmu = xMinusMu.div(standardDeviation);
+        final DoubleTensor dLogPdmu = xMinusMu.div(variance);
         final DoubleTensor dLogPdx = dLogPdmu.unaryMinus();
         final DoubleTensor dLogPdsigma = xMinusMu.powInPlace(2)
             .divInPlace(variance.timesInPlace(standardDeviation))

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -9,6 +9,12 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.16 page 29"
+ */
 public class Gaussian implements ContinuousDistribution {
 
     private static final double SQRT_2PI = Math.sqrt(Math.PI * 2);
@@ -17,13 +23,8 @@ public class Gaussian implements ContinuousDistribution {
     private final DoubleTensor scale;
 
     /**
-     * <h3>Gaussian (Normal) Distribution</h3>
      * @param location shifts the distribution; mean
      * @param scale    stretches/shrinks the distribution; variance
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.16 page 29"
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new Gaussian(location, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -25,6 +25,7 @@ public class Gaussian implements ContinuousDistribution {
     /**
      * @param mean              the mean of Gaussian Distribution
      * @param standardDeviation the standard deviation of Gaussian Distribution
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor mean, DoubleTensor standardDeviation) {
         return new Gaussian(mean, standardDeviation);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -11,20 +11,20 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.4 page 16"
+ */
 public class InverseGamma implements ContinuousDistribution {
 
     private final DoubleTensor alpha;
     private final DoubleTensor scale;
 
     /**
-     * <h3>Inverted Gamma (Person's Type 6) Distribution</h3>
-     *
      * @param alpha    shape parameter (not to be confused with tensor shape)
      * @param scale    stretches/shrinks the distribution
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.4 page 16"
      */
     public static ContinuousDistribution withParameters(DoubleTensor alpha, DoubleTensor scale) {
         return new InverseGamma(alpha, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -53,14 +53,15 @@ public class InverseGamma implements ContinuousDistribution {
 
     @Override
     public Diffs dLogProb(DoubleTensor x) {
-        final DoubleTensor dLogPdalpha = x.log().unaryMinusInPlace().minusInPlace(distributionShape.apply(Gamma::digamma)).plusInPlace(scale.log());
-        final DoubleTensor dLogPdscale = x.reciprocal().unaryMinusInPlace().plusInPlace(distributionShape.div(scale));
+        final DoubleTensor dPdalpha = x.log().unaryMinusInPlace().minusInPlace(distributionShape.apply(Gamma::digamma)).plusInPlace(scale.log());
+        final DoubleTensor dLogPdbeta = x.reciprocal().unaryMinusInPlace().plusInPlace(distributionShape.div(scale));
         final DoubleTensor dLogPdx = x.pow(2).reciprocalInPlace().timesInPlace(x.times(distributionShape.plus(1).unaryMinusInPlace()).plusInPlace(scale));
 
         return new Diffs()
-            .put(A, dLogPdalpha)
-            .put(B, dLogPdscale)
+            .put(A, dPdalpha)
+            .put(B, dLogPdbeta)
             .put(X, dLogPdx);
     }
+
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -25,6 +25,7 @@ public class InverseGamma implements ContinuousDistribution {
     /**
      * @param alpha    shape parameter (not to be confused with tensor shape)
      * @param scale    stretches/shrinks the distribution
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor alpha, DoubleTensor scale) {
         return new InverseGamma(alpha, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -73,7 +73,7 @@ public class Laplace implements ContinuousDistribution {
     public DoubleTensor logProb(DoubleTensor x) {
         final DoubleTensor locationMinusXAbsNegDivScale = location.minus(x).abs().divInPlace(scale);
         final DoubleTensor logTwoScale = scale.times(2).logInPlace();
-        return  locationMinusXAbsNegDivScale.plusInPlace(logTwoScale).unaryMinus();
+        return locationMinusXAbsNegDivScale.plusInPlace(logTwoScale).unaryMinus();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -12,20 +12,20 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.12 page 25"
+ */
 public class Laplace implements ContinuousDistribution {
 
     private final DoubleTensor location;
     private final DoubleTensor scale;
 
     /**
-     * <h3>Laplace (Double Exponential) Distribution</h3>
-     *
      * @param location shifts the distribution
      * @param scale    stretches/shrinks the distribution, must be greater than 0
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.12 page 25"
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new Laplace(location, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -26,6 +26,7 @@ public class Laplace implements ContinuousDistribution {
     /**
      * @param location shifts the distribution
      * @param scale    stretches/shrinks the distribution, must be greater than 0
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new Laplace(location, scale);
@@ -37,7 +38,10 @@ public class Laplace implements ContinuousDistribution {
     }
 
     /**
-     * @throws IllegalArgumentException if scale passed to {@link #withParameters(DoubleTensor location, DoubleTensor scale)}
+     * @param shape  an integer array describing the shape of the tensors to be sampled
+     * @param random {@link KeanuRandom}
+     * @return an instance of {@link DoubleTensor}
+     * @throws IllegalArgumentException if <code>scale</code> passed to {@link #withParameters(DoubleTensor location, DoubleTensor scale)}
      *                                  is less than or equal to 0
      */
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
@@ -24,6 +24,7 @@ public class LogNormal implements ContinuousDistribution {
     /**
      * @param scale shape parameter (not to be confused with tensor shape)
      * @param alpha stretches/shrinks the distribution
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor scale, DoubleTensor alpha) {
         return new LogNormal(scale, alpha);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
@@ -10,20 +10,20 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.15 page 28"
+ */
 public class LogNormal implements ContinuousDistribution {
 
     private final DoubleTensor location;
     private final DoubleTensor scale;
 
     /**
-     * <h3>Lognormal Distribution</h3>
-     *
      * @param location shifts the distribution
      * @param scale    stretches/shrinks the distribution
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.15 page 28"
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new LogNormal(location, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -23,6 +23,7 @@ public class Logistic implements ContinuousDistribution {
     /**
      * @param location shifts the distribution
      * @param scale    stretches/shrinks the distribution
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new Logistic(location, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -9,19 +9,20 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier,
+ * ARL-TR-2168 March 2000,
+ * 5.1.14 page 27"
+ */
 public class Logistic implements ContinuousDistribution {
 
     private final DoubleTensor location;
     private final DoubleTensor scale;
 
     /**
-     * <h3>Logistic Distribution</h3>
      * @param location shifts the distribution
      * @param scale    stretches/shrinks the distribution
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier,
-     * ARL-TR-2168 March 2000,
-     * 5.1.14 page 27"
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new Logistic(location, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -57,7 +57,7 @@ public class Logistic implements ContinuousDistribution {
         final DoubleTensor bTimesExpAOverB = expAOverB.times(scale);
         final DoubleTensor bTimesExpXOverB = expXOverB.times(scale);
 
-        final DoubleTensor dLogPdlocation = expXOverB.minus(expAOverB).divInPlace(scale.times(expPlus));
+        final DoubleTensor dLogPdmu = expXOverB.minus(expAOverB).divInPlace(scale.times(expPlus));
         final DoubleTensor dLogPdx = expAOverB.minus(expXOverB).divInPlace(bTimesExpAOverB.plus(bTimesExpXOverB));
 
         final DoubleTensor numeratorPartOne = location.times(expXOverB).plusInPlace(x.times(expAOverB)).plusInPlace(
@@ -66,11 +66,11 @@ public class Logistic implements ContinuousDistribution {
         final DoubleTensor numeratorPartTwo = bTimesExpAOverB.plus(bTimesExpXOverB).minusInPlace(x.times(expXOverB));
         final DoubleTensor denominator = scale.pow(2).timesInPlace(expPlus);
 
-        final DoubleTensor dLogPdscale = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
+        final DoubleTensor dLogPds = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
 
         return new Diffs()
-            .put(MU, dLogPdlocation)
-            .put(S, dLogPdscale)
+            .put(MU, dLogPdmu)
+            .put(S, dLogPds)
             .put(X, dLogPdx);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -11,32 +11,36 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class Logistic implements ContinuousDistribution {
 
-    private final DoubleTensor mu;
-    private final DoubleTensor s;
+    private final DoubleTensor location;
+    private final DoubleTensor scale;
 
     /**
-     * @param mu     location parameter (any real number)
-     * @param s      scale parameter (b greater than 0)
-     * @return       a new ContinuousDistribution object
+     * <h3>Logistic Distribution</h3>
+     * @param location shifts the distribution
+     * @param scale    stretches/shrinks the distribution
+     * @see "Computer Generation of Statistical Distributions
+     * by Richard Saucier,
+     * ARL-TR-2168 March 2000,
+     * 5.1.14 page 27"
      */
-    public static ContinuousDistribution withParameters(DoubleTensor mu, DoubleTensor s) {
-        return new Logistic(mu, s);
+    public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
+        return new Logistic(location, scale);
     }
 
-    private Logistic(DoubleTensor mu, DoubleTensor s) {
-        this.mu = mu;
-        this.s = s;
+    private Logistic(DoubleTensor location, DoubleTensor scale) {
+        this.location = location;
+        this.scale = scale;
     }
 
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
-        return random.nextDouble(shape).reciprocalInPlace().minusInPlace(1).logInPlace().timesInPlace(mu.minus(s));
+        return random.nextDouble(shape).reciprocalInPlace().minusInPlace(1).logInPlace().timesInPlace(location.minus(scale));
     }
 
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
-        final DoubleTensor xMinusAOverB = x.minus(mu).divInPlace(s);
-        final DoubleTensor ln1OverB = s.reciprocal().logInPlace();
+        final DoubleTensor xMinusAOverB = x.minus(location).divInPlace(scale);
+        final DoubleTensor ln1OverB = scale.reciprocal().logInPlace();
 
         return xMinusAOverB.plus(ln1OverB).minusInPlace(
             xMinusAOverB.expInPlace().plusInPlace(1).logInPlace().timesInPlace(2)
@@ -45,26 +49,27 @@ public class Logistic implements ContinuousDistribution {
 
     @Override
     public Diffs dLogProb(DoubleTensor x) {
-        final DoubleTensor expAOverB = mu.div(s).expInPlace();
-        final DoubleTensor expXOverB = x.div(s).expInPlace();
+        final DoubleTensor expAOverB = location.div(scale).expInPlace();
+        final DoubleTensor expXOverB = x.div(scale).expInPlace();
         final DoubleTensor expPlus = expAOverB.plus(expXOverB);
-        final DoubleTensor bTimesExpAOverB = expAOverB.times(s);
-        final DoubleTensor bTimesExpXOverB = expXOverB.times(s);
+        final DoubleTensor bTimesExpAOverB = expAOverB.times(scale);
+        final DoubleTensor bTimesExpXOverB = expXOverB.times(scale);
 
-        final DoubleTensor dLogPdmu = expXOverB.minus(expAOverB).divInPlace(s.times(expPlus));
+        final DoubleTensor dLogPdlocation = expXOverB.minus(expAOverB).divInPlace(scale.times(expPlus));
         final DoubleTensor dLogPdx = expAOverB.minus(expXOverB).divInPlace(bTimesExpAOverB.plus(bTimesExpXOverB));
 
-        final DoubleTensor numeratorPartOne = mu.times(expXOverB).plusInPlace(x.times(expAOverB)).plusInPlace(
-            mu.times(expAOverB.unaryMinus())
+        final DoubleTensor numeratorPartOne = location.times(expXOverB).plusInPlace(x.times(expAOverB)).plusInPlace(
+            location.times(expAOverB.unaryMinus())
         );
         final DoubleTensor numeratorPartTwo = bTimesExpAOverB.plus(bTimesExpXOverB).minusInPlace(x.times(expXOverB));
-        final DoubleTensor denominator = s.pow(2).timesInPlace(expPlus);
+        final DoubleTensor denominator = scale.pow(2).timesInPlace(expPlus);
 
-        final DoubleTensor dLogPds = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
+        final DoubleTensor dLogPdscale = numeratorPartOne.plus(numeratorPartTwo).divInPlace(denominator).unaryMinusInPlace();
 
         return new Diffs()
-            .put(MU, dLogPdmu)
-            .put(S, dLogPds)
+            .put(MU, dLogPdlocation)
+            .put(S, dLogPdscale)
             .put(X, dLogPdx);
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
@@ -6,17 +6,17 @@ import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see <a href="https://en.wikipedia.org/wiki/Multivariate_normal_distribution">Wikipedia</a>
+ */
 public class MultivariateGaussian implements ContinuousDistribution {
 
     private final DoubleTensor location;
     private final DoubleTensor scale;
 
     /**
-     * <h3>Multivariate Gaussian (Normal) Distribution</h3>
-     *
      * @param location shifts the distribution; mean
      * @param scale    stretches/shrinks the distribution; covariance
-     * @see <a href="https://en.wikipedia.org/wiki/Multivariate_normal_distribution">Wikipedia</a>
      */
     public static ContinuousDistribution withParameters(DoubleTensor location, DoubleTensor scale) {
         return new MultivariateGaussian(location, scale);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
@@ -17,6 +17,7 @@ public class MultivariateGaussian implements ContinuousDistribution {
     /**
      * @param mean       the mean of Multivariate Gaussian Distribution
      * @param covariance the covariance of Multivariate Gaussian Distribution
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor mean, DoubleTensor covariance) {
         return new MultivariateGaussian(mean, covariance);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -14,28 +14,6 @@ public class SmoothUniform implements ContinuousDistribution {
     private final double edgeSharpness;
 
     /**
-     * <h3>Smooth Uniform Distribution</h3>
-     * <p>This is the usual {@link Uniform} Distribution with the edges at <code>xMax</code> and <code>xMin</code> smoothed
-     * by attaching a sigmoid as shoulders.</p>
-     *
-     * <h4>Math:</h4>
-     * <p>Let <code>f(x)</code> be the sigmoid shoulder function, <code>Sw</code> be shoulder width, <code>Bw</code>
-     * be base width (<code>xMax - xMin</code>), and <code>h</code> be the body height of the base. Then, we have:</p>
-     * <p><code>f(x) = Ax^3 + Bx^2</code></p>
-     * <p><code>f'(x) = 3Ax^2 + 2Bx</code></p>
-     * <p><code>integral f = Ax^4/4 + Bx^3/3</code></p>
-     * <p><code>f(Sw) = h</code></p>
-     * <p><code>integral of f from 0 to Sw = 1</code> (area under the curve must be 1)</p>
-     * <p><code>f'(Sw) = 0</code></p>
-     * <p>which yields:</p>
-     * <p><code>| &nbsp;0 3Sw^2 &nbsp;2Sw   | &nbsp; | h | &nbsp; | 0 |</code></p>
-     * <p><code>|      -1 Sw^3  &nbsp;Sw^2  |    *   | A |    =   | 0 |</code></p>
-     * <p><code>|      Bw Sw/4       2Sw/3  | &nbsp; | B | &nbsp; | 1 |</code></p>
-     * <p>therefore:</p>
-     * <p><code>h = 1 / (Sw + Bw)</code></p>
-     * <p><code>A = -2 / (Sw^3 * (Sw + Bw))</code></p>
-     * <p><code>B = 3 / (Sw^3 * Sw^2*Bw)</code></p>
-     *
      * @param xMin          minimum value of random variable x
      * @param xMax          maximum value of random variable x
      * @param edgeSharpness sharpness as a percentage of (xMax - xMin), which determines the width of the shoulder

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -7,6 +7,35 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * The Smooth Uniform distribution is the usual Uniform distribution with the edges
+ * at max and min smoothed by attaching a sigmoid as shoulders.
+ * <p>
+ * Math:
+ * <p>
+ * let sigmoid shoulder function be f(x), Sw be shoulder width, Bw be base (max-min) width,
+ * and h be the bodyHeight of the base.
+ * <p>
+ * f(x) = Ax^3 + Bx^2
+ * f'(x) = 3Ax^2 + 2Bx
+ * integral f = Ax^4/4 + Bx^3/3
+ * <p>
+ * f(Sw) = h
+ * integral of f from 0 to Sw = 1 (area under the curve must be 1)
+ * f'(Sw) = 0
+ * <p>
+ * yields:
+ * <p>
+ * |  0    3Sw^2    2Sw   |   | h |   | 0 |
+ * | -1    Sw^3     Sw^2  | * | A | = | 0 |
+ * | Bw    Sw/4     2Sw/3 |   | B |   | 1 |
+ * <p>
+ * therefore:
+ * <p>
+ * h = 1 / (Sw + Bw)
+ * A = -2 / (Sw^3 * (Sw + Bw))
+ * B = 3 / (Sw^3 * Sw^2*Bw)
+ */
 public class SmoothUniform implements ContinuousDistribution {
 
     private final DoubleTensor xMin;

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -45,7 +45,8 @@ public class SmoothUniform implements ContinuousDistribution {
     /**
      * @param xMin          minimum value of random variable x
      * @param xMax          maximum value of random variable x
-     * @param edgeSharpness sharpness as a percentage of (xMax - xMin), which determines the width of the shoulder
+     * @param edgeSharpness sharpness as a percentage of <code>(xMax - xMin)</code>, which determines the width of the shoulder
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax, double edgeSharpness) {
         return new SmoothUniform(xMin, xMax, edgeSharpness);
@@ -58,6 +59,10 @@ public class SmoothUniform implements ContinuousDistribution {
 
     /**
      * Samples between <code>xMin</code> and <code>xMax</code> as well as left and right shoulder
+     *
+     * @param shape  an integer array describing the shape of the tensors to be sampled
+     * @param random {@link KeanuRandom}
+     * @return an instance of {@link DoubleTensor}
      */
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -7,35 +7,6 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-/**
- * The Smooth Uniform distribution is the usual Uniform distribution with the edges
- * at max and min smoothed by attaching a sigmoid as shoulders.
- * <p>
- * Math:
- * <p>
- * let sigmoid shoulder function be f(x), Sw be shoulder width, Bw be base (max-min) width,
- * and h be the bodyHeight of the base.
- * <p>
- * f(x) = Ax^3 + Bx^2
- * f'(x) = 3Ax^2 + 2Bx
- * integral f = Ax^4/4 + Bx^3/3
- * <p>
- * f(Sw) = h
- * integral of f from 0 to Sw = 1 (area under the curve must be 1)
- * f'(Sw) = 0
- * <p>
- * yields:
- * <p>
- * |  0    3Sw^2    2Sw   |   | h |   | 0 |
- * | -1    Sw^3     Sw^2  | * | A | = | 0 |
- * | Bw    Sw/4     2Sw/3 |   | B |   | 1 |
- * <p>
- * therefore:
- * <p>
- * h = 1 / (Sw + Bw)
- * A = -2 / (Sw^3 * (Sw + Bw))
- * B = 3 / (Sw^3 * Sw^2*Bw)
- */
 public class SmoothUniform implements ContinuousDistribution {
 
     private final DoubleTensor xMin;
@@ -43,14 +14,31 @@ public class SmoothUniform implements ContinuousDistribution {
     private final double edgeSharpness;
 
     /**
-     * Will return samples between xMin and xMax as well as samples from the left and right shoulder.
-     * The width of the shoulder is determined by the edgeSharpness as a percentage of the body width,
-     * which is (xMax - xMin).
+     * <h3>Smooth Uniform Distribution</h3>
+     * <p>This is the usual {@link Uniform} Distribution with the edges at <code>xMax</code> and <code>xMin</code> smoothed
+     * by attaching a sigmoid as shoulders.</p>
      *
-     * @param xMin          min value from body
-     * @param xMax          max value from body
-     * @param edgeSharpness sharpness as a percentage of the body width
-     * @return       a new ContinuousDistribution object
+     * <h4>Math:</h4>
+     * <p>Let <code>f(x)</code> be the sigmoid shoulder function, <code>Sw</code> be shoulder width, <code>Bw</code>
+     * be base width (<code>xMax - xMin</code>), and <code>h</code> be the body height of the base. Then, we have:</p>
+     * <p><code>f(x) = Ax^3 + Bx^2</code></p>
+     * <p><code>f'(x) = 3Ax^2 + 2Bx</code></p>
+     * <p><code>integral f = Ax^4/4 + Bx^3/3</code></p>
+     * <p><code>f(Sw) = h</code></p>
+     * <p><code>integral of f from 0 to Sw = 1</code> (area under the curve must be 1)</p>
+     * <p><code>f'(Sw) = 0</code></p>
+     * <p>which yields:</p>
+     * <p><code>| &nbsp;0 3Sw^2 &nbsp;2Sw   | &nbsp; | h | &nbsp; | 0 |</code></p>
+     * <p><code>|      -1 Sw^3  &nbsp;Sw^2  |    *   | A |    =   | 0 |</code></p>
+     * <p><code>|      Bw Sw/4       2Sw/3  | &nbsp; | B | &nbsp; | 1 |</code></p>
+     * <p>therefore:</p>
+     * <p><code>h = 1 / (Sw + Bw)</code></p>
+     * <p><code>A = -2 / (Sw^3 * (Sw + Bw))</code></p>
+     * <p><code>B = 3 / (Sw^3 * Sw^2*Bw)</code></p>
+     *
+     * @param xMin          minimum value of random variable x
+     * @param xMax          maximum value of random variable x
+     * @param edgeSharpness sharpness as a percentage of (xMax - xMin), which determines the width of the shoulder
      */
     public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax, double edgeSharpness) {
         return new SmoothUniform(xMin, xMax, edgeSharpness);
@@ -61,6 +49,9 @@ public class SmoothUniform implements ContinuousDistribution {
         this.edgeSharpness = edgeSharpness;
     }
 
+    /**
+     * Samples between <code>xMin</code> and <code>xMax</code> as well as left and right shoulder
+     */
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
 
@@ -174,4 +165,5 @@ public class SmoothUniform implements ContinuousDistribution {
     private static DoubleTensor bodyHeight(DoubleTensor shoulderWidth, DoubleTensor bodyWidth) {
         return shoulderWidth.plus(bodyWidth).reciprocalInPlace();
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -13,19 +13,19 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.23 page 36"
+ */
 public class StudentT implements ContinuousDistribution {
 
     private static final double HALF_LOG_PI = log(PI) / 2;
     private final IntegerTensor alpha;
 
     /**
-     * <h3>Student's T Distribution</h3>
-     *
      * @param alpha shape parameter; number of degrees of freedom
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.23 page 36"
      */
     public static ContinuousDistribution withParameters(IntegerTensor alpha) {
         return new StudentT(alpha);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -13,69 +13,66 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-/**
- * Student T Distribution
- * https://en.wikipedia.org/wiki/Student%27s_t-distribution#Sampling_distribution
- */
 public class StudentT implements ContinuousDistribution {
 
     private static final double HALF_LOG_PI = log(PI) / 2;
-    private final IntegerTensor v;
+    private final IntegerTensor alpha;
 
     /**
-     * Computer Generation of Statistical Distributions
+     * <h3>Student's T Distribution</h3>
+     *
+     * @param alpha shape parameter; number of degrees of freedom
+     * @see "Computer Generation of Statistical Distributions
      * by Richard Saucier
      * ARL-TR-2168 March 2000
-     * 5.1.23 page 36
-     *
-     * @param v      Degrees of Freedom
-     * @return       a new ContinuousDistribution object
+     * 5.1.23 page 36"
      */
-    public static ContinuousDistribution withParameters(IntegerTensor v) {
-        return new StudentT(v);
+    public static ContinuousDistribution withParameters(IntegerTensor alpha) {
+        return new StudentT(alpha);
     }
 
-    private StudentT(IntegerTensor v) {
-        this.v = v;
+    private StudentT(IntegerTensor alpha) {
+        this.alpha = alpha;
     }
 
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
-        DoubleTensor chi2Samples = ChiSquared.withParameters(v).sample(shape, random);
-        return random.nextGaussian(shape).divInPlace(chi2Samples.divInPlace(v.toDouble()).sqrtInPlace());
+        DoubleTensor chi2Samples = ChiSquared.withParameters(alpha).sample(shape, random);
+        return random.nextGaussian(shape).divInPlace(chi2Samples.divInPlace(alpha.toDouble()).sqrtInPlace());
     }
 
     @Override
-    public DoubleTensor logProb(DoubleTensor t) {
+    public DoubleTensor logProb(DoubleTensor x) {
 
-        DoubleTensor vAsDouble = v.toDouble();
-        DoubleTensor halfVPlusOne = vAsDouble.plus(1).divInPlace(2);
+        DoubleTensor dofAsDouble = alpha.toDouble();
+        DoubleTensor halfDofPlusOne = dofAsDouble.plus(1).divInPlace(2);
 
-        DoubleTensor logGammaHalfVPlusOne = halfVPlusOne.apply(Gamma::logGamma);
-        DoubleTensor logGammaHalfV = vAsDouble.div(2).applyInPlace(Gamma::logGamma);
-        DoubleTensor halfLogV = vAsDouble.log().divInPlace(2);
+        DoubleTensor logGammaHalfDofPlusOne = halfDofPlusOne.apply(Gamma::logGamma);
+        DoubleTensor logGammaHalfDof = dofAsDouble.div(2).applyInPlace(Gamma::logGamma);
+        DoubleTensor halfLogDof = dofAsDouble.log().divInPlace(2);
 
-        return logGammaHalfVPlusOne
-            .minusInPlace(halfLogV)
+        return logGammaHalfDofPlusOne
+            .minusInPlace(halfLogDof)
             .minusInPlace(HALF_LOG_PI)
-            .minusInPlace(logGammaHalfV)
+            .minusInPlace(logGammaHalfDof)
             .minusInPlace(
-                halfVPlusOne.timesInPlace(
-                    t.pow(2).divInPlace(vAsDouble).plusInPlace(1).logInPlace()
+                halfDofPlusOne.timesInPlace(
+                    x.pow(2).divInPlace(dofAsDouble).plusInPlace(1).logInPlace()
                 )
             );
     }
 
     @Override
-    public Diffs dLogProb(DoubleTensor t) {
-        DoubleTensor vAsDouble = v.toDouble();
-        DoubleTensor dPdt = t.unaryMinus()
-            .timesInPlace(vAsDouble.plus(1.0))
+    public Diffs dLogProb(DoubleTensor x) {
+        DoubleTensor dofAsDouble = alpha.toDouble();
+        DoubleTensor dPdx = x.unaryMinus()
+            .timesInPlace(dofAsDouble.plus(1.0))
             .divInPlace(
-                t.pow(2).plusInPlace(vAsDouble)
+                x.pow(2).plusInPlace(dofAsDouble)
             );
 
         return new Diffs()
-            .put(T, dPdt);
+            .put(T, dPdx);
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -22,58 +22,58 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 public class StudentT implements ContinuousDistribution {
 
     private static final double HALF_LOG_PI = log(PI) / 2;
-    private final IntegerTensor alpha;
+    private final IntegerTensor degreesOfFreedom;
 
     /**
-     * @param alpha shape parameter; number of degrees of freedom
+     * @param degreesOfFreedom number of degrees of freedom
      * @return an instance of {@link ContinuousDistribution}
      */
-    public static ContinuousDistribution withParameters(IntegerTensor alpha) {
-        return new StudentT(alpha);
+    public static ContinuousDistribution withParameters(IntegerTensor degreesOfFreedom) {
+        return new StudentT(degreesOfFreedom);
     }
 
-    private StudentT(IntegerTensor alpha) {
-        this.alpha = alpha;
+    private StudentT(IntegerTensor degreesOfFreedom) {
+        this.degreesOfFreedom = degreesOfFreedom;
     }
 
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
-        DoubleTensor chi2Samples = ChiSquared.withParameters(alpha).sample(shape, random);
-        return random.nextGaussian(shape).divInPlace(chi2Samples.divInPlace(alpha.toDouble()).sqrtInPlace());
+        DoubleTensor chi2Samples = ChiSquared.withParameters(degreesOfFreedom).sample(shape, random);
+        return random.nextGaussian(shape).divInPlace(chi2Samples.divInPlace(degreesOfFreedom.toDouble()).sqrtInPlace());
     }
 
     @Override
-    public DoubleTensor logProb(DoubleTensor x) {
+    public DoubleTensor logProb(DoubleTensor t) {
 
-        DoubleTensor dofAsDouble = alpha.toDouble();
-        DoubleTensor halfDofPlusOne = dofAsDouble.plus(1).divInPlace(2);
+        DoubleTensor vAsDouble = degreesOfFreedom.toDouble();
+        DoubleTensor halfVPlusOne = vAsDouble.plus(1).divInPlace(2);
 
-        DoubleTensor logGammaHalfDofPlusOne = halfDofPlusOne.apply(Gamma::logGamma);
-        DoubleTensor logGammaHalfDof = dofAsDouble.div(2).applyInPlace(Gamma::logGamma);
-        DoubleTensor halfLogDof = dofAsDouble.log().divInPlace(2);
+        DoubleTensor logGammaHalfVPlusOne = halfVPlusOne.apply(Gamma::logGamma);
+        DoubleTensor logGammaHalfV = vAsDouble.div(2).applyInPlace(Gamma::logGamma);
+        DoubleTensor halfLogV = vAsDouble.log().divInPlace(2);
 
-        return logGammaHalfDofPlusOne
-            .minusInPlace(halfLogDof)
+        return logGammaHalfVPlusOne
+            .minusInPlace(halfLogV)
             .minusInPlace(HALF_LOG_PI)
-            .minusInPlace(logGammaHalfDof)
+            .minusInPlace(logGammaHalfV)
             .minusInPlace(
-                halfDofPlusOne.timesInPlace(
-                    x.pow(2).divInPlace(dofAsDouble).plusInPlace(1).logInPlace()
+                halfVPlusOne.timesInPlace(
+                    t.pow(2).divInPlace(vAsDouble).plusInPlace(1).logInPlace()
                 )
             );
     }
 
     @Override
-    public Diffs dLogProb(DoubleTensor x) {
-        DoubleTensor dofAsDouble = alpha.toDouble();
-        DoubleTensor dPdx = x.unaryMinus()
-            .timesInPlace(dofAsDouble.plus(1.0))
+    public Diffs dLogProb(DoubleTensor t) {
+        DoubleTensor vAsDouble = degreesOfFreedom.toDouble();
+        DoubleTensor dPdt = t.unaryMinus()
+            .timesInPlace(vAsDouble.plus(1.0))
             .divInPlace(
-                x.pow(2).plusInPlace(dofAsDouble)
+                t.pow(2).plusInPlace(vAsDouble)
             );
 
         return new Diffs()
-            .put(T, dPdx);
+            .put(T, dPdt);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -26,6 +26,7 @@ public class StudentT implements ContinuousDistribution {
 
     /**
      * @param alpha shape parameter; number of degrees of freedom
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(IntegerTensor alpha) {
         return new StudentT(alpha);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
@@ -21,6 +21,7 @@ public class Triangular implements ContinuousDistribution {
      * @param xMin minimum value of random variable x
      * @param xMax maximum value of random variable x
      * @param mode location of mode
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor mode) {
         return new Triangular(xMin, xMax, mode);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
@@ -5,6 +5,12 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.24 page 37"
+ */
 public class Triangular implements ContinuousDistribution {
 
     private final DoubleTensor xMin;
@@ -12,15 +18,9 @@ public class Triangular implements ContinuousDistribution {
     private final DoubleTensor mode;
 
     /**
-     * <h3>Triangular Distribution</h3>
-     *
      * @param xMin minimum value of random variable x
      * @param xMax maximum value of random variable x
      * @param mode location of mode
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.24 page 37"
      */
     public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor mode) {
         return new Triangular(xMin, xMax, mode);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Triangular.java
@@ -9,16 +9,27 @@ public class Triangular implements ContinuousDistribution {
 
     private final DoubleTensor xMin;
     private final DoubleTensor xMax;
-    private final DoubleTensor c;
+    private final DoubleTensor mode;
 
-    public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor c) {
-        return new Triangular(xMin, xMax, c);
+    /**
+     * <h3>Triangular Distribution</h3>
+     *
+     * @param xMin minimum value of random variable x
+     * @param xMax maximum value of random variable x
+     * @param mode location of mode
+     * @see "Computer Generation of Statistical Distributions
+     * by Richard Saucier
+     * ARL-TR-2168 March 2000
+     * 5.1.24 page 37"
+     */
+    public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor mode) {
+        return new Triangular(xMin, xMax, mode);
     }
 
-    private Triangular(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor c) {
+    private Triangular(DoubleTensor xMin, DoubleTensor xMax, DoubleTensor mode) {
         this.xMin = xMin;
         this.xMax = xMax;
-        this.c = c;
+        this.mode = mode;
     }
 
     @Override
@@ -27,10 +38,10 @@ public class Triangular implements ContinuousDistribution {
         final DoubleTensor q = p.unaryMinus().plusInPlace(1);
         final DoubleTensor range = xMax.minus(xMin);
 
-        final DoubleTensor conditional = (c.minus(xMin)).divInPlace(xMax.minus(xMin));
+        final DoubleTensor conditional = (mode.minus(xMin)).divInPlace(xMax.minus(xMin));
 
-        final DoubleTensor lessThan = xMin.plus((range.times(c.minus(xMin).timesInPlace(p))).sqrtInPlace());
-        final DoubleTensor greaterThan = xMax.minus((range.timesInPlace(xMax.minus(c).timesInPlace(q))).sqrtInPlace());
+        final DoubleTensor lessThan = xMin.plus((range.times(mode.minus(xMin).timesInPlace(p))).sqrtInPlace());
+        final DoubleTensor greaterThan = xMax.minus((range.timesInPlace(xMax.minus(mode).timesInPlace(q))).sqrtInPlace());
 
         final DoubleTensor lessThanMask = p.getLessThanOrEqualToMask(conditional);
         final DoubleTensor greaterThanMask = p.getGreaterThanMask(conditional);
@@ -43,14 +54,14 @@ public class Triangular implements ContinuousDistribution {
         final DoubleTensor range = xMax.minus(xMin);
 
         final DoubleTensor conditionalFirstHalf = x.getGreaterThanMask(xMin);
-        final DoubleTensor conditionalSecondHalf = x.getLessThanMask(c);
+        final DoubleTensor conditionalSecondHalf = x.getLessThanMask(mode);
         final DoubleTensor conditionalAnd = conditionalFirstHalf.timesInPlace(conditionalSecondHalf);
-        final DoubleTensor conditionalResult = range.reciprocal().timesInPlace(2).timesInPlace(x.minus(xMin)).divInPlace(c.minus(xMin));
+        final DoubleTensor conditionalResult = range.reciprocal().timesInPlace(2).timesInPlace(x.minus(xMin)).divInPlace(mode.minus(xMin));
 
-        final DoubleTensor elseIfConditionalFirstHalf = x.getGreaterThanMask(c);
+        final DoubleTensor elseIfConditionalFirstHalf = x.getGreaterThanMask(mode);
         final DoubleTensor elseIfConditionalSecondHalf = x.getLessThanOrEqualToMask(xMax);
         final DoubleTensor elseIfConditionalAnd = elseIfConditionalFirstHalf.timesInPlace(elseIfConditionalSecondHalf);
-        final DoubleTensor elseIfConditionalResult = range.reciprocalInPlace().timesInPlace(2).timesInPlace(xMax.minus(x)).divInPlace(xMax.minus(c));
+        final DoubleTensor elseIfConditionalResult = range.reciprocalInPlace().timesInPlace(2).timesInPlace(xMax.minus(x)).divInPlace(xMax.minus(mode));
 
         return (conditionalResult.timesInPlace(conditionalAnd).plusInPlace(elseIfConditionalResult.timesInPlace(elseIfConditionalAnd))).logInPlace();
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
@@ -19,6 +19,7 @@ public class Uniform implements ContinuousDistribution {
     /**
      * @param xMin minimum value of random variable x
      * @param xMax maximum value of random variable x
+     * @return an instance of {@link ContinuousDistribution}
      */
     public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax) {
         return new Uniform(xMin, xMax);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
@@ -5,20 +5,20 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see " * Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.1.25 page 38"
+ */
 public class Uniform implements ContinuousDistribution {
 
     private final DoubleTensor xMin;
     private final DoubleTensor xMax;
 
     /**
-     * <h3>Uniform Distribution</h3>
-     *
      * @param xMin minimum value of random variable x
      * @param xMax maximum value of random variable x
-     * @see " * Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.1.25 page 38"
      */
     public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax) {
         return new Uniform(xMin, xMax);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
@@ -5,21 +5,20 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-/**
- * Computer Generation of Statistical Distributions
- * by Richard Saucier
- * ARL-TR-2168 March 2000
- * 5.1.8 page 48
- */
 public class Uniform implements ContinuousDistribution {
 
     private final DoubleTensor xMin;
     private final DoubleTensor xMax;
 
     /**
-     * @param xMin   minimum x value
-     * @param xMax   maximum x value
-     * @return       a new ContinuousDistribution object
+     * <h3>Uniform Distribution</h3>
+     *
+     * @param xMin minimum value of random variable x
+     * @param xMax maximum value of random variable x
+     * @see " * Computer Generation of Statistical Distributions
+     * by Richard Saucier
+     * ARL-TR-2168 March 2000
+     * 5.1.25 page 38"
      */
     public static ContinuousDistribution withParameters(DoubleTensor xMin, DoubleTensor xMax) {
         return new Uniform(xMin, xMax);
@@ -48,4 +47,5 @@ public class Uniform implements ContinuousDistribution {
     public Diffs dLogProb(DoubleTensor x) {
         throw new UnsupportedOperationException();
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Bernoulli.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Bernoulli.java
@@ -5,18 +5,18 @@ import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.2.1 page 42"
+ */
 public class Bernoulli implements Distribution<BooleanTensor> {
 
     private final DoubleTensor probOfEvent;
 
     /**
-     * <h3>Bernoulli Distribution</h3>
-     *
      * @param probOfEvent probability of an event
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.2.1 page 42"
      */
     public static Distribution<BooleanTensor> withParameters(DoubleTensor probOfEvent) {
         return new Bernoulli(probOfEvent);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Bernoulli.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Bernoulli.java
@@ -17,8 +17,9 @@ public class Bernoulli implements Distribution<BooleanTensor> {
 
     /**
      * @param probOfEvent probability of an event
+     * @return an instance of {@link Bernoulli}
      */
-    public static Distribution<BooleanTensor> withParameters(DoubleTensor probOfEvent) {
+    public static Bernoulli withParameters(DoubleTensor probOfEvent) {
         return new Bernoulli(probOfEvent);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Bernoulli.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Bernoulli.java
@@ -7,47 +7,56 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class Bernoulli implements Distribution<BooleanTensor> {
 
-    private final DoubleTensor probTrue;
+    private final DoubleTensor probOfEvent;
 
-    public static Bernoulli withParameters(DoubleTensor probTrue) {
-        return new Bernoulli(probTrue);
+    /**
+     * <h3>Bernoulli Distribution</h3>
+     *
+     * @param probOfEvent probability of an event
+     * @see "Computer Generation of Statistical Distributions
+     * by Richard Saucier
+     * ARL-TR-2168 March 2000
+     * 5.2.1 page 42"
+     */
+    public static Distribution<BooleanTensor> withParameters(DoubleTensor probOfEvent) {
+        return new Bernoulli(probOfEvent);
     }
 
-    private Bernoulli(DoubleTensor probTrue) {
-        this.probTrue = probTrue;
+    private Bernoulli(DoubleTensor probOfEvent) {
+        this.probOfEvent = probOfEvent;
     }
 
     @Override
     public BooleanTensor sample(int[] shape, KeanuRandom random) {
         DoubleTensor uniforms = random.nextDouble(shape);
-        return uniforms.lessThan(probTrue);
+        return uniforms.lessThan(probOfEvent);
     }
 
     @Override
     public DoubleTensor logProb(BooleanTensor x) {
-        DoubleTensor probTrueClamped = probTrue.clamp(DoubleTensor.ZERO_SCALAR, DoubleTensor.ONE_SCALAR);
+        DoubleTensor probOfEventClamped = probOfEvent.clamp(DoubleTensor.ZERO_SCALAR, DoubleTensor.ONE_SCALAR);
 
         DoubleTensor probability = x.setDoubleIf(
-            probTrueClamped,
-            probTrueClamped.unaryMinus().plusInPlace(1.0)
+            probOfEventClamped,
+            probOfEventClamped.unaryMinus().plusInPlace(1.0)
         );
 
         return probability.logInPlace();
     }
 
     public DoubleTensor dLogProb(BooleanTensor x) {
-        DoubleTensor greaterThanMask = probTrue
+        DoubleTensor greaterThanMask = probOfEvent
             .getGreaterThanMask(DoubleTensor.ONE_SCALAR);
 
-        DoubleTensor lessThanOrEqualToMask = probTrue
+        DoubleTensor lessThanOrEqualToMask = probOfEvent
             .getLessThanOrEqualToMask(DoubleTensor.ZERO_SCALAR);
 
         DoubleTensor greaterThanOneOrLessThanZero = greaterThanMask.plusInPlace(lessThanOrEqualToMask);
 
-        DoubleTensor dlogProbdxForTrue = probTrue.reciprocal();
+        DoubleTensor dlogProbdxForTrue = probOfEvent.reciprocal();
         dlogProbdxForTrue = dlogProbdxForTrue.setWithMaskInPlace(greaterThanOneOrLessThanZero, 0.0);
 
-        DoubleTensor dlogProbdxForFalse = probTrue.minus(1.0).reciprocalInPlace();
+        DoubleTensor dlogProbdxForFalse = probOfEvent.minus(1.0).reciprocalInPlace();
         dlogProbdxForFalse = dlogProbdxForFalse.setWithMaskInPlace(greaterThanOneOrLessThanZero, 0.0);
 
         DoubleTensor dLogPdp = x.setDoubleIf(

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Bernoulli.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Bernoulli.java
@@ -35,11 +35,11 @@ public class Bernoulli implements Distribution<BooleanTensor> {
 
     @Override
     public DoubleTensor logProb(BooleanTensor x) {
-        DoubleTensor probOfEventClamped = probOfEvent.clamp(DoubleTensor.ZERO_SCALAR, DoubleTensor.ONE_SCALAR);
+        DoubleTensor probTrueClamped = probOfEvent.clamp(DoubleTensor.ZERO_SCALAR, DoubleTensor.ONE_SCALAR);
 
         DoubleTensor probability = x.setDoubleIf(
-            probOfEventClamped,
-            probOfEventClamped.unaryMinus().plusInPlace(1.0)
+            probTrueClamped,
+            probTrueClamped.unaryMinus().plusInPlace(1.0)
         );
 
         return probability.logInPlace();

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
@@ -22,6 +22,7 @@ public class Binomial implements DiscreteDistribution {
     /**
      * @param successProbability probability of success
      * @param numberOfTrials     number of trials
+     * @return an instance of {@link DiscreteDistribution}
      */
     public static DiscreteDistribution withParameters(DoubleTensor successProbability, IntegerTensor numberOfTrials) {
         return new Binomial(successProbability, numberOfTrials);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
@@ -16,27 +16,27 @@ import org.nd4j.linalg.util.ArrayUtil;
  */
 public class Binomial implements DiscreteDistribution {
 
-    private final DoubleTensor successProbability;
     private final IntegerTensor numberOfTrials;
+    private final DoubleTensor successProbability;
 
     /**
-     * @param successProbability probability of success
      * @param numberOfTrials     number of trials
+     * @param successProbability probability of success
      * @return an instance of {@link DiscreteDistribution}
      */
-    public static DiscreteDistribution withParameters(DoubleTensor successProbability, IntegerTensor numberOfTrials) {
-        return new Binomial(successProbability, numberOfTrials);
+    public static DiscreteDistribution withParameters(IntegerTensor numberOfTrials, DoubleTensor successProbability) {
+        return new Binomial(numberOfTrials, successProbability);
     }
 
-    private Binomial(DoubleTensor successProbability, IntegerTensor numberOfTrials) {
-        this.successProbability = successProbability;
+    private Binomial(IntegerTensor numberOfTrials, DoubleTensor successProbability) {
         this.numberOfTrials = numberOfTrials;
+        this.successProbability = successProbability;
     }
 
     @Override
     public IntegerTensor sample(int[] shape, KeanuRandom random) {
-        Tensor.FlattenedView<Double> pWrapped = successProbability.getFlattenedView();
         Tensor.FlattenedView<Integer> nWrapped = numberOfTrials.getFlattenedView();
+        Tensor.FlattenedView<Double> pWrapped = successProbability.getFlattenedView();
 
         int length = ArrayUtil.prod(shape);
         int[] samples = new int[length];

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
@@ -8,20 +8,20 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.util.CombinatoricsUtils;
 import org.nd4j.linalg.util.ArrayUtil;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.2.2 page 43"
+ */
 public class Binomial implements DiscreteDistribution {
 
     private final DoubleTensor successProbability;
     private final IntegerTensor numberOfTrials;
 
     /**
-     * <h3>Binomial Distribution</h3>
-     *
      * @param successProbability probability of success
      * @param numberOfTrials     number of trials
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.2.2 page 43"
      */
     public static DiscreteDistribution withParameters(DoubleTensor successProbability, IntegerTensor numberOfTrials) {
         return new Binomial(successProbability, numberOfTrials);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
@@ -13,9 +13,11 @@ public class Categorical<T> {
     private final Map<T, DoubleVertex> selectableValues;
 
     /**
-     * @param selectableValues a mapping of category T to event probability
+     * @param selectableValues a mapping of category T to event probability, the total sum of probabilities must not be equal to 0
+     * @param <T>              Category object type
+     * @return an instance of {@link Categorical}
      */
-    public static <T> Categorical withParameters(Map<T, DoubleVertex> selectableValues) {
+    public static <T> Categorical<T> withParameters(Map<T, DoubleVertex> selectableValues) {
         return new Categorical<>(selectableValues);
     }
 
@@ -23,6 +25,11 @@ public class Categorical<T> {
         this.selectableValues = selectableValues;
     }
 
+    /**
+     * @param random {@link KeanuRandom}
+     * @return a sample of T
+     * @throws IllegalArgumentException if <code>selectedValues</code> from {@link Categorical#withParameters(Map selectedValues)} sum to 0
+     */
     public T sample(KeanuRandom random) {
         double sumOfProbabilities = getSumOfProbabilities();
         double p = random.nextDouble();
@@ -48,6 +55,11 @@ public class Categorical<T> {
         return value;
     }
 
+    /**
+     * @param x T
+     * @return log probability at x
+     * @throws IllegalArgumentException if <code>selectedValues</code> from {@link Categorical#withParameters(Map selectedValues)} sum to 0
+     */
     public double logProb(T x) {
         double sumOfProbabilities = getSumOfProbabilities();
         if (sumOfProbabilities == 0.0) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
@@ -9,7 +9,13 @@ public class Categorical<T> {
 
     private final Map<T, DoubleVertex> selectableValues;
 
-    public static <T> Categorical<T> withParameters(Map<T, DoubleVertex> selectableValues) {
+    /**
+     * <h3>Categorical (Generalised Bernoulli Distribution) Distribution</h3>
+     *
+     * @param selectableValues a mapping of category T to event probability
+     * @see <a href="https://en.wikipedia.org/wiki/Categorical_distribution">Wikipedia</a>
+     */
+    public static <T> Categorical withParameters(Map<T, DoubleVertex> selectableValues) {
         return new Categorical<>(selectableValues);
     }
 
@@ -58,4 +64,5 @@ public class Categorical<T> {
         }
         return sumP;
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
@@ -5,15 +5,15 @@ import java.util.Map;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see <a href="https://en.wikipedia.org/wiki/Categorical_distribution">Wikipedia</a>
+ */
 public class Categorical<T> {
 
     private final Map<T, DoubleVertex> selectableValues;
 
     /**
-     * <h3>Categorical (Generalised Bernoulli Distribution) Distribution</h3>
-     *
      * @param selectableValues a mapping of category T to event probability
-     * @see <a href="https://en.wikipedia.org/wiki/Categorical_distribution">Wikipedia</a>
      */
     public static <T> Categorical withParameters(Map<T, DoubleVertex> selectableValues) {
         return new Categorical<>(selectableValues);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -21,7 +21,8 @@ public class Poisson implements DiscreteDistribution {
     private final DoubleTensor rate;
 
     /**
-     * @param rate rate of occurrence
+     * @param rate rate of occurrence, must be greater than 0
+     * @return an instance of {@link DiscreteDistribution}
      */
     public static DiscreteDistribution withParameters(DoubleTensor rate) {
         return new Poisson(rate);
@@ -31,6 +32,12 @@ public class Poisson implements DiscreteDistribution {
         this.rate = rate;
     }
 
+     /**
+     * @param shape  an integer array describing the shape of the tensors to be sampled
+     * @param random {@link KeanuRandom}
+     * @return an instance of {@link DoubleTensor}
+     * @throws IllegalArgumentException if <code>rate</code> passed to {@link #withParameters(DoubleTensor rate)} is less than or equal to 0
+     */
     @Override
     public IntegerTensor sample(int[] shape, KeanuRandom random) {
         Tensor.FlattenedView<Double> rateWrapped = rate.getFlattenedView();

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -10,44 +10,47 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-/**
- * Computer Generation of Statistical Distributions
- * by Richard Saucier
- * ARL-TR-2168 March 2000
- * 5.2.8 page 49
- */
 public class Poisson implements DiscreteDistribution {
 
-    private final DoubleTensor mu;
+    private final DoubleTensor rate;
 
-    public static DiscreteDistribution withParameters(DoubleTensor mu) {
-        return new Poisson(mu);
+    /**
+     * <h3>Poisson Distribution</h3>
+     *
+     * @param rate rate of occurrence
+     * @see "Computer Generation of Statistical Distributions
+     * by Richard Saucier
+     * ARL-TR-2168 March 2000
+     * 5.2.8 page 49"
+     */
+    public static DiscreteDistribution withParameters(DoubleTensor rate) {
+        return new Poisson(rate);
     }
 
-    private Poisson(DoubleTensor mu) {
-        this.mu = mu;
+    private Poisson(DoubleTensor rate) {
+        this.rate = rate;
     }
 
     @Override
     public IntegerTensor sample(int[] shape, KeanuRandom random) {
-        Tensor.FlattenedView<Double> muWrapped = mu.getFlattenedView();
+        Tensor.FlattenedView<Double> rateWrapped = rate.getFlattenedView();
 
         int length = ArrayUtil.prod(shape);
         int[] samples = new int[length];
         for (int i = 0; i < length; i++) {
-            samples[i] = sample(muWrapped.getOrScalar(i), random);
+            samples[i] = sample(rateWrapped.getOrScalar(i), random);
         }
 
         return IntegerTensor.create(samples, shape);
     }
 
-    private static int sample(double mu, KeanuRandom random) {
-        if (mu <= 0.) {
-            throw new IllegalArgumentException("Invalid value for mu: " + mu);
+    private static int sample(double rate, KeanuRandom random) {
+        if (rate <= 0.) {
+            throw new IllegalArgumentException("Invalid value for rate: " + rate);
         }
 
         double b = 1.;
-        double stopB = Math.exp(-mu);
+        double stopB = Math.exp(-rate);
         int i;
 
         for (i = 0; b >= stopB; i++) {
@@ -58,28 +61,29 @@ public class Poisson implements DiscreteDistribution {
     }
 
     @Override
-    public DoubleTensor logProb(IntegerTensor k) {
-        Tensor.FlattenedView<Double> muFlattenedView = mu.getFlattenedView();
-        Tensor.FlattenedView<Integer> kFlattenedView = k.getFlattenedView();
+    public DoubleTensor logProb(IntegerTensor x) {
+        Tensor.FlattenedView<Double> rateFlattenedView = rate.getFlattenedView();
+        Tensor.FlattenedView<Integer> kFlattenedView = x.getFlattenedView();
 
-        double[] result = new double[(int) k.getLength()];
+        double[] result = new double[(int) x.getLength()];
         for (int i = 0; i < result.length; i++) {
-            result[i] = Math.log(pmf(muFlattenedView.getOrScalar(i), kFlattenedView.getOrScalar(i)));
+            result[i] = Math.log(pmf(rateFlattenedView.getOrScalar(i), kFlattenedView.getOrScalar(i)));
         }
 
-        return DoubleTensor.create(result, k.getShape());
+        return DoubleTensor.create(result, x.getShape());
     }
 
-    private static double pmf(double mu, int k) {
-        if (k >= 0 && k < 20) {
-            return (Math.pow(mu, k) / factorial(k)) * Math.exp(-mu);
-        } else if (k >= 20) {
+    private static double pmf(double rate, int x) {
+        if (x >= 0 && x < 20) {
+            return (Math.pow(rate, x) / factorial(x)) * Math.exp(-rate);
+        } else if (x >= 20) {
             double sumOfFactorial = 0;
-            for (int i = 1; i <= k; i++) {
+            for (int i = 1; i <= x; i++) {
                 sumOfFactorial += Math.log(i);
             }
-            return Math.exp((k * Math.log(mu)) - sumOfFactorial - mu);
+            return Math.exp((x * Math.log(rate)) - sumOfFactorial - rate);
         }
         return 0;
     }
+
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -38,26 +38,26 @@ public class Poisson implements DiscreteDistribution {
      * @return an instance of {@link DoubleTensor}
      * @throws IllegalArgumentException if <code>rate</code> passed to {@link #withParameters(DoubleTensor rate)} is less than or equal to 0
      */
-    @Override
-    public IntegerTensor sample(int[] shape, KeanuRandom random) {
-        Tensor.FlattenedView<Double> rateWrapped = rate.getFlattenedView();
+     @Override
+     public IntegerTensor sample(int[] shape, KeanuRandom random) {
+         Tensor.FlattenedView<Double> muWrapped = rate.getFlattenedView();
 
-        int length = ArrayUtil.prod(shape);
-        int[] samples = new int[length];
-        for (int i = 0; i < length; i++) {
-            samples[i] = sample(rateWrapped.getOrScalar(i), random);
-        }
+         int length = ArrayUtil.prod(shape);
+         int[] samples = new int[length];
+         for (int i = 0; i < length; i++) {
+             samples[i] = sample(muWrapped.getOrScalar(i), random);
+         }
 
-        return IntegerTensor.create(samples, shape);
-    }
+         return IntegerTensor.create(samples, shape);
+     }
 
-    private static int sample(double rate, KeanuRandom random) {
-        if (rate <= 0.) {
-            throw new IllegalArgumentException("Invalid value for rate: " + rate);
+    private static int sample(double mu, KeanuRandom random) {
+        if (mu <= 0.) {
+            throw new IllegalArgumentException("Invalid value for mu: " + mu);
         }
 
         double b = 1.;
-        double stopB = Math.exp(-rate);
+        double stopB = Math.exp(-mu);
         int i;
 
         for (i = 0; b >= stopB; i++) {
@@ -68,27 +68,27 @@ public class Poisson implements DiscreteDistribution {
     }
 
     @Override
-    public DoubleTensor logProb(IntegerTensor x) {
-        Tensor.FlattenedView<Double> rateFlattenedView = rate.getFlattenedView();
-        Tensor.FlattenedView<Integer> kFlattenedView = x.getFlattenedView();
+    public DoubleTensor logProb(IntegerTensor k) {
+        Tensor.FlattenedView<Double> muFlattenedView = rate.getFlattenedView();
+        Tensor.FlattenedView<Integer> kFlattenedView = k.getFlattenedView();
 
-        double[] result = new double[(int) x.getLength()];
+        double[] result = new double[(int) k.getLength()];
         for (int i = 0; i < result.length; i++) {
-            result[i] = Math.log(pmf(rateFlattenedView.getOrScalar(i), kFlattenedView.getOrScalar(i)));
+            result[i] = Math.log(pmf(muFlattenedView.getOrScalar(i), kFlattenedView.getOrScalar(i)));
         }
 
-        return DoubleTensor.create(result, x.getShape());
+        return DoubleTensor.create(result, k.getShape());
     }
 
-    private static double pmf(double rate, int x) {
-        if (x >= 0 && x < 20) {
-            return (Math.pow(rate, x) / factorial(x)) * Math.exp(-rate);
-        } else if (x >= 20) {
+    private static double pmf(double mu, int k) {
+        if (k >= 0 && k < 20) {
+            return (Math.pow(mu, k) / factorial(k)) * Math.exp(-mu);
+        } else if (k >= 20) {
             double sumOfFactorial = 0;
-            for (int i = 1; i <= x; i++) {
+            for (int i = 1; i <= k; i++) {
                 sumOfFactorial += Math.log(i);
             }
-            return Math.exp((x * Math.log(rate)) - sumOfFactorial - rate);
+            return Math.exp((k * Math.log(mu)) - sumOfFactorial - mu);
         }
         return 0;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -10,18 +10,18 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
+/**
+ * @see "Computer Generation of Statistical Distributions
+ * by Richard Saucier
+ * ARL-TR-2168 March 2000
+ * 5.2.8 page 49"
+ */
 public class Poisson implements DiscreteDistribution {
 
     private final DoubleTensor rate;
 
     /**
-     * <h3>Poisson Distribution</h3>
-     *
      * @param rate rate of occurrence
-     * @see "Computer Generation of Statistical Distributions
-     * by Richard Saucier
-     * ARL-TR-2168 March 2000
-     * 5.2.8 page 49"
      */
     public static DiscreteDistribution withParameters(DoubleTensor rate) {
         return new Poisson(rate);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
@@ -59,7 +59,7 @@ public class BinomialVertex extends IntegerVertex implements ProbabilisticIntege
 
     @Override
     public double logProb(IntegerTensor kTensor) {
-        return Binomial.withParameters(p.getValue(), n.getValue()).logProb(kTensor).sum();
+        return Binomial.withParameters(n.getValue(), p.getValue()).logProb(kTensor).sum();
     }
 
     @Override
@@ -69,6 +69,6 @@ public class BinomialVertex extends IntegerVertex implements ProbabilisticIntege
 
     @Override
     public IntegerTensor sample(KeanuRandom random) {
-        return Binomial.withParameters(p.getValue(), n.getValue()).sample(getShape(), random);
+        return Binomial.withParameters(n.getValue(), p.getValue()).sample(getShape(), random);
     }
 }


### PR DESCRIPTION
I realise this is a controversial change. I'm open to feedback. Also, I didn't finish some tasks, because I wanted to first continue our slack discussion in a PR since we can all see the method signatures here.

- [x] Rename most parameters to [location](https://en.wikipedia.org/wiki/Location_parameter), [scale](https://en.wikipedia.org/wiki/Scale_parameter) or [shape](https://en.wikipedia.org/wiki/Shape_parameter) (alpha, beta, ...) where appropriate
- [x] Add a JavaDoc for `withParameters` method explaining the parameters in
detail, alternate names of the distribution and references to books/wiki
pages
- [x] Add a JavaDoc for sample methods that throw exceptions
- [ ] Clean up `Diff` parameter names
- [ ] Rename local variables (stopped making changes in case we don't go through with my suggestion)

Note: the shape parameter is not called `shape` because (1) the name
clashes with `shape` for tensors (2) there may be more than one shape
parameters (e.g. see Beta Distribution)

Best way to test this would be to enable JavaDocs on Intellji: go to File/Settings, Editor, click on General. Scroll down, then ✔ Show quick documentation on mouse move

