### PR TITLE
Add a temporary fix for [plus][minus][times][div]InPlace from a scala…

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -115,8 +115,8 @@ public class Gamma implements ContinuousDistribution {
 
     @Override
     public Diffs dLogProb(DoubleTensor x) {
-        final DoubleTensor dLogPdx = k.minus(1.).div(x).minusInPlace(theta.reciprocal());
-        final DoubleTensor dLogPdtheta = theta.times(k).plus(x.unaryMinus()).divInPlace(theta.pow(2.)).unaryMinusInPlace();
+        final DoubleTensor dLogPdx = k.minus(1.).divInPlace(x).minusInPlace(theta.reciprocal());
+        final DoubleTensor dLogPdtheta = theta.times(k).plusInPlace(x.unaryMinus()).divInPlace(theta.pow(2.)).unaryMinusInPlace();
         final DoubleTensor dLogPdk = x.log().minusInPlace(theta.log()).minusInPlace(k.apply(org.apache.commons.math3.special.Gamma::digamma));
 
         return new Diffs()

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -510,6 +510,9 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     public DoubleTensor minusInPlace(DoubleTensor that) {
         if (that.isScalar()) {
             tensor.subi(that.scalar());
+        } else if (this.isScalar()) {
+            // Temporary fix: Scalar can't be subtracted by tensor inplace
+            return this.minus(that);
         } else {
             INDArrayShim.subi(tensor, unsafeGetNd4J(that), tensor);
         }
@@ -520,6 +523,9 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     public DoubleTensor plusInPlace(DoubleTensor that) {
         if (that.isScalar()) {
             tensor.addi(that.scalar());
+        } else if (this.isScalar()) {
+             // Temporary fix: Scalar can't be added by tensor inplace
+            return this.plus(that);
         } else {
             INDArrayShim.addi(tensor, unsafeGetNd4J(that), tensor);
         }
@@ -530,6 +536,9 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     public DoubleTensor timesInPlace(DoubleTensor that) {
         if (that.isScalar()) {
             tensor.muli(that.scalar());
+        } else if (this.isScalar()) {
+             // Temporary fix: Scalar can't be multiplied by tensor inplace
+            return this.times(that);
         } else {
             INDArrayShim.muli(tensor, unsafeGetNd4J(that), tensor);
         }
@@ -540,6 +549,9 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     public DoubleTensor divInPlace(DoubleTensor that) {
         if (that.isScalar()) {
             tensor.divi(that.scalar());
+        } else if (this.isScalar()) {
+             // Temporary fix: Scalar can't be divided by tensor inplace
+            return this.div(that);
         } else {
             INDArrayShim.divi(tensor, unsafeGetNd4J(that), tensor);
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -506,12 +506,16 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         return this;
     }
 
+    /**
+     * @param that Right operand.
+     * @return A new DoubleTensor instance only if <i>this</i> has a length of 1 and right operand has a length greater than 1.
+     * Otherwise return <i>this</i>.
+     */
     @Override
     public DoubleTensor minusInPlace(DoubleTensor that) {
         if (that.isScalar()) {
             tensor.subi(that.scalar());
         } else if (this.isScalar()) {
-            // Temporary fix: Scalar can't be subtracted by tensor inplace
             return this.minus(that);
         } else {
             INDArrayShim.subi(tensor, unsafeGetNd4J(that), tensor);
@@ -519,12 +523,16 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         return this;
     }
 
+     /**
+     * @param that Right operand.
+     * @return A new DoubleTensor instance only if <i>this</i> has a length of 1 and right operand has a length greater than 1.
+     * Otherwise return <i>this</i>.
+     */
     @Override
     public DoubleTensor plusInPlace(DoubleTensor that) {
         if (that.isScalar()) {
             tensor.addi(that.scalar());
         } else if (this.isScalar()) {
-             // Temporary fix: Scalar can't be added by tensor inplace
             return this.plus(that);
         } else {
             INDArrayShim.addi(tensor, unsafeGetNd4J(that), tensor);
@@ -532,12 +540,16 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         return this;
     }
 
+     /**
+     * @param that Right operand.
+     * @return A new DoubleTensor instance only if <i>this</i> has a length of 1 and right operand has a length greater than 1.
+     * Otherwise return <i>this</i>.
+     */
     @Override
     public DoubleTensor timesInPlace(DoubleTensor that) {
         if (that.isScalar()) {
             tensor.muli(that.scalar());
         } else if (this.isScalar()) {
-             // Temporary fix: Scalar can't be multiplied by tensor inplace
             return this.times(that);
         } else {
             INDArrayShim.muli(tensor, unsafeGetNd4J(that), tensor);
@@ -545,12 +557,16 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         return this;
     }
 
+     /**
+     * @param that Right operand.
+     * @return A new DoubleTensor instance only if <i>this</i> has a length of 1 and right operand has a length greater than 1.
+     * Otherwise return <i>this</i>.
+     */
     @Override
     public DoubleTensor divInPlace(DoubleTensor that) {
         if (that.isScalar()) {
             tensor.divi(that.scalar());
         } else if (this.isScalar()) {
-             // Temporary fix: Scalar can't be divided by tensor inplace
             return this.div(that);
         } else {
             INDArrayShim.divi(tensor, unsafeGetNd4J(that), tensor);

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -343,4 +343,36 @@ public class Nd4jDoubleTensorTest {
 
         assertArrayEquals(scalar.div(tensor).asFlatDoubleArray(), scalar.divInPlace(tensor).asFlatDoubleArray(), 1e-6);
     }
+
+    @Test
+    public void smallerTensorMinusInPlaceLargerTensorBehavesSameAsMinus() {
+        DoubleTensor smallerTensor = DoubleTensor.create(2, new int[] {2, 2});
+        DoubleTensor largerTensor = DoubleTensor.create(3, new int[] {2, 2, 2});
+
+        assertArrayEquals(smallerTensor.minus(largerTensor).asFlatDoubleArray(), smallerTensor.minusInPlace(largerTensor).asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
+    public void smallerTensorPlusInPlaceLargerTensorBehavesSameAsPlus() {
+        DoubleTensor smallerTensor = DoubleTensor.create(2, new int[] {2, 2});
+        DoubleTensor largerTensor = DoubleTensor.create(3, new int[] {2, 2, 2});
+
+        assertArrayEquals(smallerTensor.plus(largerTensor).asFlatDoubleArray(), smallerTensor.plusInPlace(largerTensor).asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
+    public void smallerTensorTimesInPlaceLargerTensorBehavesSameAsTimes() {
+        DoubleTensor smallerTensor = DoubleTensor.create(2, new int[] {2, 2});
+        DoubleTensor largerTensor = DoubleTensor.create(3, new int[] {2, 2, 2});
+
+        assertArrayEquals(smallerTensor.times(largerTensor).asFlatDoubleArray(), smallerTensor.timesInPlace(largerTensor).asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
+    public void smallerTensorDivInPlaceLargerTensorBehavesSameAsDiv() {
+        DoubleTensor smallerTensor = DoubleTensor.create(2, new int[] {2, 2});
+        DoubleTensor largerTensor = DoubleTensor.create(3, new int[] {2, 2, 2});
+
+        assertArrayEquals(smallerTensor.div(largerTensor).asFlatDoubleArray(), smallerTensor.divInPlace(largerTensor).asFlatDoubleArray(), 1e-6);
+    }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -312,4 +312,35 @@ public class Nd4jDoubleTensorTest {
         assertTrue(vectorA.isVector() && vectorB.isVector());
     }
 
+    @Test
+    public void scalarMinusInPlaceTensorBehavesSameAsMinus() {
+        DoubleTensor scalar = DoubleTensor.scalar(1);
+        DoubleTensor tensor = DoubleTensor.create(2, new int[] {1, 4});
+
+        assertArrayEquals(scalar.minus(tensor).asFlatDoubleArray(), scalar.minusInPlace(tensor).asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
+    public void scalarPlusInPlaceTensorBehavesSameAsPlus() {
+        DoubleTensor scalar = DoubleTensor.scalar(1);
+        DoubleTensor tensor = DoubleTensor.create(2, new int[] {1, 4});
+
+        assertArrayEquals(scalar.plus(tensor).asFlatDoubleArray(), scalar.plusInPlace(tensor).asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
+    public void scalarTimesInPlaceTensorBehavesSameAsTimes() {
+        DoubleTensor scalar = DoubleTensor.scalar(1);
+        DoubleTensor tensor = DoubleTensor.create(2, new int[] {1, 4});
+
+        assertArrayEquals(scalar.times(tensor).asFlatDoubleArray(), scalar.timesInPlace(tensor).asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
+    public void scalarDivInPlaceTensorBehavesSameAsDiv() {
+        DoubleTensor scalar = DoubleTensor.scalar(1);
+        DoubleTensor tensor = DoubleTensor.create(2, new int[] {1, 4});
+
+        assertArrayEquals(scalar.div(tensor).asFlatDoubleArray(), scalar.divInPlace(tensor).asFlatDoubleArray(), 1e-6);
+    }
 }


### PR DESCRIPTION
…r Nd4jDoubleTensor and a higher dimension Nd4jDoubleTensor

Context: some `dLogProb` tests in `GammaVertexTest` were failing because in place operations between a scalar and tensor weren't behaving as we expected (i.e. returning a scalar instead of a tensor).