### PR TITLE
 Added HalfCauchyVertex: a subclass of CauchyVertex

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -10,7 +10,7 @@ public class HalfCauchyVertex extends CauchyVertex {
     private static final double LOG_TWO = Math.log(2);
 
     /**
-     * One scale that matches a proposed tensor shape of HalfCauchy (Cauchy with location = 0 and x >= 0)
+     * One scale that matches a proposed tensor shape of HalfCauchy (Cauchy with location = 0 and non-negative x)
      * <p>
      * If provided parameter is scalar then the proposed shape determines the shape
      *

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -1,0 +1,51 @@
+package io.improbable.keanu.vertices.dbl.probabilistic;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+
+import java.util.Map;
+
+public class HalfCauchyVertex extends CauchyVertex {
+
+    /**
+     * One scale that matches a proposed tensor shape of Cauchy
+     * <p>
+     * If provided parameter is scalar then the proposed shape determines the shape
+     *
+     * @param tensorShape the desired shape of the tensor in this vertex
+     * @param scale       the scale of the HalfCauchy with either the same tensorShape as specified for this vertex or a scalar
+     */
+    public HalfCauchyVertex(int[] tensorShape, DoubleVertex scale) {
+        super(tensorShape, 0.0, scale);
+    }
+
+    public HalfCauchyVertex(int[] tensorShape, double scale) {
+        super(tensorShape, 0.0, scale);
+    }
+
+    public HalfCauchyVertex(DoubleVertex scale) {
+        super(0.0, scale);
+    }
+
+    public HalfCauchyVertex(double scale) {
+        super(0.0, scale);
+    }
+
+    @Override
+    public double logProb(DoubleTensor value) {
+        if (value.greaterThanOrEqual(0.0).allTrue()) {
+            return super.logProb(value);
+        }
+        return Double.NEGATIVE_INFINITY;
+    }
+
+    @Override
+    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+        Map<Long, DoubleTensor> map = super.dLogProb(value);
+        for (DoubleTensor x: map.values()) {
+            x.timesInPlace(2.0);
+        }
+        return map;
+    }
+
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class HalfCauchyVertex extends CauchyVertex {
 
@@ -34,9 +35,14 @@ public class HalfCauchyVertex extends CauchyVertex {
     @Override
     public double logProb(DoubleTensor value) {
         if (value.greaterThanOrEqual(0.0).allTrue()) {
-            return super.logProb(value) + LOG_TWO;
+            return super.logProb(value) + LOG_TWO * value.getLength();
         }
         return Double.NEGATIVE_INFINITY;
+    }
+
+    @Override
+    public DoubleTensor sample(KeanuRandom random) {
+        return super.sample(random).absInPlace();
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 public class HalfCauchyVertex extends CauchyVertex {
 
+    private static final double LOG_TWO = Math.log(2);
+
     /**
      * One scale that matches a proposed tensor shape of Cauchy
      * <p>
@@ -34,7 +36,7 @@ public class HalfCauchyVertex extends CauchyVertex {
     @Override
     public double logProb(DoubleTensor value) {
         if (value.greaterThanOrEqual(0.0).allTrue()) {
-            return super.logProb(value);
+            return super.logProb(value) + LOG_TWO;
         }
         return Double.NEGATIVE_INFINITY;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -10,7 +10,7 @@ public class HalfCauchyVertex extends CauchyVertex {
     private static final double LOG_TWO = Math.log(2);
 
     /**
-     * One scale that matches a proposed tensor shape of Cauchy
+     * One scale that matches a proposed tensor shape of HalfCauchy (Cauchy with location = 0 and x >= 0)
      * <p>
      * If provided parameter is scalar then the proposed shape determines the shape
      *

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -3,8 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
-import java.util.Map;
-
 public class HalfCauchyVertex extends CauchyVertex {
 
     private static final double LOG_TWO = Math.log(2);
@@ -39,15 +37,6 @@ public class HalfCauchyVertex extends CauchyVertex {
             return super.logProb(value) + LOG_TWO;
         }
         return Double.NEGATIVE_INFINITY;
-    }
-
-    @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
-        Map<Long, DoubleTensor> map = super.dLogProb(value);
-        for (DoubleTensor x: map.values()) {
-            x.timesInPlace(2.0);
-        }
-        return map;
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class HalfCauchyVertex extends CauchyVertex {
 
+    private static final double LOC_ZERO = 0.0;
     private static final double LOG_TWO = Math.log(2);
 
     /**
@@ -17,24 +18,24 @@ public class HalfCauchyVertex extends CauchyVertex {
      * @param scale       the scale of the HalfCauchy with either the same tensorShape as specified for this vertex or a scalar
      */
     public HalfCauchyVertex(int[] tensorShape, DoubleVertex scale) {
-        super(tensorShape, 0.0, scale);
+        super(tensorShape, LOC_ZERO, scale);
     }
 
     public HalfCauchyVertex(int[] tensorShape, double scale) {
-        super(tensorShape, 0.0, scale);
+        super(tensorShape, LOC_ZERO, scale);
     }
 
     public HalfCauchyVertex(DoubleVertex scale) {
-        super(0.0, scale);
+        super(LOC_ZERO, scale);
     }
 
     public HalfCauchyVertex(double scale) {
-        super(0.0, scale);
+        super(LOC_ZERO, scale);
     }
 
     @Override
     public double logProb(DoubleTensor value) {
-        if (value.greaterThanOrEqual(0.0).allTrue()) {
+        if (value.greaterThanOrEqual(LOC_ZERO).allTrue()) {
             return super.logProb(value) + LOG_TWO * value.getLength();
         }
         return Double.NEGATIVE_INFINITY;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -1,0 +1,147 @@
+package io.improbable.keanu.vertices.dbl.probabilistic;
+
+import io.improbable.keanu.distributions.gradient.Cauchy;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import org.apache.commons.math3.distribution.CauchyDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
+
+public class HalfCauchyVertexTest {
+
+    private static final double DELTA = 0.0001;
+
+    private KeanuRandom random;
+
+    @Before
+    public void setup() {
+        random = new KeanuRandom(1);
+    }
+
+    @Test
+    public void matchesKnownLogDensityOfScalar() {
+
+        CauchyDistribution distribution = new CauchyDistribution(0.0, 1.0);
+        HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(1);
+        double expectedDensity = distribution.logDensity(0.5) + Math.log(2.0);
+        ProbabilisticDoubleTensorContract.matchesKnownLogDensityOfScalar(tensorHalfCauchyVertex, 0.5, expectedDensity);
+    }
+
+    @Test
+    public void matchesKnownLogDensityOfVector() {
+
+        CauchyDistribution distribution = new CauchyDistribution(0.0, 1.0);
+        double expectedLogDensity = distribution.logDensity(0.25) + distribution.logDensity(0.75)  + 2.0 * Math.log(2.0);
+        HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(1);
+        ProbabilisticDoubleTensorContract.matchesKnownLogDensityOfVector(tensorHalfCauchyVertex, new double[]{0.25, 0.75}, expectedLogDensity);
+    }
+
+    @Test
+    public void matchesKnownDerivativeLogDensityOfScalar() {
+
+        Cauchy.Diff cauchyLogDiff = Cauchy.dlnPdf(0.0, 1.0, 0.5);
+
+        UniformVertex scaleTensor = new UniformVertex(0.0, 1.0);
+        scaleTensor.setValue(1.0);
+
+        HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(scaleTensor);
+        Map<Long, DoubleTensor> actualDerivatives = tensorHalfCauchyVertex.dLogPdf(0.5);
+
+        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
+
+        assertEquals(cauchyLogDiff.dPdscale, actual.withRespectTo(scaleTensor.getId()).scalar(), 1e-5);
+        assertEquals(cauchyLogDiff.dPdx, actual.withRespectTo(tensorHalfCauchyVertex.getId()).scalar(), 1e-5);
+    }
+
+    @Test
+    public void matchesKnownDerivativeLogDensityOfVector() {
+
+        double[] vector = new double[]{0.25, 0.75, 0.1, 2, 1.3};
+
+        UniformVertex scaleTensor = new UniformVertex(0.0, 1.0);
+        scaleTensor.setValue(1.0);
+
+        Supplier<HalfCauchyVertex> vertexSupplier = () -> new HalfCauchyVertex(scaleTensor);
+
+        ProbabilisticDoubleTensorContract.matchesKnownDerivativeLogDensityOfVector(vector, vertexSupplier);
+    }
+
+    @Test
+    public void isTreatedAsConstantWhenObserved() {
+        HalfCauchyVertex vertexUnderTest = new HalfCauchyVertex(3.0);
+        vertexUnderTest.setAndCascade(Nd4jDoubleTensor.scalar(1.0));
+        ProbabilisticDoubleTensorContract.isTreatedAsConstantWhenObserved(vertexUnderTest);
+        ProbabilisticDoubleTensorContract.hasNoGradientWithRespectToItsValueWhenObserved(vertexUnderTest);
+    }
+
+    @Test
+    public void dLogProbMatchesFiniteDifferenceCalculationFordPdscale() {
+        UniformVertex uniformA = new UniformVertex(1.5, 3.0);
+        HalfCauchyVertex cauchy = new HalfCauchyVertex(uniformA);
+
+        DoubleTensor vertexStartValue = Nd4jDoubleTensor.scalar(0.0);
+        DoubleTensor vertexEndValue = Nd4jDoubleTensor.scalar(0.5);
+        double vertexIncrement = 0.1;
+
+        moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues(
+            Nd4jDoubleTensor.scalar(1.0),
+            Nd4jDoubleTensor.scalar(3.0),
+            0.1,
+            uniformA,
+            cauchy,
+            vertexStartValue,
+            vertexEndValue,
+            vertexIncrement,
+            DELTA);
+    }
+
+    @Test
+    public void cauchySampleMethodMatchesLogProbMethod() {
+
+        int sampleCount = 1000000;
+        HalfCauchyVertex vertex = new HalfCauchyVertex(
+            new int[]{sampleCount, 1},
+            ConstantVertex.of(2.0)
+        );
+
+        double from = 0;
+        double to = 4;
+        double bucketSize = 0.05;
+
+        ProbabilisticDoubleTensorContract.sampleMethodMatchesLogProbMethod(vertex, from, to, bucketSize, 1e-2, random);
+    }
+
+    @Test
+    public void inferHyperParamsFromSamples() {
+
+        double trueScale = 2.0;
+
+        List<DoubleVertex> scale = new ArrayList<>();
+        scale.add(ConstantVertex.of(trueScale));
+
+        List<DoubleVertex> latentScaleList = new ArrayList<>();
+        UniformVertex latentScale = new UniformVertex(0.01, 10.0);
+        latentScale.setAndCascade(DoubleTensor.scalar(0.1));
+        latentScaleList.add(latentScale);
+
+        int numSamples = 2000;
+        VertexVariationalMAP.inferHyperParamsFromSamples(
+            hyperParams -> new HalfCauchyVertex(new int[]{numSamples, 1}, hyperParams.get(0)),
+            scale,
+            latentScaleList,
+            random
+        );
+    }
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -40,12 +40,26 @@ public class HalfCauchyVertexTest {
     }
 
     @Test
+    public void matchesKnownLogDensityOfNegativeScalar() {
+
+        HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(1);
+        ProbabilisticDoubleTensorContract.matchesKnownLogDensityOfScalar(tensorHalfCauchyVertex, -0.5, Double.NEGATIVE_INFINITY);
+    }
+
+    @Test
     public void matchesKnownLogDensityOfVector() {
 
         CauchyDistribution distribution = new CauchyDistribution(0.0, 1.0);
         double expectedLogDensity = distribution.logDensity(0.25) + distribution.logDensity(0.75)  + 2.0 * Math.log(2.0);
         HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(1);
         ProbabilisticDoubleTensorContract.matchesKnownLogDensityOfVector(tensorHalfCauchyVertex, new double[]{0.25, 0.75}, expectedLogDensity);
+    }
+
+    @Test
+    public void matchesKnownLogDensityOfNegativeVector() {
+
+        HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(1);
+        ProbabilisticDoubleTensorContract.matchesKnownLogDensityOfVector(tensorHalfCauchyVertex, new double[]{-0.25, 0.75}, Double.NEGATIVE_INFINITY);
     }
 
     @Test


### PR DESCRIPTION
Food for thought, subclassing CauchyVertex might be the easiest way to implement a HalfCauchyVertex.

I may be oversimplifying things, but I believe a half-Cauchy distribution is just a Cauchy distribution with location zero with its left half dropped and the rest scaled up by two. (I think logPdf doesn't care about scaling factors (biases in log space) so we don't even need to do that step.) And the gradient is twice as steep as it would be for the CauchyVertex. This gradient calculation implementation doesn't care if the value is less than zero, so it is not really an accurate gradient for those values, but since they have probability density zero anyway does it matter?