### PR TITLE
Extract distributions/discrete/UniformInt from UniformIntVertex.

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Uniform.java
@@ -38,8 +38,8 @@ public class Uniform implements ContinuousDistribution {
     public DoubleTensor logProb(DoubleTensor x) {
 
         DoubleTensor logOfWithinBounds = xMax.minus(xMin).logInPlace().unaryMinusInPlace();
-        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(x.getGreaterThanMask(xMax), Double.NEGATIVE_INFINITY);
-        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(x.getLessThanOrEqualToMask(xMin), Double.NEGATIVE_INFINITY);
+        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(x.getGreaterThanOrEqualToMask(xMax), Double.NEGATIVE_INFINITY);
+        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(x.getLessThanMask(xMin), Double.NEGATIVE_INFINITY);
 
         return logOfWithinBounds;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/UniformInt.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/UniformInt.java
@@ -35,8 +35,8 @@ public class UniformInt implements DiscreteDistribution {
         DoubleTensor xDouble = x.toDouble();
 
         DoubleTensor logOfWithinBounds = maxBound.minus(minBound).logInPlace().unaryMinusInPlace();
-        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(xDouble.getGreaterThanMask(maxBound), Double.NEGATIVE_INFINITY);
-        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(xDouble.getLessThanOrEqualToMask(minBound), Double.NEGATIVE_INFINITY);
+        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(xDouble.getGreaterThanOrEqualToMask(maxBound), Double.NEGATIVE_INFINITY);
+        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(xDouble.getLessThanMask(minBound), Double.NEGATIVE_INFINITY);
 
         return logOfWithinBounds;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/UniformInt.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/UniformInt.java
@@ -1,0 +1,43 @@
+package io.improbable.keanu.distributions.discrete;
+
+import io.improbable.keanu.distributions.DiscreteDistribution;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+public class UniformInt implements DiscreteDistribution {
+
+    private final IntegerTensor xMin;
+    private final IntegerTensor xMax;
+
+    public static DiscreteDistribution withParameters(IntegerTensor xMin, IntegerTensor xMax) {
+        return new UniformInt(xMin, xMax);
+    }
+
+    private UniformInt(IntegerTensor xMin, IntegerTensor xMax) {
+        this.xMin = xMin;
+        this.xMax = xMax;
+    }
+
+    @Override
+    public IntegerTensor sample(int[] shape, KeanuRandom random) {
+        DoubleTensor minDouble = xMin.toDouble();
+        DoubleTensor delta = xMax.toDouble().minus(minDouble);
+        DoubleTensor randoms = random.nextDouble(shape);
+
+        return delta.timesInPlace(randoms).plusInPlace(minDouble).toInteger();
+    }
+
+    @Override
+    public DoubleTensor logProb(IntegerTensor x) {
+        DoubleTensor maxBound = xMax.toDouble();
+        DoubleTensor minBound = xMin.toDouble();
+        DoubleTensor xDouble = x.toDouble();
+
+        DoubleTensor logOfWithinBounds = maxBound.minus(minBound).logInPlace().unaryMinusInPlace();
+        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(xDouble.getGreaterThanMask(maxBound), Double.NEGATIVE_INFINITY);
+        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(xDouble.getLessThanOrEqualToMask(minBound), Double.NEGATIVE_INFINITY);
+
+        return logOfWithinBounds;
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
+import io.improbable.keanu.distributions.discrete.UniformInt;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -75,16 +76,7 @@ public class UniformIntVertex extends IntegerVertex implements ProbabilisticInte
 
     @Override
     public double logProb(IntegerTensor value) {
-
-        DoubleTensor maxBound = max.getValue().toDouble();
-        DoubleTensor minBound = min.getValue().toDouble();
-        DoubleTensor x = value.toDouble();
-
-        DoubleTensor logOfWithinBounds = maxBound.minus(minBound).logInPlace().unaryMinusInPlace();
-        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(x.getGreaterThanMask(maxBound), Double.NEGATIVE_INFINITY);
-        logOfWithinBounds = logOfWithinBounds.setWithMaskInPlace(x.getLessThanOrEqualToMask(minBound), Double.NEGATIVE_INFINITY);
-
-        return logOfWithinBounds.sum();
+        return UniformInt.withParameters(min.getValue(), max.getValue()).logProb(value).sum();
     }
 
     @Override
@@ -94,11 +86,6 @@ public class UniformIntVertex extends IntegerVertex implements ProbabilisticInte
 
     @Override
     public IntegerTensor sample(KeanuRandom random) {
-
-        DoubleTensor minDouble = min.getValue().toDouble();
-        DoubleTensor delta = max.getValue().toDouble().minus(minDouble);
-        DoubleTensor randoms = random.nextDouble(getShape());
-
-        return delta.timesInPlace(randoms).plusInPlace(minDouble).toInteger();
+        return UniformInt.withParameters(min.getValue(), max.getValue()).sample(getShape(), random);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertexTest.java
@@ -1,0 +1,75 @@
+package io.improbable.keanu.vertices.dbl.probabilistic;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class UniformVertexTest {
+    private int N = 100000;
+    private Double lowerBound = 10.;
+    private Double upperBound = 20.;
+    private List<Double> samples = new ArrayList<>();
+    private KeanuRandom random;
+
+    @Before
+    public void setup() {
+        random = new KeanuRandom(1);
+        UniformVertex testUniformVertex = new UniformVertex(new int[]{1, N}, lowerBound, upperBound);
+        samples.addAll(testUniformVertex.sample(random).asFlatList());
+    }
+
+    @Test
+    public void allSamplesAreWithinBounds() {
+        Double minSample = Collections.min(samples);
+        Double maxSample = Collections.max(samples);
+
+        assertTrue(minSample >= lowerBound);
+        assertTrue(maxSample < upperBound);
+    }
+
+    @Test
+    public void exclusiveUpperBoundIsNeverProduced() {
+        assertFalse(samples.contains(upperBound));
+    }
+
+    @Test
+    public void canUseFullDoubleRange() {
+        UniformVertex testUniformVertex = new UniformVertex(new int[]{1, 100}, Double.MIN_VALUE, Double.MAX_VALUE);
+        DoubleTensor sample = testUniformVertex.sample(random);
+
+        Set<Double> uniqueValues = new HashSet<>(sample.asFlatList());
+
+        assertTrue(uniqueValues.size() > 1);
+    }
+
+    @Test
+    public void logProbUpperBoundIsNegativeInfinity() {
+        UniformVertex testUniformVertex = new UniformVertex(new int[]{1, N}, lowerBound, upperBound);
+        assertEquals(testUniformVertex.logProb(Nd4jDoubleTensor.scalar(upperBound)), Double.NEGATIVE_INFINITY, 1e-6);
+    }
+
+    @Test
+    public void logProbLowerBoundIsNotNegativeInfinity() {
+        UniformVertex testUniformVertex = new UniformVertex(new int[]{1, N}, lowerBound, upperBound);
+        assertNotEquals(testUniformVertex.logProb(Nd4jDoubleTensor.scalar(lowerBound)), Double.NEGATIVE_INFINITY, 1e-6);
+    }
+
+    @Test
+    public void uniformSampleMethodMatchesLogProbMethod() {
+        UniformVertex testUniformVertex = new UniformVertex(new int[] {1, N}, ConstantVertex.of(lowerBound), ConstantVertex.of(upperBound));
+        ProbabilisticDoubleTensorContract.sampleMethodMatchesLogProbMethod(testUniformVertex, lowerBound, upperBound - 1, 0.5, 1e-2, random);
+    }
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertexTest.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.tensor.intgr.Nd4jIntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Before;
@@ -42,7 +43,7 @@ public class UniformIntVertexTest {
         Integer maxSample = Collections.max(samples);
 
         assertTrue(minSample >= lowerBound);
-        assertTrue(maxSample <= upperBound);
+        assertTrue(maxSample < upperBound);
     }
 
     @Test
@@ -72,5 +73,17 @@ public class UniformIntVertexTest {
         Set<Integer> uniqueValues = new HashSet<>(sample.asFlatList());
 
         assertTrue(uniqueValues.size() > 1);
+    }
+
+    @Test
+    public void logProbUpperBoundIsNegativeInfinity() {
+        UniformIntVertex testUniformVertex = new UniformIntVertex(new int[]{1, N}, lowerBound, upperBound);
+        assertEquals(testUniformVertex.logProb(Nd4jIntegerTensor.scalar(upperBound)), Double.NEGATIVE_INFINITY, 1e-6);
+    }
+
+    @Test
+    public void logProbLowerBoundIsNotNegativeInfinity() {
+        UniformIntVertex testUniformVertex = new UniformIntVertex(new int[]{1, N}, lowerBound, upperBound);
+        assertNotEquals(testUniformVertex.logProb(Nd4jIntegerTensor.scalar(lowerBound)), Double.NEGATIVE_INFINITY, 1e-6);
     }
 }


### PR DESCRIPTION
Will use it for computing KL divergence.

Also added a fix for #197.