### PR TITLE
Add reshape to vertices

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/BooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/BooleanTensor.java
@@ -26,6 +26,14 @@ public interface BooleanTensor extends Tensor<Boolean> {
         return new SimpleBooleanTensor(shape);
     }
 
+    static BooleanTensor trues(int... shape) {
+        return new SimpleBooleanTensor(true, shape);
+    }
+
+    static BooleanTensor falses(int... shape) {
+        return new SimpleBooleanTensor(false, shape);
+    }
+
     @Override
     BooleanTensor reshape(int... newShape);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
@@ -36,7 +36,7 @@ public interface IntegerTensor extends NumberTensor<Integer, IntegerTensor>, Int
         return create(values, 1, values.length);
     }
 
-    static IntegerTensor ones(int[] shape) {
+    static IntegerTensor ones(int... shape) {
         if (Arrays.equals(shape, Tensor.SCALAR_SHAPE)) {
             return new ScalarIntegerTensor(1);
         } else {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
@@ -14,6 +14,7 @@ import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compa
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.NotEqualsVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.multiple.AndMultipleVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.multiple.OrMultipleVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary.BoolReshapeVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary.BoolSliceVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary.BoolTakeVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary.NotVertex;
@@ -91,6 +92,10 @@ public abstract class BoolVertex extends Vertex<BooleanTensor> {
 
     public BoolVertex take(int... index) {
         return new BoolTakeVertex(this, index);
+    }
+
+    public BoolVertex reshape(int... proposedShape) {
+        return new BoolReshapeVertex(this, proposedShape);
     }
 
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -25,23 +25,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.Divisi
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MatrixMultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.PowerVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.AbsVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ArcCosVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ArcSinVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ArcTanVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.CeilVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.CosVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpLambda;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ExpVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.FloorVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.LogVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.RoundVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SigmoidVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SinVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SliceVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TakeVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TanVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.*;
 
 public abstract class DoubleVertex extends Vertex<DoubleTensor> implements DoubleOperators<DoubleVertex>, Differentiable {
 
@@ -155,6 +139,10 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
 
     public DoubleVertex sum() {
         return new SumVertex(this);
+    }
+
+    public DoubleVertex reshape(int... proposedShape) {
+        return new ReshapeVertex(this, proposedShape);
     }
 
     public DoubleVertex lambda(int[] outputShape, Function<DoubleTensor, DoubleTensor> op, Function<Map<Vertex, DualNumber>, DualNumber> dualNumberCalculation) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
@@ -21,11 +21,7 @@ import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.Inte
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerDivisionVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerMultiplicationVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerPowerVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerAbsVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerSliceVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerSumVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerTakeVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerUnaryOpLambda;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.*;
 
 public abstract class IntegerVertex extends Vertex<IntegerTensor> implements IntegerOperators<IntegerVertex> {
 
@@ -131,6 +127,9 @@ public abstract class IntegerVertex extends Vertex<IntegerTensor> implements Int
         return new IntegerSliceVertex(this, dimension, index);
     }
 
+    public IntegerVertex reshape(int... proposedShape) {
+        return new IntegerReshapeVertex(this, proposedShape);
+    }
 
     public BoolVertex equalTo(IntegerVertex rhs) {
         return new EqualsVertex<>(this, rhs);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/BoolVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/BoolVertexTest.java
@@ -11,6 +11,9 @@ import java.util.Collections;
 
 import com.sun.org.apache.xpath.internal.operations.Bool;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.vertices.intgr.IntegerVertex;
+import io.improbable.keanu.vertices.intgr.probabilistic.BinomialVertex;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -217,6 +220,15 @@ public class BoolVertexTest {
         boolean[] values = new boolean[]{true, false, true};
         flip.setAndCascade(values);
         assertEquals(true, flip.take(0, 0).getValue().scalar());
+    }
+
+    @Test
+    public void canReshape() {
+        BoolVertex flip = new BernoulliVertex(0.5);
+        flip.setAndCascade(BooleanTensor.trues(2, 2));
+        assertArrayEquals(flip.getShape(), new int[]{2, 2});
+        BoolVertex reshaped = flip.reshape(4, 1);
+        assertArrayEquals(reshaped.getShape(), new int[]{4, 1});
     }
 
     private double andProbability(double pA, double pB) {

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
@@ -64,4 +64,13 @@ public class DoubleVertexTest {
         gaussianVertex.setAndCascade(values);
         assertEquals(1, gaussianVertex.take(0, 0).getValue().scalar(), 0.0);
     }
+
+    @Test
+    public void canReshape() {
+        DoubleVertex gaussianVertex = new GaussianVertex(0, 1);
+        gaussianVertex.setAndCascade(DoubleTensor.ones(2, 2));
+        assertArrayEquals(gaussianVertex.getShape(), new int[]{2, 2});
+        DoubleVertex reshaped = gaussianVertex.reshape(4, 1);
+        assertArrayEquals(reshaped.getShape(), new int[]{4, 1});
+    }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/IntegerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/IntegerVertexTest.java
@@ -141,4 +141,13 @@ public class IntegerVertexTest {
         assertEquals(1, (long) binomialVertex.take(0, 0).getValue().scalar());
     }
 
+    @Test
+    public void canReshape() {
+        IntegerVertex binomialVertex = new BinomialVertex(0, 1);
+        binomialVertex.setAndCascade(IntegerTensor.ones(2, 2));
+        assertArrayEquals(binomialVertex.getShape(), new int[]{2, 2});
+        IntegerVertex reshaped = binomialVertex.reshape(4, 1);
+        assertArrayEquals(reshaped.getShape(), new int[]{4, 1});
+    }
+
 }


### PR DESCRIPTION
Adds reshape to `Double`, `Integer` and `Bool` vertices.

Also adds an `(int...)` constructor to `ones` in `IntegerTensor` to keep it consistent.
Also adds a `trues` and `falses` constructor for `BooleanTensor` 