### PR TITLE
Progress bar

### DIFF
--- a/keanu-docs/code/src/main/java/io/improbable/docs/WetGrass.java
+++ b/keanu-docs/code/src/main/java/io/improbable/docs/WetGrass.java
@@ -1,10 +1,11 @@
 package io.improbable.docs;
 
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import io.improbable.keanu.algorithms.mcmc.MetropolisHastings;
-import io.improbable.keanu.algorithms.mcmc.NetworkSamplesGenerator;
 import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.ConditionalProbabilityTable;
@@ -43,17 +44,18 @@ public class WetGrass {
         //What does that observation say about the probability that it rained or that
         //the sprinkler was on?
         long keepSampleCount = 100000;
-        NetworkSamplesGenerator networkSamplesGenerator = MetropolisHastings.withDefaultConfig().generatePosteriorSamples(
+        Stream<NetworkState> networkSamplesStream = MetropolisHastings.withDefaultConfig().generatePosteriorSamples(
             new BayesianNetwork(wetGrass.getConnectedGraph()),
             Arrays.asList(sprinkler, rain)
-        ).dropCount(10000).downSampleInterval(2);
+        ).dropCount(10000).downSampleInterval(2).stream();
 
-        double probabilityOfRainGivenWetGrass = networkSamplesGenerator.stream()
+        double probabilityOfRainGivenWetGrass = networkSamplesStream
             .limit(keepSampleCount)
             .filter(isRaining -> isRaining.get(rain).scalar())
             .count() / (double) keepSampleCount;
 
-        System.out.println();
+        networkSamplesStream.close();
+
         System.out.println("Probability Of Rain Given Wet Grass: " + probabilityOfRainGivenWetGrass);
     }
 }

--- a/keanu-docs/code/src/main/java/io/improbable/docs/WetGrass.java
+++ b/keanu-docs/code/src/main/java/io/improbable/docs/WetGrass.java
@@ -43,7 +43,7 @@ public class WetGrass {
 
         //What does that observation say about the probability that it rained or that
         //the sprinkler was on?
-        long keepSampleCount = 100000;
+        final long keepSampleCount = 100000;
         Stream<NetworkState> networkSamplesStream = MetropolisHastings.withDefaultConfig().generatePosteriorSamples(
             new BayesianNetwork(wetGrass.getConnectedGraph()),
             Arrays.asList(sprinkler, rain)
@@ -51,7 +51,7 @@ public class WetGrass {
 
         double probabilityOfRainGivenWetGrass = networkSamplesStream
             .limit(keepSampleCount)
-            .filter(isRaining -> isRaining.get(rain).scalar())
+            .filter(sample -> sample.get(rain).scalar())
             .count() / (double) keepSampleCount;
 
         networkSamplesStream.close();

--- a/keanu-docs/code/src/main/java/io/improbable/docs/WetGrass.java
+++ b/keanu-docs/code/src/main/java/io/improbable/docs/WetGrass.java
@@ -1,14 +1,14 @@
 package io.improbable.docs;
 
-import io.improbable.keanu.algorithms.NetworkSamples;
+import java.util.Arrays;
+
 import io.improbable.keanu.algorithms.mcmc.MetropolisHastings;
+import io.improbable.keanu.algorithms.mcmc.NetworkSamplesGenerator;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.ConditionalProbabilityTable;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
-
-import java.util.Arrays;
 
 public class WetGrass {
 
@@ -42,14 +42,18 @@ public class WetGrass {
 
         //What does that observation say about the probability that it rained or that
         //the sprinkler was on?
-        NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
+        long keepSampleCount = 100000;
+        NetworkSamplesGenerator networkSamplesGenerator = MetropolisHastings.withDefaultConfig().generatePosteriorSamples(
             new BayesianNetwork(wetGrass.getConnectedGraph()),
-            Arrays.asList(sprinkler, rain),
-            100000
-        ).drop(10000).downSample(2);
+            Arrays.asList(sprinkler, rain)
+        ).dropCount(10000).downSampleInterval(2);
 
-        double probabilityOfRainGivenWetGrass = posteriorSamples.get(rain).probability(isRaining -> isRaining.scalar() == true);
+        double probabilityOfRainGivenWetGrass = networkSamplesGenerator.stream()
+            .limit(keepSampleCount)
+            .filter(isRaining -> isRaining.get(rain).scalar())
+            .count() / (double) keepSampleCount;
 
-        System.out.println(probabilityOfRainGivenWetGrass);
+        System.out.println();
+        System.out.println("Probability Of Rain Given Wet Grass: " + probabilityOfRainGivenWetGrass);
     }
 }

--- a/keanu-examples/coalMiningDisasters/src/main/java/com/example/coal/Model.java
+++ b/keanu-examples/coalMiningDisasters/src/main/java/com/example/coal/Model.java
@@ -1,6 +1,5 @@
 package com.example.coal;
 
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.mcmc.MetropolisHastings;
 import io.improbable.keanu.network.BayesianNetwork;
@@ -54,13 +53,10 @@ public class Model {
         BayesianNetwork net = buildBayesianNetwork();
         Integer numSamples = 50000;
 
-        NetworkSamples posteriorDistSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
+        results = MetropolisHastings.withDefaultConfig().generatePosteriorSamples(
             net,
-            net.getLatentVertices(),
-            numSamples
-        );
-
-        results = posteriorDistSamples.drop(10000).downSample(3);
+            net.getLatentVertices()
+        ).dropCount(10000).downSampleInterval(3).generate(numSamples);
     }
 
     private BayesianNetwork buildBayesianNetwork() {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -15,6 +15,7 @@ import io.improbable.keanu.algorithms.mcmc.proposal.ProposalDistribution;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.network.SimpleNetworkState;
+import io.improbable.keanu.util.ProgressBar;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -79,7 +80,7 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesianNetwork,
                                                             final List<? extends Vertex> verticesToSampleFrom) {
 
-        return new NetworkSamplesGenerator(setupSampler(bayesianNetwork, verticesToSampleFrom));
+        return new NetworkSamplesGenerator(setupSampler(bayesianNetwork, verticesToSampleFrom), new ProgressBar());
     }
 
     private SamplingAlgorithm setupSampler(final BayesianNetwork bayesianNetwork,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -80,7 +80,7 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesianNetwork,
                                                             final List<? extends Vertex> verticesToSampleFrom) {
 
-        return new NetworkSamplesGenerator(setupSampler(bayesianNetwork, verticesToSampleFrom), new ProgressBar());
+        return new NetworkSamplesGenerator(setupSampler(bayesianNetwork, verticesToSampleFrom), ProgressBar::new);
     }
 
     private SamplingAlgorithm setupSampler(final BayesianNetwork bayesianNetwork,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGenerator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGenerator.java
@@ -27,10 +27,11 @@ public class NetworkSamplesGenerator {
     @Setter
     private int downSampleInterval = 1;
 
-    private ProgressBar progressBar = new ProgressBar();
+    private ProgressBar progressBar;
 
-    public NetworkSamplesGenerator(SamplingAlgorithm algorithm) {
+    public NetworkSamplesGenerator(SamplingAlgorithm algorithm, ProgressBar progressBar) {
         this.algorithm = algorithm;
+        this.progressBar = progressBar;
     }
 
     public NetworkSamples generate(final int totalSampleCount) {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGenerator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGenerator.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.network.NetworkState;
+import io.improbable.keanu.util.ProgressBar;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -24,6 +25,7 @@ public class NetworkSamplesGenerator {
     @Setter
     private int downSampleInterval = 1;
 
+    private ProgressBar progressBar = new ProgressBar();
 
     public NetworkSamplesGenerator(SamplingAlgorithm algorithm) {
         this.algorithm = algorithm;
@@ -44,8 +46,11 @@ public class NetworkSamplesGenerator {
             } else {
                 algorithm.step();
             }
+
+            progressBar.progress();
         }
 
+        progressBar.finished();
         return new NetworkSamples(samplesByVertex, sampleCount);
     }
 
@@ -57,15 +62,19 @@ public class NetworkSamplesGenerator {
 
             for (int i = 0; i < downSampleInterval - 1; i++) {
                 algorithm.step();
+                progressBar.progress();
             }
 
+            progressBar.progress();
             return algorithm.sample();
-        });
+
+        }).onClose(() -> progressBar.finished());
     }
 
     private void dropSamples(int dropCount) {
         for (int i = 0; i < dropCount; i++) {
             algorithm.step();
+            progressBar.progress();
         }
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
@@ -1,11 +1,12 @@
 package io.improbable.keanu.algorithms.variational.optimizer.nongradient;
 
-import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
-import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
-import lombok.Builder;
-import lombok.Getter;
+import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+
 import org.apache.commons.math3.optim.InitialGuess;
 import org.apache.commons.math3.optim.MaxEval;
 import org.apache.commons.math3.optim.PointValuePair;
@@ -13,12 +14,13 @@ import org.apache.commons.math3.optim.SimpleBounds;
 import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunction;
 import org.apache.commons.math3.optim.nonlinear.scalar.noderiv.BOBYQAOptimizer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.BiConsumer;
-
-import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
+import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
+import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.util.ProgressBar;
+import io.improbable.keanu.vertices.Vertex;
+import lombok.Builder;
+import lombok.Getter;
 
 @Builder
 public class NonGradientOptimizer implements Optimizer {
@@ -74,8 +76,13 @@ public class NonGradientOptimizer implements Optimizer {
     private final List<BiConsumer<double[], Double>> onFitnessCalculations = new ArrayList<>();
 
     @Override
-    public void onFitnessCalculation(BiConsumer<double[], Double> fitnessCalculationHandler) {
+    public void addFitnessCalculationHandler(BiConsumer<double[], Double> fitnessCalculationHandler) {
         this.onFitnessCalculations.add(fitnessCalculationHandler);
+    }
+
+    @Override
+    public void removeFitnessCalculationHandler(BiConsumer<double[], Double> fitnessCalculationHandler) {
+        this.onFitnessCalculations.remove(fitnessCalculationHandler);
     }
 
     private void handleFitnessCalculation(double[] point, Double fitness) {
@@ -85,6 +92,8 @@ public class NonGradientOptimizer implements Optimizer {
     }
 
     private double optimize(List<Vertex> outputVertices) {
+
+        ProgressBar progressBar = Optimizer.createFitnessProgressBar(this);
         bayesianNetwork.cascadeObservations();
 
         if (bayesianNetwork.isInImpossibleState()) {
@@ -123,6 +132,7 @@ public class NonGradientOptimizer implements Optimizer {
             new InitialGuess(Optimizer.currentPoint(latentVertices))
         );
 
+        progressBar.finish();
         return pointValuePair.getValue();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
@@ -30,7 +30,14 @@ public class ProgressBar {
         ENABLED.set(true);
     }
 
-    private static final PrintStream NULL_PRINT_STREAM = new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM);
+    private static ScheduledExecutorService getDefaultScheduledExecutorService() {
+        return Executors.newScheduledThreadPool(1, r -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
     private static final AtomicBoolean ENABLED = new AtomicBoolean(true);
     private static final long FRAME_PERIOD_MS = 500;
     private static final ProgressUpdate DEFAULT_UPDATE = new ProgressUpdate();
@@ -62,14 +69,6 @@ public class ProgressBar {
 
     public ProgressBar() {
         this(DEFAULT_PRINT_STREAM, getDefaultScheduledExecutorService());
-    }
-
-    private static ScheduledExecutorService getDefaultScheduledExecutorService() {
-        return Executors.newScheduledThreadPool(1, r -> {
-            Thread t = Executors.defaultThreadFactory().newThread(r);
-            t.setDaemon(true);
-            return t;
-        });
     }
 
     public void progress() {

--- a/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
@@ -10,11 +10,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.commons.io.output.NullOutputStream;
-
 public class ProgressBar {
 
-    public static PrintStream DEFAULT_PRINT_STREAM = System.out;
+    public static PrintStream defaultPrintStream = System.out;
 
     /**
      * Disables all progress bars globally
@@ -68,7 +66,7 @@ public class ProgressBar {
     }
 
     public ProgressBar() {
-        this(DEFAULT_PRINT_STREAM, getDefaultScheduledExecutorService());
+        this(defaultPrintStream, getDefaultScheduledExecutorService());
     }
 
     public void progress() {
@@ -76,19 +74,29 @@ public class ProgressBar {
     }
 
     public void progress(String message, Double progressPercentage) {
-        progress(new ProgressUpdate(message, progressPercentage));
+        if (shouldUpdate()) {
+            progress(new ProgressUpdate(message, progressPercentage));
+        }
     }
 
     public void progress(String message) {
-        progress(new ProgressUpdate(message));
+        if (shouldUpdate()) {
+            progress(new ProgressUpdate(message));
+        }
     }
 
     public void progress(Double progressPercentage) {
-        progress(new ProgressUpdate(progressPercentage));
+        if (shouldUpdate()) {
+            progress(new ProgressUpdate(progressPercentage));
+        }
     }
 
     public void progress(ProgressUpdate progressUpdate) {
         latestProgressUpdate.set(progressUpdate);
+    }
+
+    private boolean shouldUpdate() {
+        return ENABLED.get();
     }
 
     public ProgressUpdate getProgress() {

--- a/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
@@ -1,37 +1,54 @@
 package io.improbable.keanu.util;
 
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.io.output.NullOutputStream;
 
 public class ProgressBar {
 
+    public static PrintStream DEFAULT_PRINT_STREAM = System.out;
+
+    /**
+     * Disables all progress bars globally
+     */
+    public static void disable() {
+        ENABLED.set(false);
+    }
+
+    /**
+     * Enables all progress bars globally
+     */
+    public static void enable() {
+        ENABLED.set(true);
+    }
+
+    private static final PrintStream NULL_PRINT_STREAM = new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM);
+    private static final AtomicBoolean ENABLED = new AtomicBoolean(true);
+    private static final long FRAME_PERIOD_MS = 500;
+    private static final ProgressUpdate DEFAULT_UPDATE = new ProgressUpdate();
     private static final String MIDDLE_MESSAGE = "Keanu";
     private static final String[] FRAMES = new String[]{
-        "| " + MIDDLE_MESSAGE + " |",
-        "\\ " + MIDDLE_MESSAGE + " /",
-        "- " + MIDDLE_MESSAGE + " -",
-        "/ " + MIDDLE_MESSAGE + " \\"
+        "|" + MIDDLE_MESSAGE + "|",
+        "\\" + MIDDLE_MESSAGE + "/",
+        "-" + MIDDLE_MESSAGE + "-",
+        "/" + MIDDLE_MESSAGE + "\\"
     };
 
-    private static final long FRAME_PERIOD_MS = 500;
-
     private final ScheduledExecutorService scheduler;
-    private final AtomicBoolean hasProgressed = new AtomicBoolean(true);
     private final PrintStream printStream;
 
-    public ProgressBar() {
-        this.printStream = System.out;
-        this.scheduler = Executors.newScheduledThreadPool(1, r -> {
-            Thread t = Executors.defaultThreadFactory().newThread(r);
-            t.setDaemon(true);
-            return t;
-        });
-        startUpdateThread();
-    }
+    private final AtomicReference<ProgressUpdate> latestProgressUpdate = new AtomicReference<>();
+    private final AtomicInteger nextFrameIndex = new AtomicInteger(0);
+
+    private final List<Runnable> onFinish = new ArrayList<>();
 
     public ProgressBar(PrintStream printStream, ScheduledExecutorService scheduler) {
         this.printStream = printStream;
@@ -39,25 +56,92 @@ public class ProgressBar {
         startUpdateThread();
     }
 
-    public void progress() {
-        hasProgressed.getAndSet(true);
+    public ProgressBar(PrintStream printStream) {
+        this(printStream, getDefaultScheduledExecutorService());
     }
 
-    public void finished() {
-        hasProgressed.set(false);
+    public ProgressBar() {
+        this(DEFAULT_PRINT_STREAM, getDefaultScheduledExecutorService());
+    }
+
+    private static ScheduledExecutorService getDefaultScheduledExecutorService() {
+        return Executors.newScheduledThreadPool(1, r -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    public void progress() {
+        progress(DEFAULT_UPDATE);
+    }
+
+    public void progress(String message, Double progressPercentage) {
+        progress(new ProgressUpdate(message, progressPercentage));
+    }
+
+    public void progress(String message) {
+        progress(new ProgressUpdate(message));
+    }
+
+    public void progress(Double progressPercentage) {
+        progress(new ProgressUpdate(progressPercentage));
+    }
+
+    public void progress(ProgressUpdate progressUpdate) {
+        latestProgressUpdate.set(progressUpdate);
+    }
+
+    public ProgressUpdate getProgress() {
+        return latestProgressUpdate.get();
+    }
+
+    public void finish() {
         scheduler.shutdown();
-        printStream.print("\n");
+        printUpdate();
+        printFinish();
+        onFinish.forEach(Runnable::run);
+    }
+
+    public void addFinishHandler(Runnable finishHandler) {
+        this.onFinish.add(finishHandler);
     }
 
     private void startUpdateThread() {
+        scheduler.scheduleAtFixedRate(this::printUpdate, 0, FRAME_PERIOD_MS, TimeUnit.MILLISECONDS);
+    }
 
-        final AtomicInteger nextFrameIndex = new AtomicInteger(0);
+    private void printUpdate() {
 
-        scheduler.scheduleAtFixedRate(() -> {
-            if (hasProgressed.getAndSet(false)) {
-                printStream.print("\r" + FRAMES[nextFrameIndex.getAndIncrement() % FRAMES.length]);
+        if (!ENABLED.get()) {
+            return;
+        }
+
+        ProgressUpdate update = latestProgressUpdate.get();
+
+        if (update != null) {
+
+            StringBuilder sb = new StringBuilder();
+
+            sb.append("\r").append(FRAMES[nextFrameIndex.getAndIncrement() % FRAMES.length]);
+
+            if (update.getMessage() != null) {
+                sb.append(" ");
+                sb.append(update.getMessage());
+                sb.append(" ");
             }
-        }, 0, FRAME_PERIOD_MS, TimeUnit.MILLISECONDS);
 
+            if (update.getProgressPercentage() != null) {
+                sb.append(String.format(" %3.0f%%", update.getProgressPercentage() * 100));
+            }
+
+            printStream.print(sb.toString());
+        }
+    }
+
+    private void printFinish() {
+        if (ENABLED.get()) {
+            printStream.print("\n");
+        }
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
@@ -1,0 +1,63 @@
+package io.improbable.keanu.util;
+
+import java.io.PrintStream;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ProgressBar {
+
+    private static final String MIDDLE_MESSAGE = "Keanu";
+    private static final String[] FRAMES = new String[]{
+        "| " + MIDDLE_MESSAGE + " |",
+        "\\ " + MIDDLE_MESSAGE + " /",
+        "- " + MIDDLE_MESSAGE + " -",
+        "/ " + MIDDLE_MESSAGE + " \\"
+    };
+
+    private static final long FRAME_PERIOD_MS = 500;
+
+    private final ScheduledExecutorService scheduler;
+    private final AtomicBoolean hasProgressed = new AtomicBoolean(true);
+    private final PrintStream printStream;
+
+    public ProgressBar() {
+        this.printStream = System.out;
+        this.scheduler = Executors.newScheduledThreadPool(1, r -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setDaemon(true);
+            return t;
+        });
+        startUpdateThread();
+    }
+
+    public ProgressBar(PrintStream printStream, ScheduledExecutorService scheduler) {
+        this.printStream = printStream;
+        this.scheduler = scheduler;
+        startUpdateThread();
+    }
+
+    public void progress() {
+        hasProgressed.getAndSet(true);
+    }
+
+    public void finished() {
+        hasProgressed.set(false);
+        scheduler.shutdown();
+        printStream.print("\n");
+    }
+
+    private void startUpdateThread() {
+
+        final AtomicInteger nextFrameIndex = new AtomicInteger(0);
+
+        scheduler.scheduleAtFixedRate(() -> {
+            if (hasProgressed.getAndSet(false)) {
+                printStream.print("\r" + FRAMES[nextFrameIndex.getAndIncrement() % FRAMES.length]);
+            }
+        }, 0, FRAME_PERIOD_MS, TimeUnit.MILLISECONDS);
+
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
@@ -139,7 +139,7 @@ public class ProgressBar {
             }
 
             if (update.getProgressPercentage() != null) {
-                sb.append(String.format(" %3.0f%%", update.getProgressPercentage() * 100));
+                sb.append(String.format(" %3.1f%%", Math.min(100.0, Math.max(0, update.getProgressPercentage() * 100))));
             }
 
             printStream.print(sb.toString());

--- a/keanu-project/src/main/java/io/improbable/keanu/util/ProgressUpdate.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/ProgressUpdate.java
@@ -1,0 +1,26 @@
+package io.improbable.keanu.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor
+public class ProgressUpdate {
+    private final String message;
+    private final Double progressPercentage;
+
+    public ProgressUpdate() {
+        this.message = null;
+        this.progressPercentage = null;
+    }
+
+    public ProgressUpdate(String message) {
+        this.message = message;
+        this.progressPercentage = null;
+    }
+
+    public ProgressUpdate(Double progressPercentage) {
+        this.message = null;
+        this.progressPercentage = progressPercentage;
+    }
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsTest.java
@@ -50,7 +50,7 @@ public class MetropolisHastingsTest {
         NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
             bayesNet,
             Arrays.asList(A, B),
-            10000000
+            100000
         );
 
         double averagePosteriorA = posteriorSamples.getDoubleTensorSamples(A).getAverages().scalar();

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsTest.java
@@ -50,7 +50,7 @@ public class MetropolisHastingsTest {
         NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
             bayesNet,
             Arrays.asList(A, B),
-            100000
+            10000000
         );
 
         double averagePosteriorA = posteriorSamples.getDoubleTensorSamples(A).getAverages().scalar();

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/OptimizerTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/OptimizerTest.java
@@ -1,16 +1,20 @@
 package io.improbable.keanu.algorithms.variational.optimizer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.junit.Test;
+
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.function.Function;
-
-import static org.junit.Assert.assertEquals;
 
 public class OptimizerTest {
 
@@ -91,5 +95,36 @@ public class OptimizerTest {
 
         assertEquals(22, maxA, 0.1);
         assertEquals(22, maxB, 0.1);
+    }
+
+    @Test
+    public void gradientOptimizerCanRemoveFitnessCalculationHandler() {
+        GaussianVertex gaussianVertex = new GaussianVertex(0, 1);
+        GradientOptimizer optimizer = GradientOptimizer.of(gaussianVertex.getConnectedGraph());
+        canRemoveFitnessCalculationHandler(optimizer);
+    }
+
+    @Test
+    public void nonGradientOptimizerCanRemoveFitnessCalculationHandler() {
+        GaussianVertex A = new GaussianVertex(0, 1);
+        GaussianVertex B = new GaussianVertex(0, 1);
+        A.plus(B);
+        NonGradientOptimizer optimizer = NonGradientOptimizer.of(A.getConnectedGraph());
+        canRemoveFitnessCalculationHandler(optimizer);
+    }
+
+    private void canRemoveFitnessCalculationHandler(Optimizer optimizer) {
+
+        AtomicBoolean didCallFitness = new AtomicBoolean(false);
+        BiConsumer<double[], Double> fitnessHandler = (position, logProb) -> {
+            didCallFitness.set(true);
+        };
+
+        optimizer.addFitnessCalculationHandler(fitnessHandler);
+        optimizer.removeFitnessCalculationHandler(fitnessHandler);
+
+        optimizer.maxAPosteriori();
+
+        assertFalse(didCallFitness.get());
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/OptimizerTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/OptimizerTest.java
@@ -2,6 +2,8 @@ package io.improbable.keanu.algorithms.variational.optimizer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -116,9 +118,8 @@ public class OptimizerTest {
     private void canRemoveFitnessCalculationHandler(Optimizer optimizer) {
 
         AtomicBoolean didCallFitness = new AtomicBoolean(false);
-        BiConsumer<double[], Double> fitnessHandler = (position, logProb) -> {
-            didCallFitness.set(true);
-        };
+
+        BiConsumer<double[], Double> fitnessHandler = mock(BiConsumer.class);
 
         optimizer.addFitnessCalculationHandler(fitnessHandler);
         optimizer.removeFitnessCalculationHandler(fitnessHandler);
@@ -126,5 +127,6 @@ public class OptimizerTest {
         optimizer.maxAPosteriori();
 
         assertFalse(didCallFitness.get());
+        verifyNoMoreInteractions(fitnessHandler);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizerTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizerTest.java
@@ -36,23 +36,4 @@ public class GradientOptimizerTest {
 
         GradientOptimizer optimizer = GradientOptimizer.ofConnectedGraph(v1);
     }
-
-    @Test
-    public void canRemoveFitnessCalculationHandler() {
-        GaussianVertex gaussianVertex = new GaussianVertex(0, 1);
-
-        GradientOptimizer optimizer = GradientOptimizer.of(gaussianVertex.getConnectedGraph());
-
-        AtomicBoolean didCallFitness = new AtomicBoolean(false);
-        BiConsumer<double[], Double> fitnessHandler = (position, logProb) -> {
-            didCallFitness.set(true);
-        };
-
-        optimizer.addFitnessCalculationHandler(fitnessHandler);
-        optimizer.removeFitnessCalculationHandler(fitnessHandler);
-
-        optimizer.maxAPosteriori();
-
-        assertFalse(didCallFitness.get());
-    }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizerTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizerTest.java
@@ -14,12 +14,11 @@ import static org.junit.Assert.assertTrue;
 
 public class NonGradientOptimizerTest {
 
-
     @Test
     public void doesCallOnFitnessHandler() {
         AtomicInteger timesCalled = new AtomicInteger(0);
         NonGradientOptimizer optimizer = NonGradientOptimizer.ofConnectedGraph(new GaussianVertex(new GaussianVertex(0, 1), 1));
-        optimizer.onFitnessCalculation((point, fitness) -> timesCalled.incrementAndGet());
+        optimizer.addFitnessCalculationHandler((point, fitness) -> timesCalled.incrementAndGet());
         optimizer.maxAPosteriori();
         assertTrue(timesCalled.get() > 0);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/lorenz/LorenzTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/lorenz/LorenzTest.java
@@ -30,7 +30,7 @@ public class LorenzTest {
         double[] priorMu = new double[]{3, 3, 3};
         double error = Double.MAX_VALUE;
         double convergedError = 0.01;
-        int windowSize = 100;
+        int windowSize = 300;
         int window = 0;
         int maxWindows = 5;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/lorenz/LorenzTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/lorenz/LorenzTest.java
@@ -1,5 +1,15 @@
 package io.improbable.keanu.e2e.lorenz;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -7,29 +17,22 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertTrue;
 
 public class LorenzTest {
     private final Logger log = LoggerFactory.getLogger(LorenzTest.class);
 
-    @Test
+    public static void main(String[] args) {
+        new LorenzTest().convergesOnLorenz();
+    }
+
     public void convergesOnLorenz() {
 
         double[] priorMu = new double[]{3, 3, 3};
         double error = Double.MAX_VALUE;
         double convergedError = 0.01;
-        int windowSize = 8;
+        int windowSize = 100;
         int window = 0;
-        int maxWindows = 100;
+        int maxWindows = 5;
 
         LorenzModel model = new LorenzModel();
         List<LorenzModel.Coordinates> observed = model.runModel(windowSize * maxWindows);

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/lorenz/LorenzTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/lorenz/LorenzTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,18 +22,15 @@ import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 public class LorenzTest {
     private final Logger log = LoggerFactory.getLogger(LorenzTest.class);
 
-    public static void main(String[] args) {
-        new LorenzTest().convergesOnLorenz();
-    }
-
+    @Test
     public void convergesOnLorenz() {
 
         double[] priorMu = new double[]{3, 3, 3};
         double error = Double.MAX_VALUE;
         double convergedError = 0.01;
-        int windowSize = 300;
+        int windowSize = 8;
         int window = 0;
-        int maxWindows = 5;
+        int maxWindows = 100;
 
         LorenzModel model = new LorenzModel();
         List<LorenzModel.Coordinates> observed = model.runModel(windowSize * maxWindows);

--- a/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
@@ -74,7 +74,7 @@ public class ProgressBarTest {
 
         String result = getResultWithNewLinesInsteadOfCR();
 
-        assertEquals(5, result.split("\n").length);
+        assertEquals(3, result.split("\n").length);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
@@ -1,0 +1,61 @@
+package io.improbable.keanu.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static junit.framework.TestCase.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+public class ProgressBarTest {
+
+    @Test
+    public void doesPrintToStream() throws UnsupportedEncodingException {
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(baos, true, "UTF-8");
+        ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+
+        final AtomicReference<Runnable> progressUpdateCall = new AtomicReference<>(null);
+
+        when(scheduler.scheduleAtFixedRate(any(), anyLong(), anyLong(), any()))
+            .thenAnswer(invocation -> {
+                progressUpdateCall.set(invocation.getArgument(0));
+                return null;
+            });
+
+        ProgressBar progressBar = new ProgressBar(printStream, scheduler);
+
+        progressBar.progress();
+        progressUpdateCall.get().run();
+        progressUpdateCall.get().run();
+        progressBar.progress();
+        progressUpdateCall.get().run();
+        progressBar.finished();
+
+        byte[] outputBytes = baos.toByteArray();
+        convertCrToNewLine(outputBytes);
+
+        String result = new String(outputBytes, StandardCharsets.UTF_8);
+
+        assertEquals(3, result.split("\n").length);
+    }
+
+    private void convertCrToNewLine(byte[] outputBytes) {
+        for (int i = 0; i < outputBytes.length; i++) {
+            if (outputBytes[i] == '\r') {
+                outputBytes[i] = '\n';
+            }
+        }
+    }
+
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
@@ -74,7 +74,7 @@ public class ProgressBarTest {
 
         String result = getResultWithNewLinesInsteadOfCR();
 
-        assertEquals(3, result.split("\n").length);
+        assertEquals(5, result.split("\n").length);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
@@ -1,31 +1,37 @@
 package io.improbable.keanu.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import static junit.framework.TestCase.assertEquals;
-
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ProgressBarTest {
 
-    @Test
-    public void doesPrintToStream() throws UnsupportedEncodingException {
+    private AtomicReference<Runnable> progressUpdateCall;
+    private ProgressBar progressBar;
+    private ByteArrayOutputStream byteArrayOutputStream;
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream printStream = new PrintStream(baos, true, "UTF-8");
+    @Before
+    public void setup() throws UnsupportedEncodingException {
+
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(byteArrayOutputStream, true, "UTF-8");
         ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
 
-        final AtomicReference<Runnable> progressUpdateCall = new AtomicReference<>(null);
+        progressUpdateCall = new AtomicReference<>(null);
 
         when(scheduler.scheduleAtFixedRate(any(), anyLong(), anyLong(), any()))
             .thenAnswer(invocation -> {
@@ -33,21 +39,12 @@ public class ProgressBarTest {
                 return null;
             });
 
-        ProgressBar progressBar = new ProgressBar(printStream, scheduler);
+        progressBar = new ProgressBar(printStream, scheduler);
+    }
 
-        progressBar.progress();
-        progressUpdateCall.get().run();
-        progressUpdateCall.get().run();
-        progressBar.progress();
-        progressUpdateCall.get().run();
-        progressBar.finished();
-
-        byte[] outputBytes = baos.toByteArray();
-        convertCrToNewLine(outputBytes);
-
-        String result = new String(outputBytes, StandardCharsets.UTF_8);
-
-        assertEquals(3, result.split("\n").length);
+    @After
+    public void cleanup() throws IOException {
+        byteArrayOutputStream.close();
     }
 
     private void convertCrToNewLine(byte[] outputBytes) {
@@ -56,6 +53,43 @@ public class ProgressBarTest {
                 outputBytes[i] = '\n';
             }
         }
+    }
+
+    private String getResultWithNewLinesInsteadOfCR() {
+        byte[] outputBytes = byteArrayOutputStream.toByteArray();
+        convertCrToNewLine(outputBytes);
+        return new String(outputBytes, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void doesPrintToStreamWhenEnabled() {
+        ProgressBar.enable();
+
+        progressBar.progress();
+        progressUpdateCall.get().run();
+        progressUpdateCall.get().run();
+        progressBar.progress();
+        progressUpdateCall.get().run();
+        progressBar.finish();
+
+        String result = getResultWithNewLinesInsteadOfCR();
+
+        assertEquals(5, result.split("\n").length);
+    }
+
+    @Test
+    public void doesNotPrintToStreamWhenGloballyDisabled() {
+        ProgressBar.disable();
+
+        progressBar.progress();
+        progressUpdateCall.get().run();
+        progressUpdateCall.get().run();
+        progressBar.progress();
+        progressBar.finish();
+
+        String result = getResultWithNewLinesInsteadOfCR();
+
+        assertEquals("", result);
     }
 
 }


### PR DESCRIPTION
This PR introduces the first stab at a progress bar when running inference. The progress bar is handled by a daemon thread that writes to std out by default but can be configured and also disabled.

Generating samples (not streaming them)
![generate_samples](https://user-images.githubusercontent.com/1253165/44917637-d6e27180-ad30-11e8-9621-5b855943c8e1.gif)

Streaming samples
![stream_samples](https://user-images.githubusercontent.com/1253165/44917697-0e511e00-ad31-11e8-9c3d-71d92b287408.gif)

Optimizer progress
![optimizer_progress](https://user-images.githubusercontent.com/1253165/44917748-2aed5600-ad31-11e8-86de-a17f83445900.gif)

