### PR TITLE
Add split for double tensors

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -145,7 +145,7 @@ public class TensorShape {
         return dims;
     }
 
-    public static int[] moveAxis(int from, int to, int[] shape) {
+    public static int[] slideDimension(int from, int to, int[] shape) {
         List<Integer> shapeList = new ArrayList<>(Ints.asList(shape));
         Integer dimLength = shapeList.remove(from);
         shapeList.add(to, dimLength);

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -855,7 +855,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
      * A.split(1, [1, 3, 6]) gives
      * List(
      * [1, [2, 3  , [4, 5, 6,
-     * 7]   8, 9]    1, 2, 3]
+     *  7]  8, 9]    1, 2, 3]
      * )
      */
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -861,13 +861,23 @@ public class Nd4jDoubleTensor implements DoubleTensor {
      */
     @Override
     public List<DoubleTensor> split(int dimension, int[] splitAtIndices) {
+
+        int[] shape = getShape();
+        if (dimension < 0 || dimension >= shape.length) {
+            throw new IllegalArgumentException("Invalid dimension to split on " + dimension);
+        }
+
         Nd4j.getCompressor().autoDecompress(tensor);
 
-        List<DoubleTensor> slices = new ArrayList<>();
+        List<DoubleTensor> splits = new ArrayList<>();
         int previousSplitIndex = 0;
         for (int i = 0; i < splitAtIndices.length; i++) {
 
             INDArrayIndex[] indices = new INDArrayIndex[tensor.rank()];
+
+            if(previousSplitIndex == splitAtIndices[i]){
+                throw new IllegalArgumentException("Invalid index to split on " + splitAtIndices[i] + " at dimension " + dimension + " for tensor of shape " + Arrays.toString(shape));
+            }
 
             indices[dimension] = NDArrayIndex.interval(previousSplitIndex, splitAtIndices[i]);
             previousSplitIndex = splitAtIndices[i];
@@ -878,10 +888,10 @@ public class Nd4jDoubleTensor implements DoubleTensor {
                 }
             }
 
-            slices.add(new Nd4jDoubleTensor(tensor.get(indices)));
+            splits.add(new Nd4jDoubleTensor(tensor.get(indices)));
         }
 
-        return slices;
+        return splits;
     }
 
     // Comparisons

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -875,7 +875,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
 
             INDArrayIndex[] indices = new INDArrayIndex[tensor.rank()];
 
-            if(previousSplitIndex == splitAtIndices[i]){
+            if (previousSplitIndex == splitAtIndices[i]) {
                 throw new IllegalArgumentException("Invalid index to split on " + splitAtIndices[i] + " at dimension " + dimension + " for tensor of shape " + Arrays.toString(shape));
             }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -429,7 +429,7 @@ public class ScalarDoubleTensor implements DoubleTensor {
     }
 
     @Override
-    public List<DoubleTensor> split(int dimension, int[] indices) {
+    public List<DoubleTensor> split(int dimension, int[] splitAtIndices) {
         return Collections.singletonList(this);
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -767,6 +767,18 @@ public class Nd4jDoubleTensorTest {
         assertCanSplit(new int[]{2, 3, 4, 5, 7, 2}, new int[]{3, 4, 2, 6, 9, 2}, 0);
     }
 
+    @Test(expected= IllegalArgumentException.class)
+    public void doesThrowOnZeroLengthSplit() {
+        DoubleTensor A = DoubleTensor.arange(0, 100).reshape(10, 10);
+        A.split(0, new int[]{0});
+    }
+
+    @Test(expected= IllegalArgumentException.class)
+    public void doesThrowOnNegativeDimensionSplit() {
+        DoubleTensor A = DoubleTensor.arange(0, 100).reshape(10, 10);
+        A.split(-1, new int[]{1, 5});
+    }
+
     @Test
     public void doesSatisfyJavaDocExample() {
         DoubleTensor A = DoubleTensor.create(new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3}, 2, 6);


### PR DESCRIPTION
This PR adds a split that is nice and will be required by reverse mode autodiff for concat. 

From the JavaDoc:

```
    /**
     * @param dimension      the dimension to split on
     * @param splitAtIndices the indices that the dimension to split on should be split on
     * @return pieces of the tensor split in the order specified by splitAtIndices. To get
     * pieces that encompasses the entire tensor, the last index in the splitAtIndices must
     * be the length of the dimension being split on.
     * <p>
     * e.g A =
     * [
     * 1, 2, 3, 4, 5, 6
     * 7, 8, 9, 1, 2, 3
     * ]
     * <p>
     * A.split(0, [1]) gives List([1, 2, 3, 4, 5, 6])
     * A.split(0, [1, 2] gives List([1, 2, 3, 4, 5, 6], [7, 8, 9, 1, 2, 3]
     * <p>
     * A.split(1, [1, 3, 6]) gives
     * List(
     * [1, [2, 3  , [4, 5, 6,
     * 7]   8, 9]    1, 2, 3]
     * )
     */
```

This is only for DoubleTensor and not the other tensors because it's currently only needed for autodiff, which is double only. We may add one for Integer and Boolean in future.