### PR TITLE
Fix broadcast ops

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
@@ -25,78 +25,75 @@ import java.util.List;
  */
 public class INDArrayShim {
 
-    public static INDArray muli(INDArray left, INDArray right, INDArray result) {
+    public static INDArray muli(INDArray left, INDArray right) {
         if (Arrays.equals(left.shape(), right.shape())) {
             return left.muli(right);
         } else {
-            return broadcastMultiply(left, right, result);
+            return broadcastMultiply(left, right);
         }
     }
 
-    private static INDArray broadcastMultiply(INDArray a, INDArray b, INDArray result) {
+    private static INDArray broadcastMultiply(INDArray a, INDArray b) {
         int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
         if (a.shape().length < b.shape().length) {
-            return broadcastMultiply(b, a, result);
+            return broadcastMultiply(b, a);
         }
-        result = a.dup();
         return execBroadcast(a, b,
-            new BroadcastMulOp(a, b, result, broadcastDimensions)
+            new BroadcastMulOp(a, b, a.dup(), broadcastDimensions)
         );
     }
 
-    public static INDArray divi(INDArray left, INDArray right, INDArray result) {
+    public static INDArray divi(INDArray left, INDArray right) {
         if (Arrays.equals(left.shape(), right.shape())) {
             return left.divi(right);
         } else {
-            return broadcastDivide(left, right, result);
+            return broadcastDivide(left, right);
         }
     }
 
-    private static INDArray broadcastDivide(INDArray a, INDArray b, INDArray result) {
+    private static INDArray broadcastDivide(INDArray a, INDArray b) {
         int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
         if (a.shape().length < b.shape().length) {
-            return broadcastMultiply(b, a.rdiv(1.0), result);
+            return broadcastMultiply(b, a.rdiv(1.0));
         }
-        result = a.dup();
         return execBroadcast(a, b,
-            new BroadcastDivOp(a, b, result, broadcastDimensions)
+            new BroadcastDivOp(a, b, a.dup(), broadcastDimensions)
         );
     }
 
-    public static INDArray addi(INDArray left, INDArray right, INDArray result) {
+    public static INDArray addi(INDArray left, INDArray right) {
         if (Arrays.equals(left.shape(), right.shape())) {
             return left.addi(right);
         } else {
-            return broadcastPlus(left, right, result);
+            return broadcastPlus(left, right);
         }
     }
 
-    private static INDArray broadcastPlus(INDArray a, INDArray b, INDArray result) {
+    private static INDArray broadcastPlus(INDArray a, INDArray b) {
         int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
         if (a.shape().length < b.shape().length) {
-            return broadcastPlus(b, a, result);
+            return broadcastPlus(b, a);
         }
-        result = a.dup();
         return execBroadcast(a, b,
-            new BroadcastAddOp(a, b, result, broadcastDimensions)
+            new BroadcastAddOp(a, b, a.dup(), broadcastDimensions)
         );
     }
 
-    public static INDArray subi(INDArray left, INDArray right, INDArray result) {
+    public static INDArray subi(INDArray left, INDArray right) {
         if (Arrays.equals(left.shape(), right.shape())) {
             return left.subi(right);
         } else {
-            return broadcastMinus(left, right, result);
+            return broadcastMinus(left, right);
         }
     }
 
-    private static INDArray broadcastMinus(INDArray a, INDArray b, INDArray result) {
+    private static INDArray broadcastMinus(INDArray a, INDArray b) {
         int[] broadcastDimensions = Shape.getBroadcastDimensions(a.shape(), b.shape());
         if (a.shape().length < b.shape().length) {
-            return broadcastPlus(a.neg(), b, b.dup());
+            return broadcastPlus(a.neg(), b);
         } else {
             return execBroadcast(a, b,
-                new BroadcastSubOp(a, b, result, broadcastDimensions)
+                new BroadcastSubOp(a, b, a.dup(), broadcastDimensions)
             );
         }
     }
@@ -109,9 +106,7 @@ public class INDArrayShim {
     private static int[] getBroadcastDimensions(int[] shapeA, int[] shapeB) {
         int maxRank = Math.max(shapeA.length, shapeB.length);
 
-        if (shapeA.length == shapeB.length) {
-            // do nuthing
-        } else if (shapeA.length < shapeB.length) {
+        if (shapeA.length < shapeB.length) {
             shapeA = TensorShape.shapeToDesiredRankByPrependingOnes(shapeA, shapeB.length);
         } else {
             shapeB = TensorShape.shapeToDesiredRankByPrependingOnes(shapeB, shapeA.length);
@@ -130,9 +125,7 @@ public class INDArrayShim {
     private static int[] getBroadcastAlongDimensions(int[] shapeA, int[] shapeB) {
         int maxRank = Math.max(shapeA.length, shapeB.length);
 
-        if (shapeA.length == shapeB.length) {
-            // do nuthing
-        } else if (shapeA.length < shapeB.length) {
+        if (shapeA.length < shapeB.length) {
             shapeA = TensorShape.shapeToDesiredRankByPrependingOnes(shapeA, shapeB.length);
         } else {
             shapeB = TensorShape.shapeToDesiredRankByPrependingOnes(shapeB, shapeA.length);

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
@@ -21,6 +21,11 @@ import java.util.List;
  * Until this is fixed in the ND4J codebase, these methods can be
  * used to work around the issue. The need for this should be
  * reevaluated each time the ND4J dependency is updated.
+ *
+ * To work around another issue in ND4J where you cannot broadcast
+ * a higher rank tensor onto a lower rank tensor, the shim broadcast operations
+ * ensure the higher rank tensor is always being operated on. In the case of
+ * subtract and minus, this requires a small change in the logic, as A - B != B - A.
  */
 public class INDArrayShim {
 
@@ -33,13 +38,14 @@ public class INDArrayShim {
     }
 
     private static INDArray broadcastMultiply(INDArray a, INDArray b) {
-        int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
         if (a.shape().length < b.shape().length) {
             return broadcastMultiply(b, a);
+        } else {
+            int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
+            return execBroadcast(a, b,
+                new BroadcastMulOp(a, b, a.dup(), broadcastDimensions)
+            );
         }
-        return execBroadcast(a, b,
-            new BroadcastMulOp(a, b, a.dup(), broadcastDimensions)
-        );
     }
 
     public static INDArray divi(INDArray left, INDArray right) {
@@ -51,13 +57,14 @@ public class INDArrayShim {
     }
 
     private static INDArray broadcastDivide(INDArray a, INDArray b) {
-        int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
         if (a.shape().length < b.shape().length) {
             return broadcastMultiply(b, a.rdiv(1.0));
+        } else {
+            int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
+            return execBroadcast(a, b,
+                new BroadcastDivOp(a, b, a.dup(), broadcastDimensions)
+            );
         }
-        return execBroadcast(a, b,
-            new BroadcastDivOp(a, b, a.dup(), broadcastDimensions)
-        );
     }
 
     public static INDArray addi(INDArray left, INDArray right) {
@@ -69,13 +76,14 @@ public class INDArrayShim {
     }
 
     private static INDArray broadcastPlus(INDArray a, INDArray b) {
-        int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
         if (a.shape().length < b.shape().length) {
             return broadcastPlus(b, a);
+        } else {
+            int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
+            return execBroadcast(a, b,
+                new BroadcastAddOp(a, b, a.dup(), broadcastDimensions)
+            );
         }
-        return execBroadcast(a, b,
-            new BroadcastAddOp(a, b, a.dup(), broadcastDimensions)
-        );
     }
 
     public static INDArray subi(INDArray left, INDArray right) {
@@ -87,10 +95,10 @@ public class INDArrayShim {
     }
 
     private static INDArray broadcastMinus(INDArray a, INDArray b) {
-        int[] broadcastDimensions = Shape.getBroadcastDimensions(a.shape(), b.shape());
         if (a.shape().length < b.shape().length) {
             return broadcastPlus(a.neg(), b);
         } else {
+            int[] broadcastDimensions = getBroadcastDimensions(a.shape(), b.shape());
             return execBroadcast(a, b,
                 new BroadcastSubOp(a, b, a.dup(), broadcastDimensions)
             );

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
@@ -25,7 +25,8 @@ import java.util.List;
  * To work around another issue in ND4J where you cannot broadcast
  * a higher rank tensor onto a lower rank tensor, the shim broadcast operations
  * ensure the higher rank tensor is always being operated on. In the case of
- * subtract and minus, this requires a small change in the logic, as A - B != B - A.
+ * subtract and minus, this requires a small change in the logic, as A - B != B - A and
+ * A / B != B / A.
  */
 public class INDArrayShim {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.tensor;
 
 import com.google.common.primitives.Ints;
-import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.BroadcastOp;
 import org.nd4j.linalg.api.ops.impl.broadcast.BroadcastAddOp;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -1,8 +1,6 @@
 package io.improbable.keanu.tensor;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 public class TensorShape {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -173,37 +173,5 @@ public class TensorShape {
         return newShape;
     }
 
-    public static int[] scalarDimensions(int[] shape) {
-        List<Integer> scalarDimensions = new ArrayList<>();
-        for (int i = 0; i < shape.length; i++) {
-            if (shape[i] == 1) {
-                scalarDimensions.add(i);
-            }
-        }
-        return scalarDimensions.stream().mapToInt(i -> i).toArray();
-    }
-
-    public static int[] nonScalarDimensions(int[] shape) {
-        List<Integer> nonScalarDimensions = new ArrayList<>();
-        for (int i = 0; i < shape.length; i++) {
-            if (shape[i] > 1) {
-                nonScalarDimensions.add(i);
-            }
-        }
-        return nonScalarDimensions.stream().mapToInt(i -> i).toArray();
-    }
-
-    public static int[] removeDimension(int[] shape, int dimensionToRemove) {
-        int[] shapeWithDimensionRemoved = new int[shape.length];
-        int count = 0;
-        for (int i = 0; i < shape.length; i++) {
-            if (i != dimensionToRemove) {
-                shapeWithDimensionRemoved[count] = shape[count];
-                count++;
-            }
-        }
-        return shapeWithDimensionRemoved;
-    }
-
 }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -1,6 +1,8 @@
 package io.improbable.keanu.tensor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class TensorShape {
 
@@ -159,7 +161,7 @@ public class TensorShape {
         if (append) {
             System.arraycopy(lowRankTensorShape, 0, paddedShape, 0, lowRankTensorShape.length);
         } else {
-            System.arraycopy(lowRankTensorShape, 0, paddedShape, lowRankTensorShape.length, lowRankTensorShape.length);
+            System.arraycopy(lowRankTensorShape, 0, paddedShape, paddedShape.length - lowRankTensorShape.length, lowRankTensorShape.length);
         }
 
         return paddedShape;
@@ -170,5 +172,38 @@ public class TensorShape {
         newShape[dimension] = 1;
         return newShape;
     }
+
+    public static int[] scalarDimensions(int[] shape) {
+        List<Integer> scalarDimensions = new ArrayList<>();
+        for (int i = 0; i < shape.length; i++) {
+            if (shape[i] == 1) {
+                scalarDimensions.add(i);
+            }
+        }
+        return scalarDimensions.stream().mapToInt(i -> i).toArray();
+    }
+
+    public static int[] nonScalarDimensions(int[] shape) {
+        List<Integer> nonScalarDimensions = new ArrayList<>();
+        for (int i = 0; i < shape.length; i++) {
+            if (shape[i] > 1) {
+                nonScalarDimensions.add(i);
+            }
+        }
+        return nonScalarDimensions.stream().mapToInt(i -> i).toArray();
+    }
+
+    public static int[] removeDimension(int[] shape, int dimensionToRemove) {
+        int[] shapeWithDimensionRemoved = new int[shape.length];
+        int count = 0;
+        for (int i = 0; i < shape.length; i++) {
+            if (i != dimensionToRemove) {
+                shapeWithDimensionRemoved[count] = shape[count];
+                count++;
+            }
+        }
+        return shapeWithDimensionRemoved;
+    }
+
 }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -538,7 +538,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.minus(that);
         } else {
-            return new Nd4jDoubleTensor(INDArrayShim.subi(tensor, unsafeGetNd4J(that), tensor));
+            return new Nd4jDoubleTensor(INDArrayShim.subi(tensor, unsafeGetNd4J(that)));
         }
         return this;
     }
@@ -555,7 +555,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.plus(that);
         } else {
-            return new Nd4jDoubleTensor(INDArrayShim.addi(tensor, unsafeGetNd4J(that), tensor));
+            return new Nd4jDoubleTensor(INDArrayShim.addi(tensor, unsafeGetNd4J(that)));
         }
         return this;
     }
@@ -572,7 +572,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.times(that);
         } else {
-            return new Nd4jDoubleTensor(INDArrayShim.muli(tensor, unsafeGetNd4J(that), tensor));
+            return new Nd4jDoubleTensor(INDArrayShim.muli(tensor, unsafeGetNd4J(that)));
         }
         return this;
     }
@@ -589,7 +589,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.div(that);
         } else {
-            return new Nd4jDoubleTensor(INDArrayShim.divi(tensor, unsafeGetNd4J(that), tensor));
+            return new Nd4jDoubleTensor(INDArrayShim.divi(tensor, unsafeGetNd4J(that)));
         }
         return this;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -538,7 +538,10 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.minus(that);
         } else {
-            return new Nd4jDoubleTensor(INDArrayShim.subi(tensor, unsafeGetNd4J(that)));
+            INDArray result = INDArrayShim.subi(tensor, unsafeGetNd4J(that));
+            if (result != tensor) {
+                return new Nd4jDoubleTensor(result);
+            }
         }
         return this;
     }
@@ -555,7 +558,10 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.plus(that);
         } else {
-            return new Nd4jDoubleTensor(INDArrayShim.addi(tensor, unsafeGetNd4J(that)));
+            INDArray result = INDArrayShim.addi(tensor, unsafeGetNd4J(that));
+            if (result != tensor) {
+                return new Nd4jDoubleTensor(result);
+            }
         }
         return this;
     }
@@ -572,7 +578,10 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.times(that);
         } else {
-            return new Nd4jDoubleTensor(INDArrayShim.muli(tensor, unsafeGetNd4J(that)));
+            INDArray result = INDArrayShim.muli(tensor, unsafeGetNd4J(that));
+            if (result != tensor) {
+                return new Nd4jDoubleTensor(result);
+            }
         }
         return this;
     }
@@ -589,7 +598,10 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.div(that);
         } else {
-            return new Nd4jDoubleTensor(INDArrayShim.divi(tensor, unsafeGetNd4J(that)));
+            INDArray result = INDArrayShim.divi(tensor, unsafeGetNd4J(that));
+            if (result != tensor) {
+                return new Nd4jDoubleTensor(result);
+            }
         }
         return this;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -538,12 +538,12 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.minus(that);
         } else {
-            INDArrayShim.subi(tensor, unsafeGetNd4J(that), tensor);
+            return new Nd4jDoubleTensor(INDArrayShim.subi(tensor, unsafeGetNd4J(that), tensor));
         }
         return this;
     }
 
-     /**
+    /**
      * @param that Right operand.
      * @return A new DoubleTensor instance only if <i>this</i> has a length of 1 and right operand has a length greater than 1.
      * Otherwise return <i>this</i>.
@@ -555,12 +555,12 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.plus(that);
         } else {
-            INDArrayShim.addi(tensor, unsafeGetNd4J(that), tensor);
+            return new Nd4jDoubleTensor(INDArrayShim.addi(tensor, unsafeGetNd4J(that), tensor));
         }
         return this;
     }
 
-     /**
+    /**
      * @param that Right operand.
      * @return A new DoubleTensor instance only if <i>this</i> has a length of 1 and right operand has a length greater than 1.
      * Otherwise return <i>this</i>.
@@ -572,12 +572,12 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.times(that);
         } else {
-            INDArrayShim.muli(tensor, unsafeGetNd4J(that), tensor);
+            return new Nd4jDoubleTensor(INDArrayShim.muli(tensor, unsafeGetNd4J(that), tensor));
         }
         return this;
     }
 
-     /**
+    /**
      * @param that Right operand.
      * @return A new DoubleTensor instance only if <i>this</i> has a length of 1 and right operand has a length greater than 1.
      * Otherwise return <i>this</i>.
@@ -589,7 +589,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         } else if (this.isScalar()) {
             return this.div(that);
         } else {
-            INDArrayShim.divi(tensor, unsafeGetNd4J(that), tensor);
+            return new Nd4jDoubleTensor(INDArrayShim.divi(tensor, unsafeGetNd4J(that), tensor));
         }
         return this;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -338,7 +338,7 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         if (that.isScalar()) {
             tensor.subi(that.scalar());
         } else {
-            INDArrayShim.subi(tensor, unsafeGetNd4J(that), tensor);
+            return new Nd4jIntegerTensor(INDArrayShim.subi(tensor, unsafeGetNd4J(that)));
         }
         return this;
     }
@@ -348,7 +348,7 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         if (that.isScalar()) {
             tensor.addi(that.scalar());
         } else {
-            INDArrayShim.addi(tensor, unsafeGetNd4J(that), tensor);
+            return new Nd4jIntegerTensor(INDArrayShim.addi(tensor, unsafeGetNd4J(that)));
         }
         return this;
     }
@@ -358,7 +358,7 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         if (that.isScalar()) {
             tensor.muli(that.scalar());
         } else {
-            INDArrayShim.muli(tensor, unsafeGetNd4J(that), tensor);
+            return new Nd4jIntegerTensor(INDArrayShim.muli(tensor, unsafeGetNd4J(that)));
         }
         return this;
     }
@@ -368,7 +368,8 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         if (that.isScalar()) {
             tensor.divi(that.scalar());
         } else {
-            INDArrayShim.divi(tensor, unsafeGetNd4J(that), tensor);
+            INDArray result = INDArrayShim.divi(tensor, unsafeGetNd4J(that));
+            return new Nd4jIntegerTensor(INDArrayExtensions.castToInteger(result, false));
         }
         INDArrayExtensions.castToInteger(tensor, false);
         return this;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -378,7 +378,9 @@ public class Nd4jIntegerTensor implements IntegerTensor {
             tensor.divi(that.scalar());
         } else {
             INDArray result = INDArrayShim.divi(tensor, unsafeGetNd4J(that));
-            return new Nd4jIntegerTensor(INDArrayExtensions.castToInteger(result, false));
+            if (result != tensor) {
+                return new Nd4jIntegerTensor(INDArrayExtensions.castToInteger(result, false));
+            }
         }
         INDArrayExtensions.castToInteger(tensor, false);
         return this;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -338,7 +338,10 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         if (that.isScalar()) {
             tensor.subi(that.scalar());
         } else {
-            return new Nd4jIntegerTensor(INDArrayShim.subi(tensor, unsafeGetNd4J(that)));
+            INDArray result = INDArrayShim.subi(tensor, unsafeGetNd4J(that));
+            if (result != tensor) {
+                return new Nd4jIntegerTensor(result);
+            }
         }
         return this;
     }
@@ -348,7 +351,10 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         if (that.isScalar()) {
             tensor.addi(that.scalar());
         } else {
-            return new Nd4jIntegerTensor(INDArrayShim.addi(tensor, unsafeGetNd4J(that)));
+            INDArray result = INDArrayShim.addi(tensor, unsafeGetNd4J(that));
+            if (result != tensor) {
+                return new Nd4jIntegerTensor(result);
+            }
         }
         return this;
     }
@@ -358,7 +364,10 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         if (that.isScalar()) {
             tensor.muli(that.scalar());
         } else {
-            return new Nd4jIntegerTensor(INDArrayShim.muli(tensor, unsafeGetNd4J(that)));
+            INDArray result = INDArrayShim.muli(tensor, unsafeGetNd4J(that));
+            if (result != tensor) {
+                return new Nd4jIntegerTensor(result);
+            }
         }
         return this;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -43,17 +43,22 @@ public class PartialDerivatives {
             DoubleTensor elsPartial = elsePartials.get(wrt);
             DoubleTensor broadcastedTrueMask;
             DoubleTensor broadcastedFalseMask;
+            int[] range = TensorShape.dimensionRange(0, thnPartial == null ? elsPartial.getRank() : thnPartial.getRank());
+            int[] permute = TensorShape.concat(
+                Arrays.copyOfRange(range, range.length - 2, range.length),
+                Arrays.copyOfRange(range, 0, range.length - 2)
+            );
 
             DoubleTensor newPartial;
             if (thnPartial == null) {
-                broadcastedFalseMask = DoubleTensor.zeros(elsPartial.getShape()).plusInPlace(falseMask);
+                broadcastedFalseMask = DoubleTensor.zeros(elsPartial.getShape()).plusInPlace(falseMask).permute(permute);
                 newPartial = broadcastedFalseMask.timesInPlace(elsPartial);
             } else if (elsPartial == null) {
-                broadcastedTrueMask = DoubleTensor.zeros(thnPartial.getShape()).plusInPlace(trueMask);
+                broadcastedTrueMask = DoubleTensor.zeros(thnPartial.getShape()).plusInPlace(trueMask).permute(permute);
                 newPartial = broadcastedTrueMask.timesInPlace(thnPartial);
             } else {
-                broadcastedFalseMask = DoubleTensor.zeros(thnPartial.getShape()).plusInPlace(falseMask);
-                broadcastedTrueMask = DoubleTensor.zeros(thnPartial.getShape()).plusInPlace(trueMask);
+                broadcastedFalseMask = DoubleTensor.zeros(thnPartial.getShape()).plusInPlace(falseMask).permute(permute);
+                broadcastedTrueMask = DoubleTensor.zeros(thnPartial.getShape()).plusInPlace(trueMask).permute(permute);
 
                 newPartial = broadcastedTrueMask.timesInPlace(thnPartial)
                     .plusInPlace(broadcastedFalseMask.timesInPlace(elsPartial));

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -12,7 +12,6 @@ public class Nd4jDoubleTensorTest {
 
     Nd4jDoubleTensor matrixA;
     Nd4jDoubleTensor matrixB;
-    Nd4jDoubleTensor matrixC;
     Nd4jDoubleTensor scalarA;
     Nd4jDoubleTensor vectorA;
     Nd4jDoubleTensor vectorB;
@@ -22,7 +21,6 @@ public class Nd4jDoubleTensorTest {
     public void setup() {
         matrixA = Nd4jDoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
         matrixB = Nd4jDoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
-        matrixC = Nd4jDoubleTensor.create(new double[]{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}, new int[]{4, 4});
         scalarA = Nd4jDoubleTensor.scalar(2.0);
         vectorA = Nd4jDoubleTensor.create(new double[]{1, 2, 3}, new int[]{3, 1});
         vectorB = Nd4jDoubleTensor.create(new double[]{1, 2, 3}, new int[]{1, 3});

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -2,7 +2,11 @@ package io.improbable.keanu.tensor.dbl;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import static junit.framework.TestCase.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -11,6 +15,7 @@ public class Nd4jDoubleTensorTest {
 
     Nd4jDoubleTensor matrixA;
     Nd4jDoubleTensor matrixB;
+    Nd4jDoubleTensor matrixC;
     Nd4jDoubleTensor scalarA;
     Nd4jDoubleTensor vectorA;
     Nd4jDoubleTensor vectorB;
@@ -20,6 +25,7 @@ public class Nd4jDoubleTensorTest {
     public void setup() {
         matrixA = Nd4jDoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
         matrixB = Nd4jDoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
+        matrixC = Nd4jDoubleTensor.create(new double[]{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}, new int[]{4, 4});
         scalarA = Nd4jDoubleTensor.scalar(2.0);
         vectorA = Nd4jDoubleTensor.create(new double[]{1, 2, 3}, new int[]{3, 1});
         vectorB = Nd4jDoubleTensor.create(new double[]{1, 2, 3}, new int[]{1, 3});
@@ -187,6 +193,40 @@ public class Nd4jDoubleTensorTest {
     }
 
     @Test
+    public void canSuperBroadcast() {
+        DoubleTensor x = Nd4jDoubleTensor.zeros(new int[]{2, 2, 2, 2});
+        DoubleTensor y = Nd4jDoubleTensor.create(new double[]{1, 0, 1, 0}, new int[]{2, 2});
+
+        DoubleTensor diff = x.plus(y);
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            1, 0, 1, 0,
+            1, 0, 1, 0,
+            1, 0, 1, 0,
+            1, 0, 1, 0
+        }, new int[]{2, 2, 2, 2});
+
+        assertEquals(expected, diff);
+    }
+
+    @Test
+    public void canSuperBroadcastInPlace() {
+        DoubleTensor x = Nd4jDoubleTensor.zeros(new int[]{2, 2, 2, 2});
+        DoubleTensor y = Nd4jDoubleTensor.create(new double[]{1, 0, 1, 0}, new int[]{2, 2});
+
+        DoubleTensor diff = x.plusInPlace(y);
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            1, 0, 1, 0,
+            1, 0, 1, 0,
+            1, 0, 1, 0,
+            1, 0, 1, 0
+        }, new int[]{2, 2, 2, 2});
+
+        assertEquals(expected, diff);
+    }
+
+    @Test
     public void canSetAllValues(){
         DoubleTensor rank5 = DoubleTensor.create(new double[]{
             1, 2, 3, 4, 5, 6, 7, 8, 4, 3, 2, 1, 7, 5, 8, 6,
@@ -298,6 +338,39 @@ public class Nd4jDoubleTensorTest {
     }
 
     @Test
+    public void canPermute() {
+        DoubleTensor x = Nd4jDoubleTensor.create(new double[]{1, 2, 3}, new int[]{1, 3});
+        DoubleTensor y = Nd4jDoubleTensor.create(new double[]{4, 5, 6}, new int[]{1, 3});
+
+        DoubleTensor concatDimensionZero = x.concat(0, y);
+
+        assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6}, concatDimensionZero.asFlatDoubleArray(), 1e-6);
+
+        DoubleTensor concatDimensionOne = x.concat(1, y);
+        DoubleTensor permuttedConcatDimensionOne = concatDimensionOne.permute(1, 0);
+
+        assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6}, permuttedConcatDimensionOne.asFlatDoubleArray(), 1e-6);
+
+        x = Nd4jDoubleTensor.create(new double[]{1, 2, 3, 4, 5, 6, 7, 8}, new int[]{2, 2, 2});
+        y = Nd4jDoubleTensor.create(new double[]{9, 10, 11, 12, 13, 14, 15, 16}, new int[]{2, 2, 2});
+
+        concatDimensionZero = x.concat(0, y);
+
+        assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, concatDimensionZero.asFlatDoubleArray(), 1e-6);
+
+        concatDimensionOne = x.concat(1, y);
+        permuttedConcatDimensionOne = concatDimensionOne.permute(1, 0, 2);
+
+        double[] sliced = new double[permuttedConcatDimensionOne.asFlatDoubleArray().length / 2];
+        for (int i = 0; i < permuttedConcatDimensionOne.asFlatDoubleArray().length / 2; i++) {
+            sliced[i] = permuttedConcatDimensionOne.asFlatDoubleArray()[i];
+        }
+
+        DoubleTensor answer = DoubleTensor.create(sliced, x.getShape()).permute(1, 0, 2);
+        assertArrayEquals(new double[]{1, 2, 3, 4, 5, 6, 7, 8}, answer.asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
     public void canLinSpace() {
         DoubleTensor actual = DoubleTensor.linspace(0, 10, 5);
         DoubleTensor expected = DoubleTensor.create(new double[]{0, 2.5, 5.0, 7.5, 10.0});
@@ -330,6 +403,41 @@ public class Nd4jDoubleTensorTest {
         DoubleTensor actual = DoubleTensor.arange(3, 7, 1.5);
         DoubleTensor expected = DoubleTensor.create(new double[]{3.0, 4.5, 6.0});
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void canTensorMultiplyWithVectorAndRank4() {
+        DoubleTensor a = Nd4jDoubleTensor.create(new double[]{1, 2, 3}, new int[]{1, 1, 3, 1});
+        DoubleTensor b = Nd4jDoubleTensor.create(new double[]{
+            5, 2, 3, 7, 8,
+            5, 2, 3, 7, 8,
+            5, 2, 3, 7, 8
+        }, new int[]{1, 3, 1, 5});
+
+        DoubleTensor c = a.tensorMultiply(b, new int[]{2, 3}, new int[]{1, 0});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            30, 12, 18, 42, 48
+        }, new int[]{1, 1, 1, 5});
+
+        assertEquals(expected, c);
+    }
+
+    @Test
+    public void canTensorMultiplyWithNumpyExample() {
+        DoubleTensor a = DoubleTensor.arange(0, 60).reshape(3, 4, 5);
+        DoubleTensor b = DoubleTensor.arange(0, 24.).reshape(4, 3, 2);
+        DoubleTensor c = a.tensorMultiply(b, new int[]{1, 0}, new int[]{0, 1});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            4400., 4730.,
+            4532., 4874.,
+            4664., 5018.,
+            4796., 5162.,
+            4928., 5306.
+        }, new int[]{5, 2});
+
+        assertEquals(expected, c);
     }
 
     @Test
@@ -366,7 +474,37 @@ public class Nd4jDoubleTensorTest {
     }
 
     private void assertTimesInPlaceOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
-        left.timesInPlace(right);
+        left = left.timesInPlace(right);
+        assertEquals(left, expected);
+    }
+
+    private void assertPlusOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
+        DoubleTensor actual = left.plus(right);
+        assertEquals(actual, expected);
+    }
+
+    private void assertPlusInPlaceOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
+        left = left.plusInPlace(right);
+        assertEquals(left, expected);
+    }
+
+    private void assertDivideOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
+        DoubleTensor actual = left.div(right);
+        assertEquals(actual, expected);
+    }
+
+    private void assertDivideInPlaceOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
+        left = left.divInPlace(right);
+        assertEquals(left, expected);
+    }
+
+    private void assertMinusOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
+        DoubleTensor actual = left.minus(right);
+        assertEquals(actual, expected);
+    }
+
+    private void assertMinusInPlaceOperationEquals(DoubleTensor left, DoubleTensor right, DoubleTensor expected) {
+        left = left.minusInPlace(right);
         assertEquals(left, expected);
     }
 
@@ -440,10 +578,149 @@ public class Nd4jDoubleTensorTest {
     }
 
     @Test
+    public void smallerTensorTimesInPlaceLargerTensorBehavesSameAsTimess() {
+        DoubleTensor smallerTensor = DoubleTensor.create(2, new int[] {2, 2});
+        DoubleTensor largerTensor = DoubleTensor.create(3, new int[] {2, 2, 2});
+
+        assertArrayEquals(largerTensor.times(smallerTensor).asFlatDoubleArray(), largerTensor.timesInPlace(smallerTensor).asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
     public void smallerTensorDivInPlaceLargerTensorBehavesSameAsDiv() {
         DoubleTensor smallerTensor = DoubleTensor.create(2, new int[] {2, 2});
         DoubleTensor largerTensor = DoubleTensor.create(3, new int[] {2, 2, 2});
 
         assertArrayEquals(smallerTensor.div(largerTensor).asFlatDoubleArray(), smallerTensor.divInPlace(largerTensor).asFlatDoubleArray(), 1e-6);
     }
+
+    @Test
+    public void canBroadcastMultiplyDifferentRankedTensorsBigToSmall() {
+        DoubleTensor rank4 = DoubleTensor.ones(4, 2, 2, 2);
+        DoubleTensor matrix = DoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+        }, new int[]{4, 2, 2, 2});
+
+
+        assertTimesOperationEquals(rank4, matrix, expected);
+        assertTimesInPlaceOperationEquals(rank4, matrix, expected);
+    }
+
+    @Test
+    public void canBroadcastMultiplyDifferentRankedTensorsSmallToBig() {
+        DoubleTensor rank4 = DoubleTensor.ones(4, 2, 2, 2);
+        DoubleTensor matrix = DoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+        }, new int[]{4, 2, 2, 2});
+
+
+        assertTimesOperationEquals(matrix, rank4, expected);
+        assertTimesInPlaceOperationEquals(matrix, rank4, expected);
+    }
+
+    @Test
+    public void canBroadcastPlusDifferentRankedTensorsBigToSmall() {
+        DoubleTensor rank4 = DoubleTensor.zeros(new int[]{4, 2, 2, 2});
+        DoubleTensor matrix = DoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+        }, new int[]{4, 2, 2, 2});
+
+        assertPlusOperationEquals(rank4, matrix, expected);
+        assertPlusInPlaceOperationEquals(rank4, matrix, expected);
+    }
+
+    @Test
+    public void canBroadcastPlusDifferentRankedTensorsSmallToBig() {
+        DoubleTensor rank4 = DoubleTensor.zeros(new int[]{4, 2, 2, 2});
+        DoubleTensor matrix = DoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 1, 2, 3, 4,
+        }, new int[]{4, 2, 2, 2});
+
+        assertPlusOperationEquals(matrix, rank4, expected);
+        assertPlusInPlaceOperationEquals(matrix, rank4, expected);
+    }
+
+    @Test
+    public void canBroadcastDivideDifferentRankedTensorsBigToSmall() {
+        DoubleTensor rank4 = DoubleTensor.ones(new int[]{4, 2, 2, 2}).times(10.);
+        DoubleTensor matrix = DoubleTensor.create(new double[]{1, 2, 5, 10}, new int[]{2, 2});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            10, 5, 2, 1, 10, 5, 2, 1,
+            10, 5, 2, 1, 10, 5, 2, 1,
+            10, 5, 2, 1, 10, 5, 2, 1,
+            10, 5, 2, 1, 10, 5, 2, 1,
+        }, new int[]{4, 2, 2, 2});
+
+        assertDivideOperationEquals(rank4, matrix, expected);
+        assertDivideInPlaceOperationEquals(rank4, matrix, expected);
+    }
+
+    @Test
+    public void canBroadcastDivideDifferentRankedTensorsSmallToBig() {
+        DoubleTensor rank4 = DoubleTensor.ones(new int[]{4, 2, 2, 2}).times(10.);
+        DoubleTensor matrix = DoubleTensor.create(new double[]{1, 2, 5, 10}, new int[]{2, 2});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            10, 5, 2, 1, 10, 5, 2, 1,
+            10, 5, 2, 1, 10, 5, 2, 1,
+            10, 5, 2, 1, 10, 5, 2, 1,
+            10, 5, 2, 1, 10, 5, 2, 1,
+        }, new int[]{4, 2, 2, 2});
+
+        assertDivideOperationEquals(matrix, rank4, expected);
+        assertDivideInPlaceOperationEquals(matrix, rank4, expected);
+    }
+
+    @Test
+    public void canBroadcastMinusDifferentRankedTensorsBigToSmall() {
+        DoubleTensor rank4 = DoubleTensor.ones(new int[]{4, 2, 2, 2}).times(5.);
+        DoubleTensor matrix = DoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            4, 3, 2, 1, 4, 3, 2, 1,
+            4, 3, 2, 1, 4, 3, 2, 1,
+            4, 3, 2, 1, 4, 3, 2, 1,
+            4, 3, 2, 1, 4, 3, 2, 1
+        }, new int[]{4, 2, 2, 2});
+
+        assertMinusOperationEquals(rank4, matrix, expected);
+        assertMinusInPlaceOperationEquals(rank4, matrix, expected);
+    }
+
+    @Test
+    public void canBroadcastMinusDifferentRankedTensorsSmallToBig() {
+        DoubleTensor rank4 = DoubleTensor.ones(new int[]{4, 2, 2, 2}).times(5.);
+        DoubleTensor matrix = DoubleTensor.create(new double[]{1, 2, 3, 4}, new int[]{2, 2});
+
+        DoubleTensor expected = Nd4jDoubleTensor.create(new double[]{
+            4, 3, 2, 1, 4, 3, 2, 1,
+            4, 3, 2, 1, 4, 3, 2, 1,
+            4, 3, 2, 1, 4, 3, 2, 1,
+            4, 3, 2, 1, 4, 3, 2, 1
+        }, new int[]{4, 2, 2, 2});
+
+        assertMinusOperationEquals(matrix, rank4, expected);
+        assertMinusInPlaceOperationEquals(matrix, rank4, expected);
+    }
+
 }


### PR DESCRIPTION
- Fixes a bug in the broadcast operations when operating on two tensors. Eg, multiplying a 2x2 by a 2x2x2x2 produced incorrect numbers and was different if you were doing A x B or B x A. The behaviour is now representative of numpy.
- Fixes a bug in TensorShape prepend with 1's
- Due to the behaviour of ND4J it's impossible to perform a broadcast in place on a tensor that has to increase in size. You could do an `inPlace` if multiplying a 2x2x2x2 by a 2x2, but not a 2x2 by a 2x2x2x2. To avoid confusing behaviour I've made it so that `inPlace` on a broadcast returns a duplicate. `There's no in place unless the tensors match shape`.
- Fixed `DoubleIfVertex` to use the new broadcast. It was using the previously broken broadcast to apply a mask in a pretty cheeky way 

It's impossible in `ND4J` to currently do a broadcast op on a small tensor against a larger tensor. To get around this I've done some shenanigans with swapping to ensure the larger tensor is always the primary