### PR TITLE
Fix bug in forward mode matrix multiply auto differentiation

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -95,6 +95,8 @@ public interface DoubleTensor extends NumberTensor<Double> {
     @Override
     DoubleTensor reshape(int... newShape);
 
+    DoubleTensor permute(int... rearrange);
+
     @Override
     DoubleTensor duplicate();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -116,6 +116,11 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     }
 
     @Override
+    public DoubleTensor permute(int... rearrange) {
+        return new Nd4jDoubleTensor(tensor.permute(rearrange));
+    }
+
+    @Override
     public DoubleTensor diag() {
         return new Nd4jDoubleTensor(Nd4j.diag(tensor));
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -101,6 +101,11 @@ public class ScalarDoubleTensor implements DoubleTensor {
     }
 
     @Override
+    public DoubleTensor permute(int... rearrange) {
+        return new ScalarDoubleTensor(value);
+    }
+
+    @Override
     public DoubleTensor diag() {
         return duplicate();
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.tensor.dbl;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
 
 public class Nd4jDoubleTensorTest {
 
@@ -287,6 +287,34 @@ public class Nd4jDoubleTensorTest {
         DoubleTensor actual = DoubleTensor.arange(3, 7, 1.5);
         DoubleTensor expected = DoubleTensor.create(new double[]{3.0, 4.5, 6.0});
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void canPermuteForTranspose() {
+        DoubleTensor a = DoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
+        DoubleTensor permuted = a.permute(1, 0);
+        DoubleTensor transposed = a.transpose();
+
+        assertEquals(transposed, permuted);
+    }
+
+    @Test
+    public void canPermuteUpperDimensions() {
+        DoubleTensor a = DoubleTensor.create(new double[]{
+            1, 2,
+            3, 4,
+            5, 6,
+            7, 8
+        }, new int[]{1, 2, 2, 2});
+        DoubleTensor permuted = a.permute(0, 1, 3, 2);
+        DoubleTensor expected = DoubleTensor.create(new double[]{
+            1, 3,
+            2, 4,
+            5, 7,
+            6, 8
+        }, new int[]{1, 2, 2, 2});
+
+        assertEquals(expected, permuted);
     }
 
     private void assertTimesOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
@@ -100,10 +100,14 @@ public class DoubleIfVertexTest {
         DoubleTensor dIfdA = ifVertex.getDualNumber().getPartialDerivatives().withRespectTo(a);
 
         Assert.assertArrayEquals(new double[]{
-            5, 7, 0, 0,
-            0, 5, 0, 6,
-            6, 8, 0, 0,
-            0, 7, 0, 8
+            5, 7,
+            0, 0,
+            0, 5,
+            0, 6,
+            0, 0,
+            5, 7,
+            0, 7,
+            0, 8
         }, dIfdA.asFlatDoubleArray(), 1e-6);
 
         Assert.assertArrayEquals(dDda.getShape(), dIfdA.getShape());
@@ -141,17 +145,25 @@ public class DoubleIfVertexTest {
         DoubleTensor dIfdD = ifVertex.getDualNumber().getPartialDerivatives().withRespectTo(d);
 
         Assert.assertArrayEquals(new double[]{
-            5, 7, 0, 0,
-            0, 0, 0, 0,
-            6, 8, 0, 0,
-            0, 0, 0, 0
+            5, 7,
+            0, 0,
+            0, 0,
+            0, 0,
+            0, 0,
+            5, 7,
+            0, 0,
+            0, 0
         }, dIfdA.asFlatDoubleArray(), 1e-6);
 
         Assert.assertArrayEquals(new double[]{
-            0, 0, 0, 0,
-            0, 0, 13, 15,
-            0, 0, 0, 0,
-            0, 0, 14, 16
+            0, 0,
+            0, 0,
+            14, 16,
+            0, 0,
+            0, 0,
+            0, 0,
+            0, 0,
+            14, 16
         }, dIfdD.asFlatDoubleArray(), 1e-6);
 
         Assert.assertArrayEquals(dCda.getShape(), dIfdA.getShape());

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
@@ -56,7 +56,7 @@ public class TakeVertexTest {
         DoubleTensor takePartial2 = take2.getDualNumber().getPartialDerivatives().withRespectTo(m);
 
         Assert.assertArrayEquals(new int[]{1, 1, 2, 2}, takePartial2.getShape());
-        Assert.assertArrayEquals(new double[]{0, 0, 10, 20}, takePartial2.asFlatDoubleArray(), 1e-6);
+        Assert.assertArrayEquals(new double[]{15, 25, 0, 0}, takePartial2.asFlatDoubleArray(), 1e-6);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a bug that was previously not caught in out matrix multiply tests. Tests have been added to catch it now and a function `permute` has been added to the DoubleTensor in order to make the bug fix elegant. This permute is similar to moveaxis in numpy https://docs.scipy.org/doc/numpy/reference/generated/numpy.moveaxis.html