### PR TITLE
Expose vertex id

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexId.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexId.java
@@ -24,6 +24,10 @@ public class VertexId implements Comparable<VertexId> {
         idValues[0] = ID_GENERATOR.getAndIncrement();
     }
 
+    public VertexId(long id) {
+        idValues[0] = id;
+    }
+
     @Override
     public int compareTo(VertexId that) {
         long comparisonValue = 0;


### PR DESCRIPTION
When debugging it's a massive pain to access things if I don't have access to a vertex as I'm unable to create a `VertexID` on the fly. This let's you make a `VertexID`.