### PR TITLE
Reverse mode Autodiff for concat

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -824,7 +824,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         INDArray[] toConcat = new INDArray[those.length + 1];
         toConcat[0] = dup;
         for (int i = 1; i <= those.length; i++) {
-            toConcat[i] = unsafeGetNd4J(those[i - 1]);
+            toConcat[i] = unsafeGetNd4J(those[i - 1]).dup();
         }
         INDArray concat = Nd4j.concat(dimension, toConcat);
         return new Nd4jDoubleTensor(concat);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
@@ -156,13 +156,13 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         if (this.partialDerivatives.isEmpty()) {
             thisInfMultiplied = PartialDerivatives.OF_CONSTANT;
         } else {
-            thisInfMultiplied = PartialDerivatives.matrixMultiplyForward(this.partialDerivatives, that.value, true);
+            thisInfMultiplied = PartialDerivatives.matrixMultiplyAlongOfDimensions(this.partialDerivatives, that.value, true);
         }
 
         if (that.partialDerivatives.isEmpty()) {
             thatInfMultiplied = PartialDerivatives.OF_CONSTANT;
         } else {
-            thatInfMultiplied = PartialDerivatives.matrixMultiplyForward(that.partialDerivatives, this.value, false);
+            thatInfMultiplied = PartialDerivatives.matrixMultiplyAlongOfDimensions(that.partialDerivatives, this.value, false);
         }
 
         PartialDerivatives newInf = thisInfMultiplied.add(thatInfMultiplied);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
@@ -156,13 +156,13 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         if (this.partialDerivatives.isEmpty()) {
             thisInfMultiplied = PartialDerivatives.OF_CONSTANT;
         } else {
-            thisInfMultiplied = PartialDerivatives.matrixMultiply(this.partialDerivatives, that.value, true);
+            thisInfMultiplied = PartialDerivatives.matrixMultiplyForward(this.partialDerivatives, that.value, true);
         }
 
         if (that.partialDerivatives.isEmpty()) {
             thatInfMultiplied = PartialDerivatives.OF_CONSTANT;
         } else {
-            thatInfMultiplied = PartialDerivatives.matrixMultiply(that.partialDerivatives, this.value, false);
+            thatInfMultiplied = PartialDerivatives.matrixMultiplyForward(that.partialDerivatives, this.value, false);
         }
 
         PartialDerivatives newInf = thisInfMultiplied.add(thatInfMultiplied);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -208,24 +208,33 @@ public class PartialDerivatives {
     }
 
     public PartialDerivatives multiplyBy(DoubleTensor multiplier) {
+        return multiplyBy(multiplier, false);
+    }
+
+    public PartialDerivatives multiplyBy(DoubleTensor multiplier, boolean reverse) {
         Map<VertexId, DoubleTensor> multiplied = new HashMap<>();
 
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
             VertexId k = entry.getKey();
-            DoubleTensor v = elementWiseMultiplyDiff(entry.getValue(), multiplier);
+            DoubleTensor v = elementWiseMultiplyDiff(entry.getValue(), multiplier, reverse);
             multiplied.put(k, v);
         }
 
         return new PartialDerivatives(multiplied);
     }
 
-    private DoubleTensor elementWiseMultiplyDiff(DoubleTensor partial, DoubleTensor multiplier) {
+    private DoubleTensor elementWiseMultiplyDiff(DoubleTensor partial, DoubleTensor multiplier, boolean reverse) {
 
         if (multiplier.isScalar()) {
             return partial.times(multiplier.scalar());
         }
 
-        DoubleTensor multiplierReshaped = increaseRankByAppendingOnesToShape(multiplier, partial.getRank());
+        DoubleTensor multiplierReshaped;
+        if (reverse) {
+            multiplierReshaped = increaseRankByPrependingOnesToShape(multiplier, partial.getRank());
+        } else {
+            multiplierReshaped = increaseRankByAppendingOnesToShape(multiplier, partial.getRank());
+        }
 
         if (partial.isScalar()) {
             return multiplierReshaped.times(partial.scalar());
@@ -246,7 +255,7 @@ public class PartialDerivatives {
         }
     }
 
-    public static PartialDerivatives matrixMultiply(PartialDerivatives partials, DoubleTensor multiplier, boolean partialIsLeft) {
+    public static PartialDerivatives matrixMultiplyForward(PartialDerivatives partials, DoubleTensor multiplier, boolean partialIsLeft) {
         Map<VertexId, DoubleTensor> multiplied = new HashMap<>();
 
         for (Map.Entry<VertexId, DoubleTensor> partial : partials.derivativeWithRespectTo.entrySet()) {
@@ -405,6 +414,12 @@ public class PartialDerivatives {
         }
 
         return shapeWithOnes;
+    }
+
+    private static DoubleTensor increaseRankByPrependingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
+        return lowRankTensor.reshape(
+            TensorShape.shapeToDesiredRankByPrependingOnes(lowRankTensor.getShape(), desiredRank)
+        );
     }
 
     private static DoubleTensor increaseRankByAppendingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -211,26 +211,26 @@ public class PartialDerivatives {
         return multiplyBy(multiplier, false);
     }
 
-    public PartialDerivatives multiplyBy(DoubleTensor multiplier, boolean reverse) {
+    public PartialDerivatives multiplyBy(DoubleTensor multiplier, boolean alongWrtDimensions) {
         Map<VertexId, DoubleTensor> multiplied = new HashMap<>();
 
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
             VertexId k = entry.getKey();
-            DoubleTensor v = elementWiseMultiplyDiff(entry.getValue(), multiplier, reverse);
+            DoubleTensor v = elementWiseMultiplyDiff(entry.getValue(), multiplier, alongWrtDimensions);
             multiplied.put(k, v);
         }
 
         return new PartialDerivatives(multiplied);
     }
 
-    private DoubleTensor elementWiseMultiplyDiff(DoubleTensor partial, DoubleTensor multiplier, boolean reverse) {
+    private DoubleTensor elementWiseMultiplyDiff(DoubleTensor partial, DoubleTensor multiplier, boolean alongWrtDimensions) {
 
         if (multiplier.isScalar()) {
             return partial.times(multiplier.scalar());
         }
 
         DoubleTensor multiplierReshaped;
-        if (reverse) {
+        if (alongWrtDimensions) {
             multiplierReshaped = increaseRankByPrependingOnesToShape(multiplier, partial.getRank());
         } else {
             multiplierReshaped = increaseRankByAppendingOnesToShape(multiplier, partial.getRank());
@@ -255,7 +255,7 @@ public class PartialDerivatives {
         }
     }
 
-    public static PartialDerivatives matrixMultiplyForward(PartialDerivatives partials, DoubleTensor multiplier, boolean partialIsLeft) {
+    public static PartialDerivatives matrixMultiplyAlongOfDimensions(PartialDerivatives partials, DoubleTensor multiplier, boolean partialIsLeft) {
         Map<VertexId, DoubleTensor> multiplied = new HashMap<>();
 
         for (Map.Entry<VertexId, DoubleTensor> partial : partials.derivativeWithRespectTo.entrySet()) {
@@ -281,7 +281,7 @@ public class PartialDerivatives {
         return new PartialDerivatives(multiplied);
     }
 
-    public static PartialDerivatives matrixMultiplyReverse(PartialDerivatives partials, DoubleTensor multiplier, boolean partialIsLeft) {
+    public static PartialDerivatives matrixMultiplyAlongWrtDimensions(PartialDerivatives partials, DoubleTensor multiplier, boolean partialIsLeft) {
         Map<VertexId, DoubleTensor> multiplied = new HashMap<>();
 
         for (Map.Entry<VertexId, DoubleTensor> partial : partials.derivativeWithRespectTo.entrySet()) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertex.java
@@ -32,14 +32,14 @@ public class MatrixMultiplicationVertex extends DoubleBinaryOpVertex {
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
 
         PartialDerivatives partialsLeft = PartialDerivatives
-            .matrixMultiplyReverse(
+            .matrixMultiplyAlongWrtDimensions(
                 derivativeOfOutputsWithRespectToSelf,
                 right.getValue(),
                 true
             );
 
         PartialDerivatives partialsRight = PartialDerivatives
-            .matrixMultiplyReverse(
+            .matrixMultiplyAlongWrtDimensions(
                 derivativeOfOutputsWithRespectToSelf,
                 left.getValue(),
                 false

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
@@ -30,8 +30,8 @@ public class MultiplicationVertex extends DoubleBinaryOpVertex {
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
 
-        PartialDerivatives rightPartial = derivativeOfOutputsWithRespectToSelf.multiplyBy(right.getValue());
-        PartialDerivatives leftPartial = derivativeOfOutputsWithRespectToSelf.multiplyBy(left.getValue());
+        PartialDerivatives rightPartial = derivativeOfOutputsWithRespectToSelf.multiplyBy(right.getValue(), true);
+        PartialDerivatives leftPartial = derivativeOfOutputsWithRespectToSelf.multiplyBy(left.getValue(), true);
 
         partials.put(left, rightPartial);
         partials.put(right, leftPartial);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -5,6 +5,7 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeC
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -12,6 +13,7 @@ import java.util.function.Function;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -50,7 +52,29 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
 
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        throw new UnsupportedOperationException();
+        Map<Vertex, PartialDerivatives> split = new HashMap<>();
+
+        int splitPosition = 0;
+        int[] splitIndices = new int[input.length];
+
+        for (int i = 0; i < input.length; i++) {
+            splitIndices[i] = splitPosition + input[i].getShape()[dimension];
+            splitPosition = splitIndices[i];
+            split.put(input[i], new PartialDerivatives(new HashMap<>()));
+        }
+
+        for (Map.Entry<VertexId, DoubleTensor> entry : derivativeOfOutputsWithRespectToSelf.asMap().entrySet()) {
+            DoubleTensor partial = entry.getValue();
+
+            List<DoubleTensor> splitPartial = partial.split(input[0].getShape().length + dimension, splitIndices);
+
+            for (int i = 0; i < splitPartial.size(); i++) {
+                split.get(input[i]).putWithRespectTo(entry.getKey(), splitPartial.get(i));
+            }
+
+        }
+
+        return split;
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -54,20 +54,20 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> splitPartials = new HashMap<>();
 
-        int splitPosition = 0;
+        int currentSplitIndex = 0;
         int[] splitIndices = new int[input.length];
 
         for (int i = 0; i < input.length; i++) {
-            splitIndices[i] = splitPosition + input[i].getShape()[dimension];
-            splitPosition = splitIndices[i];
+            splitIndices[i] = currentSplitIndex + input[i].getShape()[dimension];
+            currentSplitIndex = splitIndices[i];
             splitPartials.put(input[i], new PartialDerivatives(new HashMap<>()));
         }
 
-        int concatAlongWrtDimension = input[0].getShape().length + dimension;
+        int wrtDimensionToSliceOn = input[0].getShape().length + dimension;
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeOfOutputsWithRespectToSelf.asMap().entrySet()) {
             DoubleTensor partial = entry.getValue();
 
-            List<DoubleTensor> splitPartial = partial.split(concatAlongWrtDimension, splitIndices);
+            List<DoubleTensor> splitPartial = partial.split(wrtDimensionToSliceOn, splitIndices);
 
             for (int i = 0; i < splitPartial.size(); i++) {
                 splitPartials.get(input[i]).putWithRespectTo(entry.getKey(), splitPartial.get(i));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -52,7 +52,7 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
 
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        Map<Vertex, PartialDerivatives> split = new HashMap<>();
+        Map<Vertex, PartialDerivatives> splitPartials = new HashMap<>();
 
         int splitPosition = 0;
         int[] splitIndices = new int[input.length];
@@ -60,21 +60,22 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
         for (int i = 0; i < input.length; i++) {
             splitIndices[i] = splitPosition + input[i].getShape()[dimension];
             splitPosition = splitIndices[i];
-            split.put(input[i], new PartialDerivatives(new HashMap<>()));
+            splitPartials.put(input[i], new PartialDerivatives(new HashMap<>()));
         }
 
+        int concatAlongWrtDimension = input[0].getShape().length + dimension;
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeOfOutputsWithRespectToSelf.asMap().entrySet()) {
             DoubleTensor partial = entry.getValue();
 
-            List<DoubleTensor> splitPartial = partial.split(input[0].getShape().length + dimension, splitIndices);
+            List<DoubleTensor> splitPartial = partial.split(concatAlongWrtDimension, splitIndices);
 
             for (int i = 0; i < splitPartial.size(); i++) {
-                split.get(input[i]).putWithRespectTo(entry.getKey(), splitPartial.get(i));
+                splitPartials.get(input[i]).putWithRespectTo(entry.getKey(), splitPartial.get(i));
             }
 
         }
 
-        return split;
+        return splitPartials;
     }
 
     @Override

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
 
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -11,8 +11,6 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
 
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -1,9 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -141,21 +144,26 @@ public class ConcatenationVertexTest {
         DoubleVertex d = a.plus(b);
 
         ConcatenationVertex concat = new ConcatenationVertex(0, c, d);
-        PartialDerivatives concatPartial = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives concatPartialForward = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives concatPartialReverse = Differentiator.reverseModeAutoDiff(concat, a, b);
 
         PartialDerivatives cPartial = c.getDualNumber().getPartialDerivatives();
         PartialDerivatives dPartial = d.getDualNumber().getPartialDerivatives();
 
         Assert.assertArrayEquals(
             cPartial.withRespectTo(a).concat(0, dPartial.withRespectTo(a)).asFlatDoubleArray(),
-            concatPartial.withRespectTo(a).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(a).asFlatDoubleArray(),
             0.0001
         );
+
         Assert.assertArrayEquals(
             cPartial.withRespectTo(b).concat(0, dPartial.withRespectTo(b)).asFlatDoubleArray(),
-            concatPartial.withRespectTo(b).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(b).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(a), concatPartialReverse.withRespectTo(a));
+        assertEquals(concatPartialForward.withRespectTo(b), concatPartialReverse.withRespectTo(b));
     }
 
     @Test
@@ -178,11 +186,17 @@ public class ConcatenationVertexTest {
         ConcatenationVertex concat = new ConcatenationVertex(1, e, f);
 
         PartialDerivatives forward = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives reverse = Differentiator.reverseModeAutoDiff(concat, a, b, c, d);
 
         Assert.assertArrayEquals(new int[]{2, 4, 2, 2}, forward.withRespectTo(a).getShape());
         Assert.assertArrayEquals(new int[]{2, 4, 2, 2}, forward.withRespectTo(b).getShape());
         Assert.assertArrayEquals(new int[]{2, 4, 2, 2}, forward.withRespectTo(c).getShape());
         Assert.assertArrayEquals(new int[]{2, 4, 2, 2}, forward.withRespectTo(d).getShape());
+
+        Assert.assertArrayEquals(new int[]{2, 4, 2, 2}, reverse.withRespectTo(a).getShape());
+        Assert.assertArrayEquals(new int[]{2, 4, 2, 2}, reverse.withRespectTo(b).getShape());
+        Assert.assertArrayEquals(new int[]{2, 4, 2, 2}, reverse.withRespectTo(c).getShape());
+        Assert.assertArrayEquals(new int[]{2, 4, 2, 2}, reverse.withRespectTo(d).getShape());
     }
 
     @Test
@@ -202,10 +216,15 @@ public class ConcatenationVertexTest {
         ConcatenationVertex concat = new ConcatenationVertex(0, e, f);
 
         PartialDerivatives forward = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives reverse = Differentiator.reverseModeAutoDiff(concat, a, b, d);
 
         Assert.assertArrayEquals(new int[]{4, 2, 1, 1}, forward.withRespectTo(a).getShape());
         Assert.assertArrayEquals(new int[]{4, 2, 2, 2}, forward.withRespectTo(b).getShape());
         Assert.assertArrayEquals(new int[]{4, 2, 2, 2}, forward.withRespectTo(d).getShape());
+
+        Assert.assertArrayEquals(new int[]{4, 2, 1, 1}, reverse.withRespectTo(a).getShape());
+        Assert.assertArrayEquals(new int[]{4, 2, 2, 2}, reverse.withRespectTo(b).getShape());
+        Assert.assertArrayEquals(new int[]{4, 2, 2, 2}, reverse.withRespectTo(d).getShape());
     }
 
     @Test
@@ -225,10 +244,15 @@ public class ConcatenationVertexTest {
         ConcatenationVertex concat = new ConcatenationVertex(1, e, f);
 
         PartialDerivatives forward = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives reverse = Differentiator.reverseModeAutoDiff(concat, a, b, d);
 
         Assert.assertArrayEquals(new int[]{2, 5, 2, 3}, forward.withRespectTo(a).getShape());
         Assert.assertArrayEquals(new int[]{2, 5, 2, 3}, forward.withRespectTo(b).getShape());
         Assert.assertArrayEquals(new int[]{2, 5, 3, 2}, forward.withRespectTo(d).getShape());
+
+        Assert.assertArrayEquals(new int[]{2, 5, 2, 3}, reverse.withRespectTo(a).getShape());
+        Assert.assertArrayEquals(new int[]{2, 5, 2, 3}, reverse.withRespectTo(b).getShape());
+        Assert.assertArrayEquals(new int[]{2, 5, 3, 2}, reverse.withRespectTo(d).getShape());
     }
 
     @Test
@@ -243,7 +267,7 @@ public class ConcatenationVertexTest {
         DoubleVertex d = a.plus(b);
 
         ConcatenationVertex concat = new ConcatenationVertex(0, c, d);
-        DoubleTensor dualNumberValue = concat.getDualNumber().getValue();
+        DoubleTensor dualNumberValue = concat.eval();
 
         Assert.assertArrayEquals(
             new double[]{50, 90, 140, 200, 15, 21, 27, 33},
@@ -251,7 +275,6 @@ public class ConcatenationVertexTest {
             0.0001
         );
     }
-
 
     @Test
     public void canConcatenateAutoDiffMatricesAlongDimensionZero() {
@@ -271,27 +294,34 @@ public class ConcatenationVertexTest {
         DoubleTensor dDdshared = d.getDualNumber().getPartialDerivatives().withRespectTo(sharedMatrix);
 
         ConcatenationVertex concat = new ConcatenationVertex(0, c, d);
-        PartialDerivatives concatPartial = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives concatPartialForward = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives concatPartialReverse = Differentiator.reverseModeAutoDiff(concat, sharedMatrix, a, b);
 
         Assert.assertArrayEquals(
             dCdshared.concat(0, dDdshared).asFlatDoubleArray(),
-            concatPartial.withRespectTo(sharedMatrix).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(sharedMatrix).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(sharedMatrix), concatPartialReverse.withRespectTo(sharedMatrix));
 
         DoubleTensor cwrtA = c.getDualNumber().getPartialDerivatives().withRespectTo(a);
         Assert.assertArrayEquals(
             cwrtA.concat(0, DoubleTensor.zeros(cwrtA.getShape())).asFlatDoubleArray(),
-            concatPartial.withRespectTo(a).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(a).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(a), concatPartialReverse.withRespectTo(a));
 
         DoubleTensor dwrtB = d.getDualNumber().getPartialDerivatives().withRespectTo(b);
         Assert.assertArrayEquals(
             DoubleTensor.zeros(dwrtB.getShape()).concat(0, dwrtB).asFlatDoubleArray(),
-            concatPartial.withRespectTo(b).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(b).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(b), concatPartialReverse.withRespectTo(b));
     }
 
     @Test
@@ -312,27 +342,35 @@ public class ConcatenationVertexTest {
         DoubleTensor dDdshared = d.getDualNumber().getPartialDerivatives().withRespectTo(sharedMatrix);
 
         ConcatenationVertex concat = new ConcatenationVertex(1, c, d);
-        PartialDerivatives concatPartial = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives concatPartialForward = concat.getDualNumber().getPartialDerivatives();
+
+        PartialDerivatives concatPartialReverse = Differentiator.reverseModeAutoDiff(concat, sharedMatrix, a, b);
 
         Assert.assertArrayEquals(
             dCdshared.concat(1, dDdshared).asFlatDoubleArray(),
-            concatPartial.withRespectTo(sharedMatrix).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(sharedMatrix).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(sharedMatrix), concatPartialReverse.withRespectTo(sharedMatrix));
 
         DoubleTensor cwrtA = c.getDualNumber().getPartialDerivatives().withRespectTo(a);
         Assert.assertArrayEquals(
             cwrtA.concat(1, DoubleTensor.zeros(cwrtA.getShape())).asFlatDoubleArray(),
-            concatPartial.withRespectTo(a).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(a).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(a), concatPartialReverse.withRespectTo(a));
 
         DoubleTensor dwrtB = d.getDualNumber().getPartialDerivatives().withRespectTo(b);
         Assert.assertArrayEquals(
             DoubleTensor.zeros(dwrtB.getShape()).concat(1, dwrtB).asFlatDoubleArray(),
-            concatPartial.withRespectTo(b).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(b).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(b), concatPartialReverse.withRespectTo(b));
     }
 
     @Test
@@ -358,34 +396,43 @@ public class ConcatenationVertexTest {
         DoubleTensor dEdshared = e.getDualNumber().getPartialDerivatives().withRespectTo(sharedMatrix);
 
         ConcatenationVertex concat = new ConcatenationVertex(0, c, d, e);
-        PartialDerivatives concatPartial = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives concatPartialForward = concat.getDualNumber().getPartialDerivatives();
+        PartialDerivatives concatPartialReverse = Differentiator.reverseModeAutoDiff(concat, sharedMatrix, a, b, f);
 
         Assert.assertArrayEquals(
             dCdshared.concat(0, dDdshared, dEdshared).asFlatDoubleArray(),
-            concatPartial.withRespectTo(sharedMatrix).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(sharedMatrix).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(sharedMatrix), concatPartialReverse.withRespectTo(sharedMatrix));
 
         DoubleTensor cwrtA = c.getDualNumber().getPartialDerivatives().withRespectTo(a);
         Assert.assertArrayEquals(
             cwrtA.concat(0, DoubleTensor.zeros(cwrtA.getShape()), DoubleTensor.zeros(cwrtA.getShape())).asFlatDoubleArray(),
-            concatPartial.withRespectTo(a).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(a).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(a), concatPartialReverse.withRespectTo(a));
 
         DoubleTensor dwrtB = d.getDualNumber().getPartialDerivatives().withRespectTo(b);
         Assert.assertArrayEquals(
             DoubleTensor.zeros(dwrtB.getShape()).concat(0, dwrtB, DoubleTensor.zeros(dwrtB.getShape())).asFlatDoubleArray(),
-            concatPartial.withRespectTo(b).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(b).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(b), concatPartialReverse.withRespectTo(b));
 
         DoubleTensor ewrtC = e.getDualNumber().getPartialDerivatives().withRespectTo(f);
         Assert.assertArrayEquals(
             DoubleTensor.zeros(ewrtC.getShape()).concat(0, DoubleTensor.zeros(ewrtC.getShape()), ewrtC).asFlatDoubleArray(),
-            concatPartial.withRespectTo(f).asFlatDoubleArray(),
+            concatPartialForward.withRespectTo(f).asFlatDoubleArray(),
             0.0001
         );
+
+        assertEquals(concatPartialForward.withRespectTo(f), concatPartialReverse.withRespectTo(f));
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -169,30 +169,6 @@ public class MatrixMultiplicationVertexTest {
     }
 
     @Test
-    public void canShare() {
-        DoubleVertex sharedMatrix = new UniformVertex(0, 10);
-        sharedMatrix.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
-
-        DoubleVertex a = new UniformVertex(0, 10);
-        a.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
-
-        DoubleVertex b = new UniformVertex(0, 10);
-        b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
-
-        DoubleVertex c = sharedMatrix.matrixMultiply(a);
-        DoubleVertex d = sharedMatrix.matrixMultiply(b);
-
-        DoubleVertex e = c.plus(d);
-
-        PartialDerivatives forward = e.getDualNumber().getPartialDerivatives();
-        PartialDerivatives reverse = Differentiator.reverseModeAutoDiff(e, a, b, sharedMatrix);
-
-        assertEquals(forward.withRespectTo(a), reverse.withRespectTo(a));
-        assertEquals(forward.withRespectTo(b), reverse.withRespectTo(b));
-        assertEquals(forward.withRespectTo(sharedMatrix), reverse.withRespectTo(sharedMatrix));
-    }
-
-    @Test
     public void canDoDoubleMatrixMultiplyAutoDiff() {
 
         DoubleVertex m = new UniformVertex(0, 10);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -169,6 +169,30 @@ public class MatrixMultiplicationVertexTest {
     }
 
     @Test
+    public void canShare() {
+        DoubleVertex sharedMatrix = new UniformVertex(0, 10);
+        sharedMatrix.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+
+        DoubleVertex a = new UniformVertex(0, 10);
+        a.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
+
+        DoubleVertex b = new UniformVertex(0, 10);
+        b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
+
+        DoubleVertex c = sharedMatrix.matrixMultiply(a);
+        DoubleVertex d = sharedMatrix.matrixMultiply(b);
+
+        DoubleVertex e = c.plus(d);
+
+        PartialDerivatives forward = e.getDualNumber().getPartialDerivatives();
+        PartialDerivatives reverse = Differentiator.reverseModeAutoDiff(e, a, b, sharedMatrix);
+
+        assertEquals(forward.withRespectTo(a), reverse.withRespectTo(a));
+        assertEquals(forward.withRespectTo(b), reverse.withRespectTo(b));
+        assertEquals(forward.withRespectTo(sharedMatrix), reverse.withRespectTo(sharedMatrix));
+    }
+
+    @Test
     public void canDoDoubleMatrixMultiplyAutoDiff() {
 
         DoubleVertex m = new UniformVertex(0, 10);
@@ -192,7 +216,7 @@ public class MatrixMultiplicationVertexTest {
         DoubleVertex y = N.matrixMultiply(beta);
 
         DualNumber yDual = y.getDualNumber();
-        PartialDerivatives dydx = Differentiator.reverseModeAutoDiff(y, new HashSet<>(Arrays.asList(m, alpha, beta)));
+        PartialDerivatives dydx = Differentiator.reverseModeAutoDiff(y, m, alpha, beta);
 
         DoubleTensor dydmForward = yDual.getPartialDerivatives().withRespectTo(m);
         DoubleTensor dydmReverse = dydx.withRespectTo(m);


### PR DESCRIPTION
This PR:

- adds concat to the list of supported reverse mode ops
- fixes an issue in reverse mode element wise multiply that multiplies along the wrong dimensions