### PR TITLE
NUTS interface consistency

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
@@ -43,7 +43,7 @@ public class NUTS {
      * @return Samples taken with NUTS
      */
     public static NetworkSamples getPosteriorSamples(final BayesianNetwork bayesNet,
-                                                     final List<DoubleVertex> sampleFromVertices,
+                                                     final List<? extends Vertex> sampleFromVertices,
                                                      final int sampleCount,
                                                      final int adaptCount,
                                                      final double targetAcceptanceProb) {


### PR DESCRIPTION
When calling `NUTS.getPosteriorSamples` with a specified `KeanuRandom` instance as the final input parameter (as is done in all the NUTS tests), the second parameter is of type `List<? extends Vertex>`. When calling it without that final input, the second parameter is of type `List<DoubleVertex>`. They should be the same.