### PR TITLE
Make Vertex ID an object instead of long.

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/NetworkSamples.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/NetworkSamples.java
@@ -1,16 +1,21 @@
 package io.improbable.keanu.algorithms;
 
+import static java.util.stream.Collectors.toMap;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
 import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertexSamples;
 import io.improbable.keanu.vertices.intgr.IntegerTensorVertexSamples;
-
-import java.util.*;
-import java.util.function.Function;
-
-import static java.util.stream.Collectors.toMap;
 
 /**
  * An immutable collection of network samples. A network sample is a collection
@@ -18,10 +23,10 @@ import static java.util.stream.Collectors.toMap;
  */
 public class NetworkSamples {
 
-    private final Map<Long, ? extends List> samplesByVertex;
+    private final Map<VertexId, ? extends List> samplesByVertex;
     private final int size;
 
-    public NetworkSamples(Map<Long, ? extends List> samplesByVertex, int size) {
+    public NetworkSamples(Map<VertexId, ? extends List> samplesByVertex, int size) {
         this.samplesByVertex = samplesByVertex;
         this.size = size;
     }
@@ -34,7 +39,7 @@ public class NetworkSamples {
         return get(vertex.getId());
     }
 
-    public <T> VertexSamples<T> get(long vertexId) {
+    public <T> VertexSamples<T> get(VertexId vertexId) {
         return new VertexSamples<>((List<T>) samplesByVertex.get(vertexId));
     }
 
@@ -42,7 +47,7 @@ public class NetworkSamples {
         return getDoubleTensorSamples(vertex.getId());
     }
 
-    public DoubleVertexSamples getDoubleTensorSamples(long vertexId) {
+    public DoubleVertexSamples getDoubleTensorSamples(VertexId vertexId) {
         return new DoubleVertexSamples(samplesByVertex.get(vertexId));
     }
 
@@ -50,13 +55,13 @@ public class NetworkSamples {
         return getIntegerTensorSamples(vertex.getId());
     }
 
-    public IntegerTensorVertexSamples getIntegerTensorSamples(long vertexId) {
+    public IntegerTensorVertexSamples getIntegerTensorSamples(VertexId vertexId) {
         return new IntegerTensorVertexSamples(samplesByVertex.get(vertexId));
     }
 
     public NetworkSamples drop(int dropCount) {
 
-        final Map<Long, List<?>> withSamplesDropped = samplesByVertex.entrySet().parallelStream()
+        final Map<VertexId, List<?>> withSamplesDropped = samplesByVertex.entrySet().parallelStream()
             .collect(toMap(
                 Map.Entry::getKey,
                 e -> e.getValue().subList(dropCount, size))
@@ -67,7 +72,7 @@ public class NetworkSamples {
 
     public NetworkSamples downSample(final int downSampleInterval) {
 
-        final Map<Long, List<?>> withSamplesDownSampled = samplesByVertex.entrySet().parallelStream()
+        final Map<VertexId, List<?>> withSamplesDownSampled = samplesByVertex.entrySet().parallelStream()
             .collect(toMap(
                 Map.Entry::getKey,
                 e -> downSample(e.getValue(), downSampleInterval)
@@ -111,10 +116,10 @@ public class NetworkSamples {
 
     private static class SamplesBackedNetworkState implements NetworkState {
 
-        private final Map<Long, ? extends List> samplesByVertex;
+        private final Map<VertexId, ? extends List> samplesByVertex;
         private final int index;
 
-        public SamplesBackedNetworkState(Map<Long, ? extends List> samplesByVertex, int index) {
+        public SamplesBackedNetworkState(Map<VertexId, ? extends List> samplesByVertex, int index) {
             this.samplesByVertex = samplesByVertex;
             this.index = index;
         }
@@ -125,12 +130,12 @@ public class NetworkSamples {
         }
 
         @Override
-        public <T> T get(long vertexId) {
+        public <T> T get(VertexId vertexId) {
             return ((List<T>) samplesByVertex.get(vertexId)).get(index);
         }
 
         @Override
-        public Set<Long> getVertexIds() {
+        public Set<VertexId> getVertexIds() {
             return new HashSet<>(samplesByVertex.keySet());
         }
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/TopologicalSort.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/TopologicalSort.java
@@ -1,9 +1,15 @@
 package io.improbable.keanu.algorithms.graphtraversal;
 
-import io.improbable.keanu.vertices.Vertex;
-
-import java.util.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import io.improbable.keanu.vertices.Vertex;
 
 public class TopologicalSort {
 
@@ -19,7 +25,7 @@ public class TopologicalSort {
      */
     public static List<Vertex> sort(Collection<? extends Vertex> vertices) {
         return vertices.stream().
-            sorted(Comparator.comparingLong(Vertex::getId))
+            sorted(Comparator.comparing(Vertex::getId, Comparator.naturalOrder()))
             .collect(Collectors.toList());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/VertexValuePropagation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/VertexValuePropagation.java
@@ -36,7 +36,7 @@ public class VertexValuePropagation {
      */
     public static void cascadeUpdate(Collection<? extends Vertex> cascadeFrom) {
 
-        PriorityQueue<Vertex> priorityQueue = new PriorityQueue<>(Comparator.comparingLong(Vertex::getId));
+        PriorityQueue<Vertex> priorityQueue = new PriorityQueue<>(Comparator.comparing(Vertex::getId, Comparator.naturalOrder()));
         priorityQueue.addAll(cascadeFrom);
 
         HashSet<Vertex> alreadyQueued = new HashSet<>(cascadeFrom);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -12,6 +12,7 @@ import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradient;
 import lombok.Builder;
@@ -77,22 +78,22 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         final List<Vertex<DoubleTensor>> latentVertices = bayesNet.getContinuousLatentVertices();
         final List<? extends Probabilistic> probabilisticVertices = Probabilistic.keepOnlyProbabilisticVertices(bayesNet.getLatentAndObservedVertices());
 
-        final Map<Long, List<?>> samples = new HashMap<>();
+        final Map<VertexId, List<?>> samples = new HashMap<>();
         addSampleFromVertices(samples, fromVertices);
 
-        Map<Long, DoubleTensor> position = new HashMap<>();
+        Map<VertexId, DoubleTensor> position = new HashMap<>();
         cachePosition(latentVertices, position);
-        Map<Long, DoubleTensor> positionBeforeLeapfrog = new HashMap<>();
+        Map<VertexId, DoubleTensor> positionBeforeLeapfrog = new HashMap<>();
 
-        Map<Long, DoubleTensor> gradient = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
-        Map<Long, DoubleTensor> gradientBeforeLeapfrog = new HashMap<>();
+        Map<VertexId, DoubleTensor> gradient = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
+        Map<VertexId, DoubleTensor> gradientBeforeLeapfrog = new HashMap<>();
 
-        final Map<Long, DoubleTensor> momentum = new HashMap<>();
-        final Map<Long, DoubleTensor> momentumBeforeLeapfrog = new HashMap<>();
+        final Map<VertexId, DoubleTensor> momentum = new HashMap<>();
+        final Map<VertexId, DoubleTensor> momentumBeforeLeapfrog = new HashMap<>();
 
         double logOfMasterPBeforeLeapfrog = bayesNet.getLogOfMasterP();
 
-        final Map<Long, ?> sampleBeforeLeapfrog = new HashMap<>();
+        final Map<VertexId, ?> sampleBeforeLeapfrog = new HashMap<>();
 
         for (int sampleNum = 1; sampleNum < sampleCount; sampleNum++) {
 
@@ -127,7 +128,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
             if (shouldReject(likelihoodOfLeapfrog, random)) {
 
                 //Revert to position and gradient before leapfrog
-                Map<Long, DoubleTensor> tempSwap = position;
+                Map<VertexId, DoubleTensor> tempSwap = position;
                 position = positionBeforeLeapfrog;
                 positionBeforeLeapfrog = tempSwap;
 
@@ -145,22 +146,22 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         return new NetworkSamples(samples, sampleCount);
     }
 
-    private static void cachePosition(List<Vertex<DoubleTensor>> latentVertices, Map<Long, DoubleTensor> position) {
+    private static void cachePosition(List<Vertex<DoubleTensor>> latentVertices, Map<VertexId, DoubleTensor> position) {
         for (Vertex<DoubleTensor> vertex : latentVertices) {
             position.put(vertex.getId(), vertex.getValue());
         }
     }
 
     private static void initializeMomentumForEachVertex(List<Vertex<DoubleTensor>> vertexes,
-                                                        Map<Long, DoubleTensor> momentums,
+                                                        Map<VertexId, DoubleTensor> momentums,
                                                         KeanuRandom random) {
         for (Vertex<DoubleTensor> currentVertex : vertexes) {
             momentums.put(currentVertex.getId(), random.nextGaussian(currentVertex.getShape()));
         }
     }
 
-    private static void cache(Map<Long, DoubleTensor> from, Map<Long, DoubleTensor> to) {
-        for (Map.Entry<Long, DoubleTensor> entry : from.entrySet()) {
+    private static void cache(Map<VertexId, DoubleTensor> from, Map<VertexId, DoubleTensor> to) {
+        for (Map.Entry<VertexId, DoubleTensor> entry : from.entrySet()) {
             to.put(entry.getKey(), entry.getValue());
         }
     }
@@ -180,19 +181,19 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
      * @param probabilisticVertices all vertices that impact the joint posterior (masterP)
      * @return the gradient at the updated position
      */
-    private static Map<Long, DoubleTensor> leapfrog(final List<Vertex<DoubleTensor>> latentVertices,
-                                                    final Map<Long, DoubleTensor> position,
-                                                    final Map<Long, DoubleTensor> gradient,
-                                                    final Map<Long, DoubleTensor> momentums,
+    private static Map<VertexId, DoubleTensor> leapfrog(final List<Vertex<DoubleTensor>> latentVertices,
+                                                    final Map<VertexId, DoubleTensor> position,
+                                                    final Map<VertexId, DoubleTensor> gradient,
+                                                    final Map<VertexId, DoubleTensor> momentums,
                                                     final double stepSize,
                                                     final List<? extends Probabilistic> probabilisticVertices) {
 
         final double halfTimeStep = stepSize / 2.0;
 
-        Map<Long, DoubleTensor> momentumsAtHalfTimeStep = new HashMap<>();
+        Map<VertexId, DoubleTensor> momentumsAtHalfTimeStep = new HashMap<>();
 
         //Set `r = r + (eps/2)dTL(T)
-        for (Map.Entry<Long, DoubleTensor> vertexMomentum : momentums.entrySet()) {
+        for (Map.Entry<VertexId, DoubleTensor> vertexMomentum : momentums.entrySet()) {
             final DoubleTensor updatedMomentum = gradient.get(vertexMomentum.getKey()).times(halfTimeStep).plusInPlace(vertexMomentum.getValue());
             momentumsAtHalfTimeStep.put(vertexMomentum.getKey(), updatedMomentum);
         }
@@ -207,11 +208,11 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         VertexValuePropagation.cascadeUpdate(latentVertices);
 
         //Set `r = `r + (eps/2)dTL(`T)
-        Map<Long, DoubleTensor> newGradient = LogProbGradient.getJointLogProbGradientWrtLatents(
+        Map<VertexId, DoubleTensor> newGradient = LogProbGradient.getJointLogProbGradientWrtLatents(
             probabilisticVertices
         );
 
-        for (Map.Entry<Long, DoubleTensor> halfTimeStepMomentum : momentumsAtHalfTimeStep.entrySet()) {
+        for (Map.Entry<VertexId, DoubleTensor> halfTimeStepMomentum : momentumsAtHalfTimeStep.entrySet()) {
             final DoubleTensor updatedMomentum = newGradient.get(halfTimeStepMomentum.getKey()).times(halfTimeStep).plusInPlace(halfTimeStepMomentum.getValue());
             momentums.put(halfTimeStepMomentum.getKey(), updatedMomentum);
         }
@@ -221,8 +222,8 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
 
     private static double getLikelihoodOfLeapfrog(final double logOfMasterPAfterLeapfrog,
                                                   final double previousLogOfMasterP,
-                                                  final Map<Long, DoubleTensor> leapfroggedMomentum,
-                                                  final Map<Long, DoubleTensor> momentumPreviousTimeStep) {
+                                                  final Map<VertexId, DoubleTensor> leapfroggedMomentum,
+                                                  final Map<VertexId, DoubleTensor> momentumPreviousTimeStep) {
 
         final double leapFroggedMomentumDotProduct = (0.5 * dotProduct(leapfroggedMomentum));
         final double previousMomentumDotProduct = (0.5 * dotProduct(momentumPreviousTimeStep));
@@ -240,7 +241,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         return likelihood < random.nextDouble();
     }
 
-    private static double dotProduct(Map<Long, DoubleTensor> momentums) {
+    private static double dotProduct(Map<VertexId, DoubleTensor> momentums) {
         double dotProduct = 0.0;
         for (DoubleTensor momentum : momentums.values()) {
             dotProduct += momentum.pow(2).sum();
@@ -255,14 +256,14 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
      * @param sample
      * @param fromVertices
      */
-    private static void takeSample(Map<Long, ?> sample, List<? extends Vertex> fromVertices) {
+    private static void takeSample(Map<VertexId, ?> sample, List<? extends Vertex> fromVertices) {
         for (Vertex<?> vertex : fromVertices) {
             putValue(vertex, sample);
         }
     }
 
-    private static <T> void putValue(Vertex<T> vertex, Map<Long, ?> target) {
-        ((Map<Long, T>) target).put(vertex.getId(), vertex.getValue());
+    private static <T> void putValue(Vertex<T> vertex, Map<VertexId, ?> target) {
+        ((Map<VertexId, T>) target).put(vertex.getId(), vertex.getValue());
     }
 
     /**
@@ -272,8 +273,8 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
      * @param samples
      * @param cachedSample a cached sample from before leapfrog
      */
-    private static void addSampleFromCache(Map<Long, List<?>> samples, Map<Long, ?> cachedSample) {
-        for (Map.Entry<Long, ?> sampleEntry : cachedSample.entrySet()) {
+    private static void addSampleFromCache(Map<VertexId, List<?>> samples, Map<VertexId, ?> cachedSample) {
+        for (Map.Entry<VertexId, ?> sampleEntry : cachedSample.entrySet()) {
             addSampleForVertex(sampleEntry.getKey(), sampleEntry.getValue(), samples);
         }
     }
@@ -285,13 +286,13 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
      * @param samples
      * @param fromVertices vertices from which to create and save new sample.
      */
-    private static void addSampleFromVertices(Map<Long, List<?>> samples, List<? extends Vertex> fromVertices) {
+    private static void addSampleFromVertices(Map<VertexId, List<?>> samples, List<? extends Vertex> fromVertices) {
         for (Vertex<?> vertex : fromVertices) {
             addSampleForVertex(vertex.getId(), vertex.getValue(), samples);
         }
     }
 
-    private static <T> void addSampleForVertex(long id, T value, Map<Long, List<?>> samples) {
+    private static <T> void addSampleForVertex(VertexId id, T value, Map<VertexId, List<?>> samples) {
         List<T> samplesForVertex = (List<T>) samples.computeIfAbsent(id, v -> new ArrayList<T>());
         samplesForVertex.add(value);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -16,6 +16,7 @@ import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.network.SimpleNetworkState;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import lombok.Builder;
 import lombok.Getter;
@@ -135,7 +136,7 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
         }
 
         @Override
-        public void sample(Map<Long, List<?>> samplesByVertex) {
+        public void sample(Map<VertexId, List<?>> samplesByVertex) {
             step();
             takeSamples(samplesByVertex, verticesToSampleFrom);
         }
@@ -147,19 +148,19 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
         }
     }
 
-    private static Map<Long, ?> takeSample(List<? extends Vertex> fromVertices) {
-        Map<Long, Object> sample = new HashMap<>();
+    private static Map<VertexId, ?> takeSample(List<? extends Vertex> fromVertices) {
+        Map<VertexId, Object> sample = new HashMap<>();
         for (Vertex v : fromVertices) {
             sample.put(v.getId(), v.getValue());
         }
         return sample;
     }
 
-    private static void takeSamples(Map<Long, List<?>> samples, List<? extends Vertex> fromVertices) {
+    private static void takeSamples(Map<VertexId, List<?>> samples, List<? extends Vertex> fromVertices) {
         fromVertices.forEach(vertex -> addSampleForVertex((Vertex<?>) vertex, samples));
     }
 
-    private static <T> void addSampleForVertex(Vertex<T> vertex, Map<Long, List<?>> samples) {
+    private static <T> void addSampleForVertex(Vertex<T> vertex, Map<VertexId, List<?>> samples) {
         List<T> samplesForVertex = (List<T>) samples.computeIfAbsent(vertex.getId(), v -> new ArrayList<T>());
         samplesForVertex.add(vertex.getValue());
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
@@ -12,6 +12,7 @@ import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradient;
 import lombok.Builder;
@@ -81,15 +82,15 @@ public class NUTS implements PosteriorSamplingAlgorithm {
         final List<Vertex<DoubleTensor>> latentVertices = bayesNet.getContinuousLatentVertices();
         List<? extends Probabilistic> probabilisticVertices = Probabilistic.keepOnlyProbabilisticVertices(bayesNet.getLatentAndObservedVertices());
 
-        final Map<Long, List<?>> samples = new HashMap<>();
+        final Map<VertexId, List<?>> samples = new HashMap<>();
         addSampleFromCache(samples, takeSample(sampleFromVertices));
 
-        Map<Long, DoubleTensor> position = new HashMap<>();
+        Map<VertexId, DoubleTensor> position = new HashMap<>();
         cachePosition(latentVertices, position);
 
-        Map<Long, DoubleTensor> gradient = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
+        Map<VertexId, DoubleTensor> gradient = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
 
-        Map<Long, DoubleTensor> momentum = new HashMap<>();
+        Map<VertexId, DoubleTensor> momentum = new HashMap<>();
 
         double initialLogOfMasterP = getLogProb(probabilisticVertices);
 
@@ -253,9 +254,9 @@ public class NUTS implements PosteriorSamplingAlgorithm {
     private static BuiltTree buildTree(List<Vertex<DoubleTensor>> latentVertices,
                                        List<? extends Probabilistic> probabilisticVertices,
                                        final List<? extends Vertex> sampleFromVertices,
-                                       Map<Long, DoubleTensor> position,
-                                       Map<Long, DoubleTensor> gradient,
-                                       Map<Long, DoubleTensor> momentum,
+                                       Map<VertexId, DoubleTensor> position,
+                                       Map<VertexId, DoubleTensor> gradient,
+                                       Map<VertexId, DoubleTensor> momentum,
                                        double u,
                                        int buildDirection,
                                        int treeHeight,
@@ -339,9 +340,9 @@ public class NUTS implements PosteriorSamplingAlgorithm {
     private static BuiltTree builtTreeBaseCase(List<Vertex<DoubleTensor>> latentVertices,
                                                List<? extends Probabilistic> probabilisticVertices,
                                                final List<? extends Vertex> sampleFromVertices,
-                                               Map<Long, DoubleTensor> position,
-                                               Map<Long, DoubleTensor> gradient,
-                                               Map<Long, DoubleTensor> momentum,
+                                               Map<VertexId, DoubleTensor> position,
+                                               Map<VertexId, DoubleTensor> gradient,
+                                               Map<VertexId, DoubleTensor> momentum,
                                                double u,
                                                int buildDirection,
                                                double epsilon,
@@ -362,7 +363,7 @@ public class NUTS implements PosteriorSamplingAlgorithm {
         final int acceptedLeapfrogCount = u <= Math.exp(logOfMasterPMinusMomentum) ? 1 : 0;
         final boolean shouldContinueFlag = u < Math.exp(DELTA_MAX + logOfMasterPMinusMomentum);
 
-        final Map<Long, ?> sampleAtAcceptedPosition = takeSample(sampleFromVertices);
+        final Map<VertexId, ?> sampleAtAcceptedPosition = takeSample(sampleFromVertices);
 
         double deltaLikelihoodOfLeapfrog = Math.exp(logOfMasterPMinusMomentum - logOfMasterPMinusMomentumBeforeLeapfrog);
         deltaLikelihoodOfLeapfrog = deltaLikelihoodOfLeapfrog < 1 ? deltaLikelihoodOfLeapfrog : 1;
@@ -409,16 +410,16 @@ public class NUTS implements PosteriorSamplingAlgorithm {
         return random.nextDouble() < probability;
     }
 
-    private static boolean isNotUTurning(Map<Long, DoubleTensor> positionForward,
-                                         Map<Long, DoubleTensor> positionBackward,
-                                         Map<Long, DoubleTensor> momentumForward,
-                                         Map<Long, DoubleTensor> momentumBackward) {
+    private static boolean isNotUTurning(Map<VertexId, DoubleTensor> positionForward,
+                                         Map<VertexId, DoubleTensor> positionBackward,
+                                         Map<VertexId, DoubleTensor> momentumForward,
+                                         Map<VertexId, DoubleTensor> momentumBackward) {
         double forward = 0.0;
         double backward = 0.0;
 
-        for (Map.Entry<Long, DoubleTensor> forwardPositionForLatent : positionForward.entrySet()) {
+        for (Map.Entry<VertexId, DoubleTensor> forwardPositionForLatent : positionForward.entrySet()) {
 
-            final long latentId = forwardPositionForLatent.getKey();
+            final VertexId latentId = forwardPositionForLatent.getKey();
             final DoubleTensor forwardMinusBackward = forwardPositionForLatent.getValue().minus(
                 positionBackward.get(latentId)
             );
@@ -430,39 +431,39 @@ public class NUTS implements PosteriorSamplingAlgorithm {
         return (forward >= 0.0) && (backward >= 0.0);
     }
 
-    private static void cachePosition(List<Vertex<DoubleTensor>> latentVertices, Map<Long, DoubleTensor> position) {
+    private static void cachePosition(List<Vertex<DoubleTensor>> latentVertices, Map<VertexId, DoubleTensor> position) {
         for (Vertex<DoubleTensor> vertex : latentVertices) {
             position.put(vertex.getId(), vertex.getValue());
         }
     }
 
     private static void initializeMomentumForEachVertex(List<Vertex<DoubleTensor>> vertices,
-                                                        Map<Long, DoubleTensor> momentums,
+                                                        Map<VertexId, DoubleTensor> momentums,
                                                         KeanuRandom random) {
         for (Vertex<DoubleTensor> vertex : vertices) {
             momentums.put(vertex.getId(), random.nextGaussian(vertex.getShape()));
         }
     }
 
-    private static void cache(Map<Long, DoubleTensor> from, Map<Long, DoubleTensor> to) {
-        for (Map.Entry<Long, DoubleTensor> entry : from.entrySet()) {
+    private static void cache(Map<VertexId, DoubleTensor> from, Map<VertexId, DoubleTensor> to) {
+        for (Map.Entry<VertexId, DoubleTensor> entry : from.entrySet()) {
             to.put(entry.getKey(), entry.getValue());
         }
     }
 
     private static LeapFrogged leapfrog(final List<Vertex<DoubleTensor>> latentVertices,
                                         final List<? extends Probabilistic> probabilisticVertices,
-                                        final Map<Long, DoubleTensor> position,
-                                        final Map<Long, DoubleTensor> gradient,
-                                        final Map<Long, DoubleTensor> momentum,
+                                        final Map<VertexId, DoubleTensor> position,
+                                        final Map<VertexId, DoubleTensor> gradient,
+                                        final Map<VertexId, DoubleTensor> momentum,
                                         final double epsilon) {
 
         final double halfTimeStep = epsilon / 2.0;
 
-        Map<Long, DoubleTensor> nextMomentum = new HashMap<>();
-        Map<Long, DoubleTensor> nextPosition = new HashMap<>();
+        Map<VertexId, DoubleTensor> nextMomentum = new HashMap<>();
+        Map<VertexId, DoubleTensor> nextPosition = new HashMap<>();
 
-        for (Map.Entry<Long, DoubleTensor> rEntry : momentum.entrySet()) {
+        for (Map.Entry<VertexId, DoubleTensor> rEntry : momentum.entrySet()) {
             final DoubleTensor updatedMomentum = (gradient.get(rEntry.getKey()).times(halfTimeStep)).plusInPlace(rEntry.getValue());
             nextMomentum.put(rEntry.getKey(), updatedMomentum);
         }
@@ -479,9 +480,9 @@ public class NUTS implements PosteriorSamplingAlgorithm {
 
         VertexValuePropagation.cascadeUpdate(latentVertices);
 
-        Map<Long, DoubleTensor> nextPositionGradient = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
+        Map<VertexId, DoubleTensor> nextPositionGradient = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
 
-        for (Map.Entry<Long, DoubleTensor> nextMomentumForLatent : nextMomentum.entrySet()) {
+        for (Map.Entry<VertexId, DoubleTensor> nextMomentumForLatent : nextMomentum.entrySet()) {
             final DoubleTensor nextNextMomentumForLatent = nextPositionGradient.get(nextMomentumForLatent.getKey()).
                 times(halfTimeStep).
                 plusInPlace(
@@ -493,7 +494,7 @@ public class NUTS implements PosteriorSamplingAlgorithm {
         return new LeapFrogged(nextPosition, nextMomentum, nextPositionGradient);
     }
 
-    private static double dotProduct(Map<Long, DoubleTensor> momentums) {
+    private static double dotProduct(Map<VertexId, DoubleTensor> momentums) {
         double dotProduct = 0.0;
         for (DoubleTensor momentum : momentums.values()) {
             dotProduct += momentum.pow(2).sum();
@@ -506,16 +507,16 @@ public class NUTS implements PosteriorSamplingAlgorithm {
      *
      * @param sampleFromVertices take samples from these vertices
      */
-    private static Map<Long, ?> takeSample(List<? extends Vertex> sampleFromVertices) {
-        Map<Long, ?> sample = new HashMap<>();
+    private static Map<VertexId, ?> takeSample(List<? extends Vertex> sampleFromVertices) {
+        Map<VertexId, ?> sample = new HashMap<>();
         for (Vertex vertex : sampleFromVertices) {
             putValue(vertex, sample);
         }
         return sample;
     }
 
-    private static <T> void putValue(Vertex<T> vertex, Map<Long, ?> target) {
-        ((Map<Long, T>) target).put(vertex.getId(), vertex.getValue());
+    private static <T> void putValue(Vertex<T> vertex, Map<VertexId, ?> target) {
+        ((Map<VertexId, T>) target).put(vertex.getId(), vertex.getValue());
     }
 
     /**
@@ -524,25 +525,25 @@ public class NUTS implements PosteriorSamplingAlgorithm {
      * @param samples      samples taken already
      * @param cachedSample a cached sample from before leapfrog
      */
-    private static void addSampleFromCache(Map<Long, List<?>> samples, Map<Long, ?> cachedSample) {
-        for (Map.Entry<Long, ?> sampleEntry : cachedSample.entrySet()) {
+    private static void addSampleFromCache(Map<VertexId, List<?>> samples, Map<VertexId, ?> cachedSample) {
+        for (Map.Entry<VertexId, ?> sampleEntry : cachedSample.entrySet()) {
             addSampleForVertex(sampleEntry.getKey(), sampleEntry.getValue(), samples);
         }
     }
 
-    private static <T> void addSampleForVertex(long id, T value, Map<Long, List<?>> samples) {
+    private static <T> void addSampleForVertex(VertexId id, T value, Map<VertexId, List<?>> samples) {
         List<T> samplesForVertex = (List<T>) samples.computeIfAbsent(id, v -> new ArrayList<T>());
         samplesForVertex.add(value);
     }
 
     private static class LeapFrogged {
-        final Map<Long, DoubleTensor> position;
-        final Map<Long, DoubleTensor> momentum;
-        final Map<Long, DoubleTensor> gradient;
+        final Map<VertexId, DoubleTensor> position;
+        final Map<VertexId, DoubleTensor> momentum;
+        final Map<VertexId, DoubleTensor> gradient;
 
-        LeapFrogged(Map<Long, DoubleTensor> position,
-                    Map<Long, DoubleTensor> momentum,
-                    Map<Long, DoubleTensor> gradient) {
+        LeapFrogged(Map<VertexId, DoubleTensor> position,
+                    Map<VertexId, DoubleTensor> momentum,
+                    Map<VertexId, DoubleTensor> gradient) {
             this.position = position;
             this.momentum = momentum;
             this.gradient = gradient;
@@ -551,31 +552,31 @@ public class NUTS implements PosteriorSamplingAlgorithm {
 
     private static class BuiltTree {
 
-        Map<Long, DoubleTensor> positionBackward;
-        Map<Long, DoubleTensor> gradientBackward;
-        Map<Long, DoubleTensor> momentumBackward;
-        Map<Long, DoubleTensor> positionForward;
-        Map<Long, DoubleTensor> gradientForward;
-        Map<Long, DoubleTensor> momentumForward;
-        Map<Long, DoubleTensor> acceptedPosition;
-        Map<Long, DoubleTensor> gradientAtAcceptedPosition;
+        Map<VertexId, DoubleTensor> positionBackward;
+        Map<VertexId, DoubleTensor> gradientBackward;
+        Map<VertexId, DoubleTensor> momentumBackward;
+        Map<VertexId, DoubleTensor> positionForward;
+        Map<VertexId, DoubleTensor> gradientForward;
+        Map<VertexId, DoubleTensor> momentumForward;
+        Map<VertexId, DoubleTensor> acceptedPosition;
+        Map<VertexId, DoubleTensor> gradientAtAcceptedPosition;
         double logOfMasterPAtAcceptedPosition;
-        Map<Long, ?> sampleAtAcceptedPosition;
+        Map<VertexId, ?> sampleAtAcceptedPosition;
         int acceptedLeapfrogCount;
         boolean shouldContinueFlag;
         double deltaLikelihoodOfLeapfrog;
         double treeSize;
 
-        BuiltTree(Map<Long, DoubleTensor> positionBackward,
-                  Map<Long, DoubleTensor> gradientBackward,
-                  Map<Long, DoubleTensor> momentumBackward,
-                  Map<Long, DoubleTensor> positionForward,
-                  Map<Long, DoubleTensor> gradientForward,
-                  Map<Long, DoubleTensor> momentumForward,
-                  Map<Long, DoubleTensor> acceptedPosition,
-                  Map<Long, DoubleTensor> gradientAtAcceptedPosition,
+        BuiltTree(Map<VertexId, DoubleTensor> positionBackward,
+                  Map<VertexId, DoubleTensor> gradientBackward,
+                  Map<VertexId, DoubleTensor> momentumBackward,
+                  Map<VertexId, DoubleTensor> positionForward,
+                  Map<VertexId, DoubleTensor> gradientForward,
+                  Map<VertexId, DoubleTensor> momentumForward,
+                  Map<VertexId, DoubleTensor> acceptedPosition,
+                  Map<VertexId, DoubleTensor> gradientAtAcceptedPosition,
                   double logOfMasterPAtAcceptedPosition,
-                  Map<Long, ?> sampleAtAcceptedPosition,
+                  Map<VertexId, ?> sampleAtAcceptedPosition,
                   int acceptedLeapfrogCount,
                   boolean shouldContinueFlag,
                   double deltaLikelihoodOfLeapfrog,
@@ -619,14 +620,14 @@ public class NUTS implements PosteriorSamplingAlgorithm {
         }
     }
 
-    private static double findStartingStepSize(Map<Long, DoubleTensor> position,
-                                               Map<Long, DoubleTensor> gradient,
+    private static double findStartingStepSize(Map<VertexId, DoubleTensor> position,
+                                               Map<VertexId, DoubleTensor> gradient,
                                                List<Vertex<DoubleTensor>> vertices,
                                                List<? extends Probabilistic> probabilisticVertices,
                                                KeanuRandom random) {
         double stepsize = 1;
         double probBeforeLeapfrog = getLogProb(probabilisticVertices);
-        Map<Long, DoubleTensor> momentums = new HashMap<>();
+        Map<VertexId, DoubleTensor> momentums = new HashMap<>();
         initializeMomentumForEachVertex(vertices, momentums, random);
         leapfrog(vertices, probabilisticVertices, position, gradient, momentums, stepsize);
         double probAfterLeapfrog = getLogProb(probabilisticVertices);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGenerator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGenerator.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.network.NetworkState;
+import io.improbable.keanu.vertices.VertexId;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -31,7 +32,7 @@ public class NetworkSamplesGenerator {
 
     public NetworkSamples generate(final int totalSampleCount) {
 
-        Map<Long, List<?>> samplesByVertex = new HashMap<>();
+        Map<VertexId, List<?>> samplesByVertex = new HashMap<>();
 
         dropSamples(dropCount);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.improbable.keanu.network.NetworkState;
+import io.improbable.keanu.vertices.VertexId;
 
 public interface SamplingAlgorithm {
 
@@ -18,7 +19,7 @@ public interface SamplingAlgorithm {
      *
      * @param samples map to store sampled vertex values
      */
-    void sample(Map<Long, List<?>> samples);
+    void sample(Map<VertexId, List<?>> samples);
 
     /**
      * Takes a sample with the algorithm and returns the state of the network for that sample.

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SimulatedAnnealing.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SimulatedAnnealing.java
@@ -13,6 +13,7 @@ import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.network.SimpleNetworkState;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import lombok.Builder;
 import lombok.Getter;
@@ -83,7 +84,7 @@ public class SimulatedAnnealing {
             throw new IllegalArgumentException("Cannot start optimizer on zero probability network");
         }
 
-        Map<Long, ?> maxSamplesByVertex = new HashMap<>();
+        Map<VertexId, ?> maxSamplesByVertex = new HashMap<>();
         List<Vertex> latentVertices = bayesNet.getLatentVertices();
 
         double logProbabilityBeforeStep = bayesNet.getLogOfMasterP();
@@ -117,12 +118,12 @@ public class SimulatedAnnealing {
         return new SimpleNetworkState(maxSamplesByVertex);
     }
 
-    private static void setSamplesAsMax(Map<Long, ?> samples, List<? extends Vertex> fromVertices) {
+    private static void setSamplesAsMax(Map<VertexId, ?> samples, List<? extends Vertex> fromVertices) {
         fromVertices.forEach(vertex -> setSampleForVertex((Vertex<?>) vertex, samples));
     }
 
-    private static <T> void setSampleForVertex(Vertex<T> vertex, Map<Long, ?> samples) {
-        ((Map<Long, ? super T>) samples).put(vertex.getId(), vertex.getValue());
+    private static <T> void setSampleForVertex(Vertex<T> vertex, Map<VertexId, ?> samples) {
+        ((Map<VertexId, ? super T>) samples).put(vertex.getId(), vertex.getValue());
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/Prior.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/Prior.java
@@ -1,15 +1,16 @@
 package io.improbable.keanu.algorithms.sampling;
 
-import io.improbable.keanu.algorithms.NetworkSamples;
-import io.improbable.keanu.algorithms.graphtraversal.TopologicalSort;
-import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import io.improbable.keanu.algorithms.NetworkSamples;
+import io.improbable.keanu.algorithms.graphtraversal.TopologicalSort;
+import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class Prior {
 
@@ -43,7 +44,7 @@ public class Prior {
         }
 
         List<? extends Vertex> topologicallySorted = TopologicalSort.sort(bayesNet.getLatentVertices());
-        Map<Long, List> samplesByVertex = new HashMap<>();
+        Map<VertexId, List> samplesByVertex = new HashMap<>();
 
         for (int sampleNum = 0; sampleNum < sampleCount; sampleNum++) {
             nextSample(topologicallySorted, random);
@@ -63,11 +64,11 @@ public class Prior {
         vertex.setAndCascade(vertex.sample(random));
     }
 
-    private static void takeSamples(Map<Long, List> samples, List<? extends Vertex> fromVertices) {
+    private static void takeSamples(Map<VertexId, List> samples, List<? extends Vertex> fromVertices) {
         fromVertices.forEach(vertex -> addSampleForVertex(vertex, samples));
     }
 
-    private static void addSampleForVertex(Vertex vertex, Map<Long, List> samples) {
+    private static void addSampleForVertex(Vertex vertex, Map<VertexId, List> samples) {
         List samplesForVertex = samples.computeIfAbsent(vertex.getId(), v -> new ArrayList<>());
         samplesForVertex.add(vertex.getValue());
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/sampling/RejectionSampler.java
@@ -10,6 +10,7 @@ import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class RejectionSampler {
@@ -72,7 +73,7 @@ public class RejectionSampler {
 
         bayesNet.cascadeObservations();
 
-        Map<Long, List<?>> samples = new HashMap<>();
+        Map<VertexId, List<?>> samples = new HashMap<>();
         long acceptedCount = 0;
 
         while (acceptedCount < sampleCount) {
@@ -100,11 +101,11 @@ public class RejectionSampler {
             .noneMatch(v -> ((NonProbabilistic) v).contradictsObservation());
     }
 
-    private static void takeSamples(Map<Long, List<?>> samples, List<? extends Vertex<?>> fromVertices) {
+    private static void takeSamples(Map<VertexId, List<?>> samples, List<? extends Vertex<?>> fromVertices) {
         fromVertices.forEach(vertex -> addSampleForVertex(vertex, samples));
     }
 
-    private static <T> void addSampleForVertex(Vertex<T> vertex, Map<Long, List<?>> samples) {
+    private static <T> void addSampleForVertex(Vertex<T> vertex, Map<VertexId, List<?>> samples) {
         List<T> samplesForVertex = (List<T>) samples.computeIfAbsent(vertex.getId(), v -> new ArrayList<T>());
         samplesForVertex.add(vertex.getValue());
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
@@ -14,6 +14,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.ProbabilityCalculator;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradient;
 
 
@@ -45,7 +46,7 @@ public class FitnessFunctionWithGradient {
             setAndCascadePoint(point, latentVertices);
 
             List<? extends Probabilistic> probabilisticVertices = Probabilistic.keepOnlyProbabilisticVertices(this.vertices);
-            Map<Long, DoubleTensor> diffs = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
+            Map<VertexId, DoubleTensor> diffs = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
 
             double[] gradients = alignGradientsToAppropriateIndex(diffs, latentVertices);
 
@@ -70,7 +71,7 @@ public class FitnessFunctionWithGradient {
         };
     }
 
-    private static double[] alignGradientsToAppropriateIndex(Map<Long /*Vertex Label*/, DoubleTensor /*Gradient*/> diffs,
+    private static double[] alignGradientsToAppropriateIndex(Map<VertexId, DoubleTensor /*Gradient*/> diffs,
                                                              List<? extends Vertex<DoubleTensor>> latentVertices) {
 
         List<DoubleTensor> tensors = new ArrayList<>();

--- a/keanu-project/src/main/java/io/improbable/keanu/network/NetworkState.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/NetworkState.java
@@ -1,8 +1,9 @@
 package io.improbable.keanu.network;
 
-import io.improbable.keanu.vertices.Vertex;
-
 import java.util.Set;
+
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 
 /**
  * Depending on how a NetworkState is being used, it may be significantly more efficient
@@ -15,7 +16,7 @@ public interface NetworkState {
 
     <T> T get(Vertex<T> vertex);
 
-    <T> T get(long vertexId);
+    <T> T get(VertexId vertexId);
 
-    Set<Long> getVertexIds();
+    Set<VertexId> getVertexIds();
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/network/SimpleNetworkState.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/SimpleNetworkState.java
@@ -1,15 +1,16 @@
 package io.improbable.keanu.network;
 
-import io.improbable.keanu.vertices.Vertex;
-
 import java.util.Map;
 import java.util.Set;
 
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+
 public class SimpleNetworkState implements NetworkState {
 
-    private final Map<Long, ?> vertexValues;
+    private final Map<VertexId, ?> vertexValues;
 
-    public SimpleNetworkState(Map<Long, ?> vertexValues) {
+    public SimpleNetworkState(Map<VertexId, ?> vertexValues) {
         this.vertexValues = vertexValues;
     }
 
@@ -19,12 +20,12 @@ public class SimpleNetworkState implements NetworkState {
     }
 
     @Override
-    public <T> T get(long vertexId) {
+    public <T> T get(VertexId vertexId) {
         return (T) vertexValues.get(vertexId);
     }
 
     @Override
-    public Set<Long> getVertexIds() {
+    public Set<VertexId> getVertexIds() {
         return vertexValues.keySet();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/util/csv/ColumnWriter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/csv/ColumnWriter.java
@@ -1,17 +1,17 @@
 package io.improbable.keanu.util.csv;
 
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.vertices.Vertex;
+import static io.improbable.keanu.util.csv.WriteCsv.findLongestTensor;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.improbable.keanu.util.csv.WriteCsv.findLongestTensor;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.vertices.Vertex;
 
 public class ColumnWriter extends Writer {
 
-    private static final String HEADER_STYLE = "{%d}";
+    private static final String HEADER_STYLE = "{%s}";
 
     private List<? extends Vertex<? extends Tensor>> vertices;
 
@@ -44,7 +44,7 @@ public class ColumnWriter extends Writer {
     @Override
     public Writer withDefaultHeader() {
         int headerSize = vertices.size();
-        String[] header = createHeader(headerSize, HEADER_STYLE, i -> (int) vertices.get(i).getId());
+        String[] header = createHeader(headerSize, HEADER_STYLE, i -> vertices.get(i).getId().toString());
         withHeader(header);
         return this;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/util/csv/RowWriter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/csv/RowWriter.java
@@ -1,17 +1,17 @@
 package io.improbable.keanu.util.csv;
 
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.vertices.Vertex;
+import static io.improbable.keanu.util.csv.WriteCsv.findLongestTensor;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.improbable.keanu.util.csv.WriteCsv.findLongestTensor;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.vertices.Vertex;
 
 public class RowWriter extends Writer {
 
-    private static final String HEADER_STYLE = "[%d]";
+    private static final String HEADER_STYLE = "[%s]";
 
     private List<? extends Vertex<? extends Tensor>> vertices;
 
@@ -44,7 +44,7 @@ public class RowWriter extends Writer {
     @Override
     public Writer withDefaultHeader() {
         int sizeOfHeader = findLongestTensor(vertices);
-        String[] header = createHeader(sizeOfHeader, HEADER_STYLE, i -> i);
+        String[] header = createHeader(sizeOfHeader, HEADER_STYLE, i -> Integer.toString(i));
         withHeader(header);
         return this;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/util/csv/SampleWriter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/csv/SampleWriter.java
@@ -1,16 +1,16 @@
 package io.improbable.keanu.util.csv;
 
-import io.improbable.keanu.algorithms.NetworkSamples;
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.vertices.Vertex;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.improbable.keanu.algorithms.NetworkSamples;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.vertices.Vertex;
+
 public class SampleWriter extends Writer {
 
-    private static final String HEADER_STYLE = "{%d}[%d]";
+    private static final String HEADER_STYLE = "{%s}[%d]";
 
     private NetworkSamples samples;
     private List<? extends Vertex<? extends Tensor>> vertices;

--- a/keanu-project/src/main/java/io/improbable/keanu/util/csv/Writer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/csv/Writer.java
@@ -1,14 +1,14 @@
 package io.improbable.keanu.util.csv;
 
-import com.opencsv.CSVWriter;
-import com.opencsv.ICSVWriter;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.function.Function;
+
+import com.opencsv.CSVWriter;
+import com.opencsv.ICSVWriter;
 
 public abstract class Writer {
 
@@ -100,7 +100,7 @@ public abstract class Writer {
         return file;
     }
 
-    String[] createHeader(int size, String headerStyle, Function<Integer, Integer> func) {
+    String[] createHeader(int size, String headerStyle, Function<Integer, String> func) {
         String[] header = new String[size];
         for (int i = 0; i < size; i++) {
             header[i] = String.format(headerStyle, func.apply(i));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
@@ -29,7 +29,7 @@ public interface Probabilistic<T> extends Observable<T> {
      * For continuous variables this is called the PDF (probability density function).
      * For discrete variables this is called the PMF (probability mass function).
      */
-    Map<Long, DoubleTensor> dLogProb(T value);
+    Map<VertexId, DoubleTensor> dLogProb(T value);
 
     T getValue();
 
@@ -39,7 +39,7 @@ public interface Probabilistic<T> extends Observable<T> {
         return logProb(getValue());
     }
 
-    default Map<Long, DoubleTensor> dLogProbAtValue() {
+    default Map<VertexId, DoubleTensor> dLogProbAtValue() {
         return dLogProb(getValue());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -3,9 +3,9 @@ package io.improbable.keanu.vertices;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -16,9 +16,7 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public abstract class Vertex<T> implements Observable<T> {
 
-    public static final AtomicLong ID_GENERATOR = new AtomicLong(0L);
-
-    private long uuid = ID_GENERATOR.getAndIncrement();
+    private VertexId id = new VertexId();
     private Set<Vertex> children = Collections.emptySet();
     private Set<Vertex> parents = Collections.emptySet();
     private T value;
@@ -172,8 +170,8 @@ public abstract class Vertex<T> implements Observable<T> {
         return observation.getObservedValue();
     }
 
-    public long getId() {
-        return uuid;
+    public VertexId getId() {
+        return id;
     }
 
     public Set<Vertex> getChildren() {
@@ -213,12 +211,12 @@ public abstract class Vertex<T> implements Observable<T> {
 
         Vertex<?> vertex = (Vertex<?>) o;
 
-        return uuid == vertex.uuid;
+        return Objects.equals(this.id, vertex.id);
     }
 
     @Override
     public int hashCode() {
-        return (int) (uuid ^ (uuid >>> 32));
+        return (int)Objects.hash(id);
     }
 
     public Set<Vertex> getConnectedGraph() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexId.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexId.java
@@ -1,0 +1,63 @@
+package io.improbable.keanu.vertices;
+
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.primitives.Ints;
+
+/**
+ * An object representing the ID value of a vertex.  IDs are assigned in such a way that a Lexicographic ordering of
+ * all nodes based on their ID value is a valid topological ordering of the graph made up by those vertices.
+ *
+ * Ids also encapsulate the notion of "Depth".  When we have graphs within graphs, the depth tells us at what level the
+ * graph exists - ie depth 1 is the outermost graph, depth 2 is a graph within a graph etc.
+ */
+public class VertexId implements Comparable<VertexId> {
+
+    public static final AtomicLong ID_GENERATOR = new AtomicLong(0L);
+
+    LinkedList<Long> idValues = new LinkedList<>();
+
+    public VertexId() {
+        long newId = ID_GENERATOR.getAndIncrement();
+        idValues.push(newId);
+    }
+
+    @Override
+    public int compareTo(VertexId that) {
+        long comparisonValue = 0;
+
+        for (int i = 0; i < Math.min(this.idValues.size(), that.idValues.size()) && comparisonValue == 0; i++) {
+            comparisonValue = this.idValues.get(i) - that.idValues.get(i);
+        }
+
+        if (comparisonValue == 0) {
+            comparisonValue = this.idValues.size() - that.idValues.size();
+        }
+
+        return Ints.saturatedCast(comparisonValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VertexId vertexId = (VertexId) o;
+        return Objects.equals(idValues, vertexId.idValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idValues);
+    }
+
+    @Override
+    public String toString() {
+        return idValues.peek().toString();
+    }
+
+    public int getDepth() {
+        return idValues.size();
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
@@ -10,6 +10,7 @@ import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -63,7 +64,7 @@ public class BernoulliVertex extends BoolVertex implements ProbabilisticBoolean 
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(BooleanTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(BooleanTensor value) {
 
         if (!(probTrue instanceof Differentiable)) {
             throw new UnsupportedOperationException("The probability of the Bernoulli being true must be differentiable");

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBoolean.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBoolean.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticBoolean extends Probabilistic<BooleanTensor> {
     default double logPmf(boolean value) {
@@ -19,15 +20,15 @@ public interface ProbabilisticBoolean extends Probabilistic<BooleanTensor> {
         return logProb(value);
     }
 
-    default Map<Long, DoubleTensor> dLogPmf(boolean value) {
+    default Map<VertexId, DoubleTensor> dLogPmf(boolean value) {
         return dLogPmf(BooleanTensor.scalar(value));
     }
 
-    default Map<Long, DoubleTensor> dLogPmf(boolean[] values) {
+    default Map<VertexId, DoubleTensor> dLogPmf(boolean[] values) {
         return dLogPmf(BooleanTensor.create(values));
     }
 
-    default Map<Long, DoubleTensor> dLogPmf(BooleanTensor value) {
+    default Map<VertexId, DoubleTensor> dLogPmf(BooleanTensor value) {
         return dLogProb(value);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
@@ -1,16 +1,24 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.math3.util.Pair;
+
+import io.improbable.keanu.kotlin.DoubleOperators;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
-import io.improbable.keanu.kotlin.DoubleOperators;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import org.apache.commons.math3.util.Pair;
 
 public class DualNumber implements DoubleOperators<DualNumber> {
 
@@ -18,7 +26,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         return new DualNumber(value, PartialDerivatives.OF_CONSTANT);
     }
 
-    public static DualNumber createWithRespectToSelf(long withRespectTo, DoubleTensor value) {
+    public static DualNumber createWithRespectToSelf(VertexId withRespectTo, DoubleTensor value) {
         return new DualNumber(value, PartialDerivatives.withRespectToSelf(withRespectTo, value.getShape()));
     }
 
@@ -39,11 +47,11 @@ public class DualNumber implements DoubleOperators<DualNumber> {
                                     int dimension,
                                     DoubleTensor[] dualValues) {
 
-        Map<Long, List<DoubleTensor>> dualNumbersToConcat = new HashMap<>();
-        List<Pair<Long, List<Integer>>> vertexIds = findShapesOfVertexWithRespectTo(dualNumbersOfInputs);
+        Map<VertexId, List<DoubleTensor>> dualNumbersToConcat = new HashMap<>();
+        List<Pair<VertexId, List<Integer>>> vertexIds = findShapesOfVertexWithRespectTo(dualNumbersOfInputs);
 
-        for (Pair<Long, List<Integer>> wrtVertex : vertexIds) {
-            long vertexId = wrtVertex.getFirst();
+        for (Pair<VertexId, List<Integer>> wrtVertex : vertexIds) {
+            VertexId vertexId = wrtVertex.getFirst();
 
             for (DoubleVertex ofVertex : input) {
                 int[] shapeOfVertexWithRespectTo = wrtVertex.getSecond().stream().mapToInt(i -> i).toArray();
@@ -60,9 +68,9 @@ public class DualNumber implements DoubleOperators<DualNumber> {
             }
         }
 
-        Map<Long, DoubleTensor> concattedDualNumbers = new HashMap<>();
+        Map<VertexId, DoubleTensor> concattedDualNumbers = new HashMap<>();
 
-        for (Map.Entry<Long, List<DoubleTensor>> dualNumberForVertex : dualNumbersToConcat.entrySet()) {
+        for (Map.Entry<VertexId, List<DoubleTensor>> dualNumberForVertex : dualNumbersToConcat.entrySet()) {
             DoubleTensor concatted = concatPartialDerivates(dimension, dualNumberForVertex.getValue());
             concattedDualNumbers.put(dualNumberForVertex.getKey(), concatted);
         }
@@ -81,12 +89,12 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         }
     }
 
-    private static List<Pair<Long, List<Integer>>> findShapesOfVertexWithRespectTo(List<DualNumber> dualNumbers) {
-        List<Pair<Long, List<Integer>>> vertexInfo = new ArrayList<>();
+    private static List<Pair<VertexId, List<Integer>>> findShapesOfVertexWithRespectTo(List<DualNumber> dualNumbers) {
+        List<Pair<VertexId, List<Integer>>> vertexInfo = new ArrayList<>();
         Set ids = new HashSet();
 
         for (DualNumber dualNumber : dualNumbers) {
-            for (Map.Entry<Long, DoubleTensor> entry : dualNumber.getPartialDerivatives().asMap().entrySet()) {
+            for (Map.Entry<VertexId, DoubleTensor> entry : dualNumber.getPartialDerivatives().asMap().entrySet()) {
                 if (!ids.contains(entry.getKey())) {
                     vertexInfo.add(new Pair<>(entry.getKey(), Arrays.stream(entry.getValue().getShape()).boxed().collect(Collectors.toList())));
                     ids.add(entry.getKey());
@@ -105,11 +113,11 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         this.partialDerivatives = partialDerivatives;
     }
 
-    public DualNumber(DoubleTensor value, Map<Long, DoubleTensor> partialDerivatives) {
+    public DualNumber(DoubleTensor value, Map<VertexId, DoubleTensor> partialDerivatives) {
         this(value, new PartialDerivatives(partialDerivatives));
     }
 
-    public DualNumber(DoubleTensor value, long infinitesimalLabel) {
+    public DualNumber(DoubleTensor value, VertexId infinitesimalLabel) {
         this(value, new PartialDerivatives(Collections.singletonMap(infinitesimalLabel, DoubleTensor.ones(value.getShape()))));
     }
 
@@ -379,9 +387,9 @@ public class DualNumber implements DoubleOperators<DualNumber> {
     }
 
     public DualNumber take(int... index) {
-        Map<Long, DoubleTensor> dualsAtIndex = new HashMap<>();
+        Map<VertexId, DoubleTensor> dualsAtIndex = new HashMap<>();
 
-        for (Map.Entry<Long, DoubleTensor> entry : this.partialDerivatives.asMap().entrySet()) {
+        for (Map.Entry<VertexId, DoubleTensor> entry : this.partialDerivatives.asMap().entrySet()) {
             DoubleTensor atIndexTensor = takeFromPartial(entry.getValue(), index);
             int desiredRank = entry.getValue().getShape().length;
             int[] paddedShape = TensorShape.shapeToDesiredRankByPrependingOnes(atIndexTensor.getShape(), desiredRank);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradient.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.VertexId;
 
 public class LogProbGradient {
 
@@ -16,8 +17,8 @@ public class LogProbGradient {
      * @param probabilisticVertices vertices to use in LogProb calc
      * @return the partial derivatives with respect to any latents upstream
      */
-    public static Map<Long, DoubleTensor> getJointLogProbGradientWrtLatents(List<? extends Probabilistic> probabilisticVertices) {
-        final Map<Long, DoubleTensor> diffOfLogWrt = new HashMap<>();
+    public static Map<VertexId, DoubleTensor> getJointLogProbGradientWrtLatents(List<? extends Probabilistic> probabilisticVertices) {
+        final Map<VertexId, DoubleTensor> diffOfLogWrt = new HashMap<>();
 
         for (final Probabilistic probabilisticVertex : probabilisticVertices) {
             getLogProbGradientWrtLatents(probabilisticVertex, diffOfLogWrt);
@@ -26,15 +27,15 @@ public class LogProbGradient {
         return diffOfLogWrt;
     }
 
-    public static Map<Long, DoubleTensor> getLogProbGradientWrtLatents(final Probabilistic probabilisticVertex,
-                                                                       final Map<Long, DoubleTensor> diffOfLogProbWrt) {
+    public static Map<VertexId, DoubleTensor> getLogProbGradientWrtLatents(final Probabilistic probabilisticVertex,
+                                                                       final Map<VertexId, DoubleTensor> diffOfLogProbWrt) {
         //dlogProbForProbabilisticVertex is the partial differentials of the natural
         //log of the fitness vertex's probability w.r.t latent vertices. The key of the
         //map is the latent vertex's id.
-        final Map<Long, DoubleTensor> dlogProbForProbabilisticVertex = probabilisticVertex.dLogProbAtValue();
+        final Map<VertexId, DoubleTensor> dlogProbForProbabilisticVertex = probabilisticVertex.dLogProbAtValue();
 
-        for (Map.Entry<Long, DoubleTensor> partialDiffLogPWrt : dlogProbForProbabilisticVertex.entrySet()) {
-            final long wrtLatentVertexId = partialDiffLogPWrt.getKey();
+        for (Map.Entry<VertexId, DoubleTensor> partialDiffLogPWrt : dlogProbForProbabilisticVertex.entrySet()) {
+            final VertexId wrtLatentVertexId = partialDiffLogPWrt.getKey();
             final DoubleTensor partialDiffLogProbContribution = partialDiffLogPWrt.getValue();
 
             //partialDiffLogProbContribution is the contribution to the rate of change of
@@ -51,7 +52,7 @@ public class LogProbGradient {
         return diffOfLogProbWrt;
     }
 
-    public static Map<Long, DoubleTensor> getLogProbGradientWrtLatents(final Probabilistic probabilisticVertex) {
+    public static Map<VertexId, DoubleTensor> getLogProbGradientWrtLatents(final Probabilistic probabilisticVertex) {
         return getLogProbGradientWrtLatents(probabilisticVertex, new HashMap<>());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -14,6 +14,7 @@ import io.improbable.keanu.distributions.continuous.Beta;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -89,12 +90,12 @@ public class BetaVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = distribution().dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(A).getValue(), dlnP.get(B).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdalpha,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdalpha,
                                                              DoubleTensor dLogPdbeta,
                                                              DoubleTensor dLogPdx) {
         PartialDerivatives dLogPdInputsFromAlpha = alpha.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdalpha);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
@@ -13,6 +13,7 @@ import io.improbable.keanu.distributions.continuous.Cauchy;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -90,12 +91,12 @@ public class CauchyVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = Cauchy.withParameters(location.getValue(), scale.getValue()).dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(L).getValue(), dlnP.get(S).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlocation,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlocation,
                                                              DoubleTensor dLogPdscale,
                                                              DoubleTensor dLogPdx) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -8,6 +8,7 @@ import io.improbable.keanu.distributions.continuous.ChiSquared;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -62,7 +63,7 @@ public class ChiSquaredVertex extends DoubleVertex implements ProbabilisticDoubl
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
@@ -10,6 +10,7 @@ import io.improbable.keanu.distributions.continuous.Dirichlet;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -70,7 +71,7 @@ public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = Dirichlet.withParameters(concentration.getValue()).dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(C).getValue(), dlnP.get(X).getValue());
     }
@@ -80,7 +81,7 @@ public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble
         return Dirichlet.withParameters(concentration.getValue()).sample(getShape(), random);
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdc,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdc,
                                                              DoubleTensor dLogPdx) {
 
         PartialDerivatives dLogPdInputs = concentration.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdc);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -12,6 +12,7 @@ import io.improbable.keanu.distributions.continuous.Exponential;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -65,12 +66,12 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = Exponential.withParameters(lambda.getValue()).dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(LAMBDA).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlambda,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlambda,
                                                              DoubleTensor dLogPdx) {
 
         PartialDerivatives dLogPdInputs = lambda.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlambda);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -13,6 +13,7 @@ import io.improbable.keanu.distributions.continuous.Gamma;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -74,15 +75,15 @@ public class GammaVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = Gamma.withParameters(theta.getValue(), k.getValue()).dLogProb(value);
 
         return convertDualNumbersToDiff(dlnP.get(THETA).getValue(), dlnP.get(K).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdtheta,
-                                                             DoubleTensor dLogPdk,
-                                                             DoubleTensor dLogPdx) {
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdtheta,
+                                                                 DoubleTensor dLogPdk,
+                                                                 DoubleTensor dLogPdx) {
 
         PartialDerivatives dLogPdInputsFromTheta = theta.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdtheta);
         PartialDerivatives dLogPdInputsFromK = k.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdk);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -14,6 +14,7 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -92,12 +93,12 @@ public class GaussianVertex extends DoubleVertex implements ProbabilisticDouble 
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = Gaussian.withParameters(mu.getValue(), sigma.getValue()).dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(SIGMA).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
                                                              DoubleTensor dLogPdsigma,
                                                              DoubleTensor dLogPdx) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -13,6 +13,7 @@ import io.improbable.keanu.distributions.continuous.InverseGamma;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -87,13 +88,13 @@ public class InverseGammaVertex extends DoubleVertex implements ProbabilisticDou
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = InverseGamma.withParameters(alpha.getValue(), beta.getValue()).dLogProb(value);
 
         return convertDualNumbersToDiff(dlnP.get(A).getValue(), dlnP.get(B).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdalpha,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdalpha,
                                                              DoubleTensor dLogPdbeta,
                                                              DoubleTensor dLogPdx) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -54,8 +55,8 @@ public class KDEVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
-        Map<Long, DoubleTensor> partialDerivatives = new HashMap<>();
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
+        Map<VertexId, DoubleTensor> partialDerivatives = new HashMap<>();
 
         DoubleTensor dlnPdfs = dPdx(value).divInPlace(pdf(value));
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -13,6 +13,7 @@ import io.improbable.keanu.distributions.continuous.Laplace;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -77,12 +78,12 @@ public class LaplaceVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = Laplace.withParameters(mu.getValue(), beta.getValue()).dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(BETA).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
                                                              DoubleTensor dLogPdbeta,
                                                              DoubleTensor dLogPdx) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -14,6 +14,7 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -81,12 +82,12 @@ public class LogNormalVertex extends DoubleVertex implements ProbabilisticDouble
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = LogNormal.withParameters(mu.getValue(), sigma.getValue()).dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(SIGMA).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
                                                              DoubleTensor dLogPdsigma,
                                                              DoubleTensor dLogPdx) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -13,6 +13,7 @@ import io.improbable.keanu.distributions.continuous.Logistic;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -69,12 +70,12 @@ public class LogisticVertex extends DoubleVertex implements ProbabilisticDouble 
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = Logistic.withParameters(mu.getValue(), s.getValue()).dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(S).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
                                                              DoubleTensor dLogPds,
                                                              DoubleTensor dLogPdx) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import io.improbable.keanu.distributions.continuous.MultivariateGaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -67,7 +68,7 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Probabil
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
@@ -14,6 +14,7 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -90,14 +91,14 @@ public class ParetoVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         Diffs dlnP = Pareto.withParameters(location.getValue(), scale.getValue()).dLogProb(value);
         return convertDualNumbersToDiff(dlnP.get(L).getValue(), dlnP.get(S).getValue(), dlnP.get(X).getValue());
     }
 
-    private Map<Long, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdLoc,
-                                                             DoubleTensor dLogPdScale,
-                                                             DoubleTensor dLogPdX) {
+    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdLoc,
+                                                                 DoubleTensor dLogPdScale,
+                                                                 DoubleTensor dLogPdX) {
 
         PartialDerivatives dLogPdInputsFromLoc = location.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdLoc);
         PartialDerivatives dLogPdInputsFromScale = scale.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdScale);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticDouble extends Probabilistic<DoubleTensor> {
     default double logPdf(double value) {
@@ -18,15 +19,15 @@ public interface ProbabilisticDouble extends Probabilistic<DoubleTensor> {
         return logProb(value);
     }
 
-    default Map<Long, DoubleTensor> dLogPdf(double value) {
+    default Map<VertexId, DoubleTensor> dLogPdf(double value) {
         return dLogPdf(DoubleTensor.scalar(value));
     }
 
-    default Map<Long, DoubleTensor> dLogPdf(double[] values) {
+    default Map<VertexId, DoubleTensor> dLogPdf(double[] values) {
         return dLogPdf(DoubleTensor.create(values));
     }
 
-    default Map<Long,DoubleTensor> dLogPdf(DoubleTensor value) {
+    default Map<VertexId,DoubleTensor> dLogPdf(DoubleTensor value) {
         return dLogProb(value);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.SmoothUniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -121,7 +122,7 @@ public class SmoothUniformVertex extends DoubleVertex implements ProbabilisticDo
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         final DoubleTensor min = xMin.getValue();
         final DoubleTensor max = xMax.getValue();
         ContinuousDistribution distribution = SmoothUniform.withParameters(min, max, this.edgeSharpness);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -10,6 +10,7 @@ import io.improbable.keanu.distributions.continuous.StudentT;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -56,9 +57,9 @@ public class StudentTVertex extends DoubleVertex implements ProbabilisticDouble 
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor t) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor t) {
         Diffs diff = StudentT.withParameters(v.getValue()).dLogProb(t);
-        Map<Long, DoubleTensor> m = new HashMap<>();
+        Map<VertexId, DoubleTensor> m = new HashMap<>();
         m.put(getId(), diff.get(T).getValue());
         return m;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import io.improbable.keanu.distributions.continuous.Triangular;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -108,7 +109,7 @@ public class TriangularVertex extends DoubleVertex implements ProbabilisticDoubl
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -86,7 +87,7 @@ public class UniformVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
         DoubleTensor dLogPdx = DoubleTensor.zeros(this.xMax.getShape());
         dLogPdx = dLogPdx.setWithMaskInPlace(value.getGreaterThanMask(xMax.getValue()), Double.NEGATIVE_INFINITY);
         dLogPdx = dLogPdx.setWithMaskInPlace(value.getLessThanOrEqualToMask(xMin.getValue()), Double.POSITIVE_INFINITY);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
@@ -10,6 +10,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -51,7 +52,7 @@ public class CategoricalVertex<T> extends Vertex<T> implements Probabilistic<T> 
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(T value) {
+    public Map<VertexId, DoubleTensor> dLogProb(T value) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
@@ -10,6 +10,7 @@ import io.improbable.keanu.distributions.discrete.Binomial;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -63,7 +64,7 @@ public class BinomialVertex extends IntegerVertex implements ProbabilisticIntege
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(IntegerTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -11,6 +11,7 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.CastDoubleVertex;
@@ -70,7 +71,7 @@ public class PoissonVertex extends IntegerVertex implements ProbabilisticInteger
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(IntegerTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticInteger extends Probabilistic<IntegerTensor> {
     default double logPmf(int value) {
@@ -19,15 +20,15 @@ public interface ProbabilisticInteger extends Probabilistic<IntegerTensor> {
         return logProb(value);
     }
 
-    default Map<Long, DoubleTensor> dLogPmf(int value) {
+    default Map<VertexId, DoubleTensor> dLogPmf(int value) {
         return dLogPmf(IntegerTensor.scalar(value));
     }
 
-    default Map<Long, DoubleTensor> dLogPmf(int[] values) {
+    default Map<VertexId, DoubleTensor> dLogPmf(int[] values) {
         return dLogPmf(IntegerTensor.create(values));
     }
 
-    default Map<Long,DoubleTensor> dLogPmf(IntegerTensor value) {
+    default Map<VertexId,DoubleTensor> dLogPmf(IntegerTensor value) {
         return dLogProb(value);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -1,15 +1,16 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
-import io.improbable.keanu.distributions.discrete.UniformInt;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 import java.util.Map;
 
+import io.improbable.keanu.distributions.discrete.UniformInt;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
@@ -80,7 +81,7 @@ public class UniformIntVertex extends IntegerVertex implements ProbabilisticInte
     }
 
     @Override
-    public Map<Long, DoubleTensor> dLogProb(IntegerTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/DeterministicRule.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/DeterministicRule.java
@@ -1,17 +1,18 @@
 package io.improbable.keanu;
 
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class DeterministicRule implements TestRule {
 
     @Override
     public Statement apply(final Statement base, final Description description) {
         KeanuRandom.setDefaultRandomSeed(1);
-        Vertex.ID_GENERATOR.set(1);
+        VertexId.ID_GENERATOR.set(1);
         return base;
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/NetworkSamplesTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/NetworkSamplesTest.java
@@ -1,25 +1,29 @@
 package io.improbable.keanu.algorithms;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.improbable.keanu.vertices.VertexId;
 
 public class NetworkSamplesTest {
 
     NetworkSamples samples;
+    VertexId v1 = new VertexId();
+    VertexId v2 = new VertexId();
 
     @Before
     public void setup() {
 
-        Map<Long, List<Integer>> sampleMap = new HashMap<>();
-        sampleMap.put(1L, Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-        sampleMap.put(2L, Arrays.asList(9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
+        Map<VertexId, List<Integer>> sampleMap = new HashMap<>();
+        sampleMap.put(v1, Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        sampleMap.put(v2, Arrays.asList(9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
 
         samples = new NetworkSamples(sampleMap, 10);
     }
@@ -29,8 +33,8 @@ public class NetworkSamplesTest {
         NetworkSamples droppedSamples = samples.drop(5);
 
         assertTrue(droppedSamples.size() == 5);
-        assertTrue(droppedSamples.get(1L).asList().equals(Arrays.asList(6, 7, 8, 9, 10)));
-        assertTrue(droppedSamples.get(2L).asList().equals(Arrays.asList(4, 3, 2, 1, 0)));
+        assertTrue(droppedSamples.get(v1).asList().equals(Arrays.asList(6, 7, 8, 9, 10)));
+        assertTrue(droppedSamples.get(v2).asList().equals(Arrays.asList(4, 3, 2, 1, 0)));
     }
 
     @Test
@@ -38,15 +42,15 @@ public class NetworkSamplesTest {
         NetworkSamples subsamples = samples.downSample(5);
 
         assertTrue(subsamples.size() == 2);
-        assertTrue(subsamples.get(1L).asList().equals(Arrays.asList(1, 6)));
-        assertTrue(subsamples.get(2L).asList().equals(Arrays.asList(9, 4)));
+        assertTrue(subsamples.get(v1).asList().equals(Arrays.asList(1, 6)));
+        assertTrue(subsamples.get(v2).asList().equals(Arrays.asList(9, 4)));
     }
 
     @Test
     public void doesCalculateProbability() {
         double result2 = samples.probability(state -> {
-            int a = state.get(1L);
-            int b = state.get(2L);
+            int a = state.get(v1);
+            int b = state.get(v2);
             return a == b;
         });
         assertTrue(result2 == 0.1);
@@ -56,8 +60,8 @@ public class NetworkSamplesTest {
     public void doesFind100PercentProbability() {
 
         double result = samples.probability(state -> {
-            int a = state.get(1L);
-            int b = state.get(2L);
+            int a = state.get(v1);
+            int b = state.get(v2);
             return (a + b) == 10;
         });
         assertTrue(result == 1.0);

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGeneratorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGeneratorTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.network.SimpleNetworkState;
+import io.improbable.keanu.vertices.VertexId;
 import lombok.Value;
 
 public class NetworkSamplesGeneratorTest {
@@ -71,7 +72,7 @@ public class NetworkSamplesGeneratorTest {
         }
 
         @Override
-        public void sample(Map<Long, List<?>> samples) {
+        public void sample(Map<VertexId, List<?>> samples) {
             sampleCount.incrementAndGet();
         }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/network/NetworkStateGrouperTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/NetworkStateGrouperTest.java
@@ -1,23 +1,29 @@
 package io.improbable.keanu.network;
 
-import io.improbable.keanu.network.grouping.NetworkStateGrouper;
-import io.improbable.keanu.network.grouping.continuouspointgroupers.DBSCANContinuousPointGrouper;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 
-import java.util.*;
-
-import static org.junit.Assert.assertTrue;
+import io.improbable.keanu.network.grouping.NetworkStateGrouper;
+import io.improbable.keanu.network.grouping.continuouspointgroupers.DBSCANContinuousPointGrouper;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class NetworkStateGrouperTest {
 
     private KeanuRandom random = new KeanuRandom(1);
 
-    long v1Id = 1;
-    long v2Id = 2;
-    long v3Id = 3;
-    long v4Id = 4;
-    long v5Id = 5;
+    VertexId v1Id = new VertexId();
+    VertexId v2Id = new VertexId();
+    VertexId v3Id = new VertexId();
+    VertexId v4Id = new VertexId();
+    VertexId v5Id = new VertexId();
 
     @Test
     public void finds5Groupings() {
@@ -30,8 +36,8 @@ public class NetworkStateGrouperTest {
         networkStates.addAll(createGroup(true, false, 6.0, 5.0, 4.0));
         networkStates.addAll(createGroup(false, false, 100.0, 200.0, 50000.0));
 
-        List<Long> discreteIds = Arrays.asList(v1Id, v2Id);
-        List<Long> continuousIds = Arrays.asList(v3Id, v4Id, v5Id);
+        List<VertexId> discreteIds = Arrays.asList(v1Id, v2Id);
+        List<VertexId> continuousIds = Arrays.asList(v3Id, v4Id, v5Id);
 
         NetworkStateGrouper grouper = new NetworkStateGrouper(new DBSCANContinuousPointGrouper(1.0, 3));
         List<List<NetworkState>> filteredStates = grouper.groupNetworkStates(networkStates, discreteIds, continuousIds);
@@ -44,7 +50,7 @@ public class NetworkStateGrouperTest {
         List<NetworkState> group = new ArrayList<>();
 
         for (int i = 0; i < 100; i++) {
-            Map<Long, ? super Object> values = new HashMap<>();
+            Map<VertexId, ? super Object> values = new HashMap<>();
             values.put(v1Id, v1);
             values.put(v2Id, v2);
             values.put(v3Id, v3 + (random.nextDouble() - 0.5));

--- a/keanu-project/src/test/java/io/improbable/keanu/util/csv/WriteCsvTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/csv/WriteCsvTest.java
@@ -1,20 +1,26 @@
 package io.improbable.keanu.util.csv;
 
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-
-import static org.junit.Assert.assertTrue;
 
 public class WriteCsvTest {
 
@@ -49,7 +55,7 @@ public class WriteCsvTest {
         scalarTensors.addAll(Arrays.asList(c1, c2));
         integerColumnTensors.addAll(Arrays.asList(i1, i2));
 
-        Map<Long, List<DoubleTensor>> networkSamples = new HashMap<>();
+        Map<VertexId, List<DoubleTensor>> networkSamples = new HashMap<>();
         networkSamples.put(g1.getId(), Arrays.asList(g1.getValue(), g1.times(2).getValue()));
         networkSamples.put(g2.getId(), Arrays.asList(g2.getValue(), g2.times(2).getValue()));
         samples = new NetworkSamples(networkSamples, 2);
@@ -78,8 +84,8 @@ public class WriteCsvTest {
         CsvReader reader = ReadCsv.fromFile(file).expectHeader(true);
         List<List<String>> lines = reader.readLines();
 
-        long firstId = rowTensors.get(0).getId();
-        long secondId = rowTensors.get(1).getId();
+        VertexId firstId = rowTensors.get(0).getId();
+        VertexId secondId = rowTensors.get(1).getId();
 
         assertTrue(lines.size() == 2);
         assertTrue(reader.getHeader().equals(Arrays.asList(
@@ -140,8 +146,8 @@ public class WriteCsvTest {
         CsvReader reader = ReadCsv.fromFile(file).expectHeader(true);
         List<List<String>> lines = reader.readLines();
 
-        long firstId = columnTensors.get(0).getId();
-        long secondId = columnTensors.get(1).getId();
+        VertexId firstId = columnTensors.get(0).getId();
+        VertexId secondId = columnTensors.get(1).getId();
 
         assertTrue(lines.size() == 5);
         assertTrue(reader.getHeader().equals(Arrays.asList("{" + firstId + "}", "{" + secondId + "}")));
@@ -209,8 +215,8 @@ public class WriteCsvTest {
         CsvReader reader = ReadCsv.fromFile(file).expectHeader(true);
         List<List<String>> lines = reader.readLines();
 
-        long firstId = scalarTensors.get(0).getId();
-        long secondId = scalarTensors.get(1).getId();
+        VertexId firstId = scalarTensors.get(0).getId();
+        VertexId secondId = scalarTensors.get(1).getId();
 
         assertTrue(lines.size() == 1);
         assertTrue(reader.getHeader().equals(Arrays.asList("{" + firstId + "}", "{" + secondId + "}")));

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
@@ -31,9 +31,9 @@ public class TestGraphGenerator {
 
         private final AtomicInteger opCount;
         private final AtomicInteger dualNumberCount;
-        private final Consumer<Long> onOp;
+        private final Consumer<VertexId> onOp;
 
-        public PassThroughVertex(DoubleVertex inputVertex, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<Long> onOp) {
+        public PassThroughVertex(DoubleVertex inputVertex, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<VertexId> onOp) {
             super(inputVertex);
             this.opCount = opCount;
             this.dualNumberCount = dualNumberCount;
@@ -54,7 +54,7 @@ public class TestGraphGenerator {
         }
     }
 
-    static DoubleVertex passThroughVertex(DoubleVertex from, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<Long> onOp) {
+    static DoubleVertex passThroughVertex(DoubleVertex from, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<VertexId> onOp) {
         return new PassThroughVertex(from, opCount, dualNumberCount, onOp);
     }
 
@@ -62,11 +62,11 @@ public class TestGraphGenerator {
 
         private final AtomicInteger opCount;
         private final AtomicInteger dualNumberCount;
-        private final Consumer<Long> onOp;
+        private final Consumer<VertexId> onOp;
 
         public SumVertex(DoubleVertex left, DoubleVertex right,
                          AtomicInteger opCount, AtomicInteger dualNumberCount,
-                         Consumer<Long> onOp) {
+                         Consumer<VertexId> onOp) {
             super(left, right);
             this.opCount = opCount;
             this.dualNumberCount = dualNumberCount;
@@ -87,7 +87,7 @@ public class TestGraphGenerator {
         }
     }
 
-    static DoubleVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<Long> onOp) {
+    static DoubleVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<VertexId> onOp) {
         return new SumVertex(left, right, opCount, dualNumberCount, onOp);
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
@@ -1,21 +1,23 @@
 package io.improbable.keanu.vertices.bool.probabilistic;
 
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.testGradientAcrossMultipleHyperParameterValues;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.util.Map;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.testGradientAcrossMultipleHyperParameterValues;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 public class BernoulliVertexTest {
 
@@ -49,7 +51,7 @@ public class BernoulliVertexTest {
         DoubleVertex C = A.times(B);
         BernoulliVertex D = new BernoulliVertex(C);
 
-        Map<Long, DoubleTensor> dLogPmf = D.dLogPmf(BooleanTensor.create(new boolean[]{true, false}));
+        Map<VertexId, DoubleTensor> dLogPmf = D.dLogPmf(BooleanTensor.create(new boolean[]{true, false}));
 
         DoubleTensor expectedWrtA = DoubleTensor.create(new double[]{(1.0 / 0.125) * 0.5, (-1.0 / 0.88) * 0.2});
         DoubleTensor expectedWrtB = DoubleTensor.create(new double[]{(1.0 / 0.125) * 0.25, (-1.0 / 0.88) * 0.6});
@@ -127,7 +129,7 @@ public class BernoulliVertexTest {
             true, true
         }, shape);
 
-        Map<Long, DoubleTensor> dLogPmf = D.dLogPmf(atValue);
+        Map<VertexId, DoubleTensor> dLogPmf = D.dLogPmf(atValue);
 
         DoubleTensor expectedWrtA = atValue.setDoubleIf(
             AValue.reciprocal(),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumbersTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumbersTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 
@@ -70,7 +71,7 @@ public class DualNumbersTest {
         DualNumber cDual = vC.getDualNumber();
 
         DoubleTensor C = cDual.getValue();
-        Map<Long, DoubleTensor> dc = cDual.getPartialDerivatives().asMap();
+        Map<VertexId, DoubleTensor> dc = cDual.getPartialDerivatives().asMap();
 
         double da = 0.00000001;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -17,6 +17,7 @@ import io.improbable.keanu.distributions.gradient.Beta;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -61,7 +62,7 @@ public class BetaVertexTest {
         betaTensor.setValue(3.0);
 
         BetaVertex tensorBetaVertex = new BetaVertex(alphaTensor, betaTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorBetaVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorBetaVertex.dLogPdf(0.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertexTest.java
@@ -16,6 +16,7 @@ import io.improbable.keanu.distributions.gradient.Cauchy;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -61,7 +62,7 @@ public class CauchyVertexTest {
         scaleTensor.setValue(1.0);
 
         CauchyVertex tensorCauchyVertex = new CauchyVertex(locationTensor, scaleTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorCauchyVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorCauchyVertex.dLogPdf(0.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
@@ -18,6 +18,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import umontreal.ssj.probdistmulti.DirichletDist;
 
@@ -168,7 +169,7 @@ public class DirichletVertexTest {
 
             double diffLnDensityApproxExpected = (lnDensityA2 - lnDensityA1) / (2 * gradientDelta);
 
-            Map<Long, DoubleTensor> diffln = dirichlet.dLogProbAtValue();
+            Map<VertexId, DoubleTensor> diffln = dirichlet.dLogProbAtValue();
 
             double actualDiff = diffln.get(concentrationHyperParam.getId()).getValue(0, 0) + diffln.get(concentrationHyperParam.getId()).getValue(0, 1);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -17,6 +17,7 @@ import io.improbable.keanu.distributions.continuous.Exponential;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -67,7 +68,7 @@ public class ExponentialVertexTest {
         bTensor.setValue(2.5);
 
         ExponentialVertex tensorExponentialVertex = new ExponentialVertex(bTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorExponentialVertex.dLogPdf(1.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorExponentialVertex.dLogPdf(1.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -17,6 +17,7 @@ import io.improbable.keanu.distributions.gradient.Gamma;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -62,7 +63,7 @@ public class GammaVertexTest {
         kTensor.setValue(Nd4jDoubleTensor.scalar(5.5));
 
         GammaVertex tensorGamma = new GammaVertex(thetaTensor, kTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorGamma.dLogPdf(Nd4jDoubleTensor.scalar(1.5));
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorGamma.dLogPdf(Nd4jDoubleTensor.scalar(1.5));
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -17,6 +17,7 @@ import io.improbable.keanu.distributions.gradient.Gaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -62,7 +63,7 @@ public class GaussianVertexTest {
         sigmaTensor.setValue(1.0);
 
         GaussianVertex tensorGaussianVertex = new GaussianVertex(muTensor, sigmaTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -1,23 +1,25 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import io.improbable.keanu.distributions.gradient.Cauchy;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
-import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
-import org.apache.commons.math3.distribution.CauchyDistribution;
-import org.junit.Before;
-import org.junit.Test;
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-import static org.junit.Assert.assertEquals;
+import org.apache.commons.math3.distribution.CauchyDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.improbable.keanu.distributions.gradient.Cauchy;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class HalfCauchyVertexTest {
 
@@ -71,7 +73,7 @@ public class HalfCauchyVertexTest {
         scaleTensor.setValue(1.0);
 
         HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(scaleTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorHalfCauchyVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorHalfCauchyVertex.dLogPdf(0.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
@@ -1,23 +1,25 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import io.improbable.keanu.distributions.gradient.Gaussian;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
-import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
-import org.apache.commons.math3.distribution.NormalDistribution;
-import org.junit.Before;
-import org.junit.Test;
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-import static org.junit.Assert.assertEquals;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.improbable.keanu.distributions.gradient.Gaussian;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class HalfGaussianVertexTest {
 
@@ -71,7 +73,7 @@ public class HalfGaussianVertexTest {
         sigmaTensor.setValue(1.0);
 
         HalfGaussianVertex tensorGaussianVertex = new HalfGaussianVertex(sigmaTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
@@ -16,6 +16,7 @@ import io.improbable.keanu.distributions.gradient.InverseGamma;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -59,7 +60,7 @@ public class InverseGammaVertexTest {
         bTensor.setValue(1.0);
 
         InverseGammaVertex tensorInverseGammaVertex = new InverseGammaVertex(aTensor, bTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorInverseGammaVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorInverseGammaVertex.dLogPdf(0.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
@@ -17,6 +17,7 @@ import io.improbable.keanu.distributions.gradient.Laplace;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -62,7 +63,7 @@ public class LaplaceVertexTest {
         betaTensor.setValue(1.0);
 
         LaplaceVertex tensorLaplaceVertex = new LaplaceVertex(muTensor, betaTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorLaplaceVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorLaplaceVertex.dLogPdf(0.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertexTest.java
@@ -17,6 +17,7 @@ import io.improbable.keanu.distributions.gradient.LogNormal;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -61,7 +62,7 @@ public class LogNormalVertexTest {
         sigmaTensor.setValue(1.0);
 
         LogNormalVertex tensorLogNormalVertex = new LogNormalVertex(muTensor, sigmaTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorLogNormalVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorLogNormalVertex.dLogPdf(0.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -1,22 +1,24 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import io.improbable.keanu.distributions.gradient.Logistic;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
-import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
-import org.apache.commons.math3.distribution.LogisticDistribution;
-import org.junit.Before;
-import org.junit.Test;
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-import static org.junit.Assert.assertEquals;
+import org.apache.commons.math3.distribution.LogisticDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.improbable.keanu.distributions.gradient.Logistic;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class LogisticVertexTest {
 
@@ -58,7 +60,7 @@ public class LogisticVertexTest {
         bTensor.setValue(0.5);
 
         LogisticVertex tensorLogisticVertex = new LogisticVertex(aTensor, bTensor);
-        Map<Long, DoubleTensor> actualDerivatives = tensorLogisticVertex.dLogPdf(1.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorLogisticVertex.dLogPdf(1.5);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
@@ -16,6 +16,7 @@ import io.improbable.keanu.distributions.gradient.Pareto;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -59,7 +60,7 @@ public class ParetoVertexTest {
         scaleTensor.setValue(1.5);
 
         ParetoVertex vertex = new ParetoVertex(locationTensor, scaleTensor);
-        Map<Long, DoubleTensor> actualDerivatives = vertex.dLogPdf(2.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = vertex.dLogPdf(2.5);
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 
         assertEquals(paretoLogDiff.dPdLoc, actual.withRespectTo(locationTensor.getId()).scalar(), 1e-5);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -1,14 +1,12 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import com.google.common.collect.ImmutableList;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
-import io.improbable.keanu.vertices.Probabilistic;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
-import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
-import org.apache.commons.math3.util.Pair;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,13 +16,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.groupingBy;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.apache.commons.math3.util.Pair;
+
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class ProbabilisticDoubleTensorContract {
 
@@ -197,7 +200,7 @@ public class ProbabilisticDoubleTensorContract {
 
         hyperParameterVertex.setAndCascade(hyperParameterValue);
 
-        Map<Long, DoubleTensor> diffln = vertexUnderTest.dLogProbAtValue();
+        Map<VertexId, DoubleTensor> diffln = vertexUnderTest.dLogProbAtValue();
 
         double actualDiffLnDensity = diffln.get(hyperParameterVertex.getId()).scalar();
 
@@ -250,14 +253,14 @@ public class ProbabilisticDoubleTensorContract {
 
         V tensorVertex = vertexUnderTestSupplier.get();
 
-        Map<Long, DoubleTensor> actualDerivatives = tensorVertex.dLogProb(
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorVertex.dLogProb(
             DoubleTensor.create(vector, new int[]{vector.length, 1})
         );
 
-        HashSet<Long> hyperParameterVertices = new HashSet<>(actualDerivatives.keySet());
+        HashSet<VertexId> hyperParameterVertices = new HashSet<>(actualDerivatives.keySet());
         hyperParameterVertices.remove(tensorVertex.getId());
 
-        for (Long id : hyperParameterVertices) {
+        for (VertexId id : hyperParameterVertices) {
             assertEquals(expectedPartialDerivatives.withRespectTo(id).sum(), actualDerivatives.get(id).sum(), 1e-5);
         }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertexTest.java
@@ -1,13 +1,15 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class SmoothUniformVertexTest {
 
@@ -49,24 +51,24 @@ public class SmoothUniformVertexTest {
         SmoothUniformVertex smoothUniformVertex = new SmoothUniformVertex(0, 1, 10);
         SmoothUniformVertex tensorSmoothUniformVertex = new SmoothUniformVertex(0, 1, 10);
 
-        Map<Long, DoubleTensor> derivativeFlatRegion = smoothUniformVertex.dLogPdf(0.5);
-        Map<Long, DoubleTensor> tensorDerivativeFlatRegion = tensorSmoothUniformVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> derivativeFlatRegion = smoothUniformVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> tensorDerivativeFlatRegion = tensorSmoothUniformVertex.dLogPdf(0.5);
 
         assertEquals(derivativeFlatRegion.get(smoothUniformVertex.getId()).scalar(),
             tensorDerivativeFlatRegion.get(tensorSmoothUniformVertex.getId()).scalar(),
             DELTA
         );
 
-        Map<Long, DoubleTensor> derivativeLeftRegion = smoothUniformVertex.dLogPdf(-0.5);
-        Map<Long, DoubleTensor> tensorDerivativeLeftRegion = tensorSmoothUniformVertex.dLogPdf(-0.5);
+        Map<VertexId, DoubleTensor> derivativeLeftRegion = smoothUniformVertex.dLogPdf(-0.5);
+        Map<VertexId, DoubleTensor> tensorDerivativeLeftRegion = tensorSmoothUniformVertex.dLogPdf(-0.5);
 
         assertEquals(derivativeLeftRegion.get(smoothUniformVertex.getId()).scalar(),
             tensorDerivativeLeftRegion.get(tensorSmoothUniformVertex.getId()).scalar(),
             DELTA
         );
 
-        Map<Long, DoubleTensor> derivativeRightRegion = smoothUniformVertex.dLogPdf(1.5);
-        Map<Long, DoubleTensor> tensorDerivativeRightRegion = tensorSmoothUniformVertex.dLogPdf(1.5);
+        Map<VertexId, DoubleTensor> derivativeRightRegion = smoothUniformVertex.dLogPdf(1.5);
+        Map<VertexId, DoubleTensor> tensorDerivativeRightRegion = tensorSmoothUniformVertex.dLogPdf(1.5);
 
         assertEquals(derivativeRightRegion.get(smoothUniformVertex.getId()).scalar(),
             tensorDerivativeRightRegion.get(tensorSmoothUniformVertex.getId()).scalar(),


### PR DESCRIPTION
A long, but relatively simple PR that moves away from using a long value to represent a vertexID and instead uses a new VertexId object.  All files + tests should be migrated and all tests pass.

I've done this to make the graphception stuff a bit more elegant (more on that soon) and thought that given the amount of changes, best to get that reviewed separately.