### PR TITLE
Fix for Issue 190

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -142,6 +142,7 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
 
         @Override
         public NetworkState sample() {
+            step();
             return new SimpleNetworkState(takeSample(verticesToSampleFrom));
         }
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
@@ -8,21 +8,20 @@ import io.improbable.keanu.network.NetworkState;
 public interface SamplingAlgorithm {
 
     /**
-     * Move forward the state of the Sampling Algorithm by a single step.
+     * Move forward the state of the Sampling Algorithm by a single step but do not return anything.
      */
     void step();
 
     /**
-     * Takes a sample with the algorithm and saves it in the supplied map.  Repeated calls to this function will return
-     * the same values without an intermediary call to 'step()'
+     * Takes a sample with the algorithm and saves it in the supplied map (creating a new entry in the list if the
+     * Vertex already exists.
      *
      * @param samples map to store sampled vertex values
      */
     void sample(Map<Long, List<?>> samples);
 
     /**
-     * Takes a sample with the algorithm and returns the state of the network for that sample.  Repeated calls to this
-     * function will return the same values without an intermediary call to 'step()'
+     * Takes a sample with the algorithm and returns the state of the network for that sample.
      *
      * @return a network state that represents the current state of the algorithm.
      */

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
@@ -14,7 +14,7 @@ public interface SamplingAlgorithm {
 
     /**
      * Takes a sample with the algorithm and saves it in the supplied map (creating a new entry in the list if the
-     * Vertex already exists.
+     * Vertex already exists).
      *
      * @param samples map to store sampled vertex values
      */

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
@@ -8,20 +8,23 @@ import io.improbable.keanu.network.NetworkState;
 public interface SamplingAlgorithm {
 
     /**
-     * Same effect as a sample but the result isn't saved or returned.
+     * Move forward the state of the Sampling Algorithm by a single step.
      */
     void step();
 
     /**
-     * Takes a sample with the algorithm and saves it in the supplied map
+     * Takes a sample with the algorithm and saves it in the supplied map.  Repeated calls to this function will return
+     * the same values without an intermediary call to 'step()'
      *
      * @param samples map to store sampled vertex values
      */
     void sample(Map<Long, List<?>> samples);
 
     /**
-     * @return a network state that represents the value of vertices at the
-     * end of the algorithm step
+     * Takes a sample with the algorithm and returns the state of the network for that sample.  Repeated calls to this
+     * function will return the same values without an intermediary call to 'step()'
+     *
+     * @return a network state that represents the current state of the algorithm.
      */
     NetworkState sample();
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsTest.java
@@ -262,7 +262,7 @@ public class MetropolisHastingsTest {
 
         int sampleCount = 1000;
         int dropCount = 100;
-        int downSampleInterval = 2;
+        int downSampleInterval = 0;
         GaussianVertex A = new GaussianVertex(0, 1);
         BayesianNetwork network = new BayesianNetwork(A.getConnectedGraph());
 
@@ -270,7 +270,7 @@ public class MetropolisHastingsTest {
             .dropCount(dropCount)
             .downSampleInterval(downSampleInterval)
             .stream()
-            .limit(200)
+            .limit(sampleCount)
             .mapToDouble(networkState -> networkState.get(A).scalar())
             .average().getAsDouble();
 


### PR DESCRIPTION
Fix Issue with Metropolis Hastings algorithm not generating samples correctly (we always returned the same value) if Downsampling not used when streaming.

Also includes a small fix to the Metropolis Hastings tests to make it more reliable (it was randomly failing for me).