### PR TITLE
Actually use reverse auto diff for LogProb gradient

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -10,7 +10,6 @@ import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -77,7 +76,6 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
 
         final List<Vertex<DoubleTensor>> latentVertices = bayesNet.getContinuousLatentVertices();
         final LogProbGradientCalculator logProbGradientCalculator = new LogProbGradientCalculator(bayesNet.getLatentOrObservedVertices(), latentVertices);
-        final List<? extends Probabilistic> probabilisticVertices = Probabilistic.keepOnlyProbabilisticVertices(bayesNet.getLatentOrObservedVertices());
 
         final Map<VertexId, List<?>> samples = new HashMap<>();
         addSampleFromVertices(samples, fromVertices);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -14,7 +14,7 @@ import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradient;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -76,6 +76,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         bayesNet.cascadeObservations();
 
         final List<Vertex<DoubleTensor>> latentVertices = bayesNet.getContinuousLatentVertices();
+        final LogProbGradientCalculator logProbGradientCalculator = new LogProbGradientCalculator(bayesNet.getLatentOrObservedVertices(), latentVertices);
         final List<? extends Probabilistic> probabilisticVertices = Probabilistic.keepOnlyProbabilisticVertices(bayesNet.getLatentOrObservedVertices());
 
         final Map<VertexId, List<?>> samples = new HashMap<>();
@@ -85,7 +86,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         cachePosition(latentVertices, position);
         Map<VertexId, DoubleTensor> positionBeforeLeapfrog = new HashMap<>();
 
-        Map<VertexId, DoubleTensor> gradient = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
+        Map<VertexId, DoubleTensor> gradient = logProbGradientCalculator.getJointLogProbGradientWrtLatents();
         Map<VertexId, DoubleTensor> gradientBeforeLeapfrog = new HashMap<>();
 
         final Map<VertexId, DoubleTensor> momentum = new HashMap<>();
@@ -114,7 +115,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
                     gradient,
                     momentum,
                     stepSize,
-                    probabilisticVertices
+                    logProbGradientCalculator
                 );
             }
 
@@ -178,18 +179,18 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
      *
      * @param latentVertices
      * @param position
-     * @param gradient              gradient at current position
-     * @param momentums             current vertex momentums
+     * @param gradient        gradient at current position
+     * @param momentums       current vertex momentums
      * @param stepSize
-     * @param probabilisticVertices all vertices that impact the joint posterior (masterP)
+     * @param logProbGradient calculator of the logProb gradients
      * @return the gradient at the updated position
      */
     private static Map<VertexId, DoubleTensor> leapfrog(final List<Vertex<DoubleTensor>> latentVertices,
-                                                    final Map<VertexId, DoubleTensor> position,
-                                                    final Map<VertexId, DoubleTensor> gradient,
-                                                    final Map<VertexId, DoubleTensor> momentums,
-                                                    final double stepSize,
-                                                    final List<? extends Probabilistic> probabilisticVertices) {
+                                                        final Map<VertexId, DoubleTensor> position,
+                                                        final Map<VertexId, DoubleTensor> gradient,
+                                                        final Map<VertexId, DoubleTensor> momentums,
+                                                        final double stepSize,
+                                                        final LogProbGradientCalculator logProbGradient) {
 
         final double halfTimeStep = stepSize / 2.0;
 
@@ -211,9 +212,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         VertexValuePropagation.cascadeUpdate(latentVertices);
 
         //Set `r = `r + (eps/2)dTL(`T)
-        Map<VertexId, DoubleTensor> newGradient = LogProbGradient.getJointLogProbGradientWrtLatents(
-            probabilisticVertices
-        );
+        Map<VertexId, DoubleTensor> newGradient = logProbGradient.getJointLogProbGradientWrtLatents();
 
         for (Map.Entry<VertexId, DoubleTensor> halfTimeStepMomentum : momentumsAtHalfTimeStep.entrySet()) {
             final DoubleTensor updatedMomentum = newGradient.get(halfTimeStepMomentum.getKey()).times(halfTimeStep).plusInPlace(halfTimeStepMomentum.getValue());

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
@@ -48,7 +48,6 @@ public class FitnessFunctionWithGradient {
 
             setAndCascadePoint(point, wrtVertices);
 
-//            List<? extends Probabilistic> probabilisticVertices = Probabilistic.keepOnlyProbabilisticVertices(this.ofVertices);
             Map<VertexId, DoubleTensor> diffs = logProbGradient.getJointLogProbGradientWrtLatents();
 
             double[] gradients = alignGradientsToAppropriateIndex(diffs, wrtVertices);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.algorithms.variational.optimizer.gradient;
 
 
 import static io.improbable.keanu.algorithms.variational.optimizer.Optimizer.setAndCascadePoint;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -11,44 +12,46 @@ import org.apache.commons.math3.analysis.MultivariateFunction;
 import org.apache.commons.math3.analysis.MultivariateVectorFunction;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.ProbabilityCalculator;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradient;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
 
 
 public class FitnessFunctionWithGradient {
 
-    private final List<? extends Vertex> vertices;
-    private final List<? extends Vertex<DoubleTensor>> latentVertices;
+    private final List<? extends Vertex> ofVertices;
+    private final List<? extends Vertex<DoubleTensor>> wrtVertices;
+    private final LogProbGradientCalculator logProbGradient;
+
     private final BiConsumer<double[], double[]> onGradientCalculation;
     private final BiConsumer<double[], Double> onFitnessCalculation;
 
-    public FitnessFunctionWithGradient(List<? extends Vertex> vertices,
-                                       List<? extends Vertex<DoubleTensor>> latentVertices,
+    public FitnessFunctionWithGradient(List<? extends Vertex> ofVertices,
+                                       List<? extends Vertex<DoubleTensor>> wrtVertices,
                                        BiConsumer<double[], double[]> onGradientCalculation,
                                        BiConsumer<double[], Double> onFitnessCalculation) {
-        this.vertices = vertices;
-        this.latentVertices = latentVertices;
+        this.ofVertices = ofVertices;
+        this.wrtVertices = wrtVertices;
+        this.logProbGradient = new LogProbGradientCalculator(ofVertices, wrtVertices);
         this.onGradientCalculation = onGradientCalculation;
         this.onFitnessCalculation = onFitnessCalculation;
     }
 
-    public FitnessFunctionWithGradient(List<? extends Vertex> vertices,
-                                       List<? extends Vertex<DoubleTensor>> latentVertices) {
-        this(vertices, latentVertices, null, null);
+    public FitnessFunctionWithGradient(List<? extends Vertex> ofVertices,
+                                       List<? extends Vertex<DoubleTensor>> wrtVertices) {
+        this(ofVertices, wrtVertices, null, null);
     }
 
     public MultivariateVectorFunction gradient() {
         return point -> {
 
-            setAndCascadePoint(point, latentVertices);
+            setAndCascadePoint(point, wrtVertices);
 
-            List<? extends Probabilistic> probabilisticVertices = Probabilistic.keepOnlyProbabilisticVertices(this.vertices);
-            Map<VertexId, DoubleTensor> diffs = LogProbGradient.getJointLogProbGradientWrtLatents(probabilisticVertices);
+//            List<? extends Probabilistic> probabilisticVertices = Probabilistic.keepOnlyProbabilisticVertices(this.ofVertices);
+            Map<VertexId, DoubleTensor> diffs = logProbGradient.getJointLogProbGradientWrtLatents();
 
-            double[] gradients = alignGradientsToAppropriateIndex(diffs, latentVertices);
+            double[] gradients = alignGradientsToAppropriateIndex(diffs, wrtVertices);
 
             if (onGradientCalculation != null) {
                 onGradientCalculation.accept(point, gradients);
@@ -60,8 +63,8 @@ public class FitnessFunctionWithGradient {
 
     public MultivariateFunction fitness() {
         return point -> {
-            setAndCascadePoint(point, latentVertices);
-            double logOfTotalProbability = ProbabilityCalculator.calculateLogProbFor(vertices);
+            setAndCascadePoint(point, wrtVertices);
+            double logOfTotalProbability = ProbabilityCalculator.calculateLogProbFor(ofVertices);
 
             if (onFitnessCalculation != null) {
                 onFitnessCalculation.accept(point, logOfTotalProbability);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
@@ -22,7 +22,7 @@ public class FitnessFunctionWithGradient {
 
     private final List<? extends Vertex> ofVertices;
     private final List<? extends Vertex<DoubleTensor>> wrtVertices;
-    private final LogProbGradientCalculator logProbGradient;
+    private final LogProbGradientCalculator logProbGradientCalculator;
 
     private final BiConsumer<double[], double[]> onGradientCalculation;
     private final BiConsumer<double[], Double> onFitnessCalculation;
@@ -33,7 +33,7 @@ public class FitnessFunctionWithGradient {
                                        BiConsumer<double[], Double> onFitnessCalculation) {
         this.ofVertices = ofVertices;
         this.wrtVertices = wrtVertices;
-        this.logProbGradient = new LogProbGradientCalculator(ofVertices, wrtVertices);
+        this.logProbGradientCalculator = new LogProbGradientCalculator(ofVertices, wrtVertices);
         this.onGradientCalculation = onGradientCalculation;
         this.onFitnessCalculation = onFitnessCalculation;
     }
@@ -48,7 +48,7 @@ public class FitnessFunctionWithGradient {
 
             setAndCascadePoint(point, wrtVertices);
 
-            Map<VertexId, DoubleTensor> diffs = logProbGradient.getJointLogProbGradientWrtLatents();
+            Map<VertexId, DoubleTensor> diffs = logProbGradientCalculator.getJointLogProbGradientWrtLatents();
 
             double[] gradients = alignGradientsToAppropriateIndex(diffs, wrtVertices);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -130,7 +130,7 @@ public class GradientOptimizer implements Optimizer {
         return optimize(bayesianNetwork.getObservedVertices());
     }
 
-    private double optimize(List<Vertex> outputVertices) {
+    private double optimize(List<? extends Vertex> outputVertices) {
 
         ProgressBar progressBar = Optimizer.createFitnessProgressBar(this);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -130,7 +130,7 @@ public class GradientOptimizer implements Optimizer {
         return optimize(bayesianNetwork.getObservedVertices());
     }
 
-    private double optimize(List<? extends Vertex> outputVertices) {
+    private double optimize(List<Vertex> outputVertices) {
 
         ProgressBar progressBar = Optimizer.createFitnessProgressBar(this);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -6,6 +6,7 @@ import static io.improbable.keanu.distributions.dual.Diffs.X;
 
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.dual.Diffs;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -16,7 +16,7 @@ public class Gaussian implements ContinuousDistribution {
     private final DoubleTensor mu;
     private final DoubleTensor sigma;
 
-    public static Gaussian withParameters(DoubleTensor mu, DoubleTensor sigma) {
+    public static ContinuousDistribution withParameters(DoubleTensor mu, DoubleTensor sigma) {
         return new Gaussian(mu, sigma);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -6,7 +6,6 @@ import static io.improbable.keanu.distributions.dual.Diffs.X;
 
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -16,7 +16,7 @@ public class Gaussian implements ContinuousDistribution {
     private final DoubleTensor mu;
     private final DoubleTensor sigma;
 
-    public static ContinuousDistribution withParameters(DoubleTensor mu, DoubleTensor sigma) {
+    public static Gaussian withParameters(DoubleTensor mu, DoubleTensor sigma) {
         return new Gaussian(mu, sigma);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -201,12 +201,5 @@ public class TensorShape {
         return highRankCopy;
     }
 
-    public static int[] prependOnes(int[] originalShape, int numberOfOnesToPrepend) {
-        int[] newShape = new int[originalShape.length + numberOfOnesToPrepend];
-        Arrays.fill(newShape, 1);
-        System.arraycopy(originalShape, 0, newShape, numberOfOnesToPrepend, newShape.length - numberOfOnesToPrepend);
-        return newShape;
-    }
-
 }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -184,10 +184,10 @@ public class TensorShape {
 
     /**
      * Writes a lower rank shape over a higher rank shape, starting from the right.
-     *
+     * <p>
      * e.g: high rank shape = [1, 2, 2, 1]
-     *      low rank shape = [1, 4]
-     *
+     * low rank shape = [1, 4]
+     * <p>
      * Result after copy = [1, 2, 1, 4]
      *
      * @param higherRankShape source shape that will get written over
@@ -199,6 +199,13 @@ public class TensorShape {
         int deltaLength = highRankCopy.length - lowerRankShape.length;
         System.arraycopy(lowerRankShape, 0, highRankCopy, deltaLength, highRankCopy.length - deltaLength);
         return highRankCopy;
+    }
+
+    public static int[] prependOnes(int[] originalShape, int numberOfOnesToPrepend) {
+        int[] newShape = new int[originalShape.length + numberOfOnesToPrepend];
+        Arrays.fill(newShape, 1);
+        System.arraycopy(originalShape, 0, newShape, numberOfOnesToPrepend, newShape.length - numberOfOnesToPrepend);
+        return newShape;
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
@@ -27,7 +27,8 @@ public interface Probabilistic<T> extends Observable<T> {
     /**
      * The partial derivatives of the natural log prob.
      *
-     * @param atValue at a given value
+     * @param atValue       at a given value
+     * @param withRespectTo list of parents to differentiate with respect to
      * @return the partial derivatives of the log of the probability function at the supplied value.
      * For continuous variables this is called the PDF (probability density function).
      * For discrete variables this is called the PMF (probability mass function).

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
@@ -32,9 +32,9 @@ public interface Probabilistic<T> extends Observable<T> {
      * For continuous variables this is called the PDF (probability density function).
      * For discrete variables this is called the PMF (probability mass function).
      */
-    Map<VertexId, DoubleTensor> dLogProb(T atValue, Set<Vertex> withRespectTo);
+    Map<Vertex, DoubleTensor> dLogProb(T atValue, Set<? extends Vertex> withRespectTo);
 
-    default Map<VertexId, DoubleTensor> dLogProb(T atValue, Vertex... withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogProb(T atValue, Vertex... withRespectTo) {
         return dLogProb(atValue, new HashSet<>(Arrays.asList(withRespectTo)));
     }
 
@@ -46,11 +46,11 @@ public interface Probabilistic<T> extends Observable<T> {
         return logProb(getValue());
     }
 
-    default Map<VertexId, DoubleTensor> dLogProbAtValue(Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogProbAtValue(Set<? extends Vertex> withRespectTo) {
         return dLogProb(getValue(), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogProbAtValue(Vertex... withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogProbAtValue(Vertex... withRespectTo) {
         return dLogProb(getValue(), new HashSet<>(Arrays.asList(withRespectTo)));
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
@@ -51,7 +51,7 @@ public interface Probabilistic<T> extends Observable<T> {
     }
 
     default Map<Vertex, DoubleTensor> dLogProbAtValue(Vertex... withRespectTo) {
-        return dLogProb(getValue(), new HashSet<>(Arrays.asList(withRespectTo)));
+        return dLogProb(getValue(), withRespectTo);
     }
 
     static <V extends Vertex & Probabilistic> List<V> keepOnlyProbabilisticVertices(Iterable<? extends Vertex> vertices) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.vertices;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 
@@ -24,12 +27,16 @@ public interface Probabilistic<T> extends Observable<T> {
     /**
      * The partial derivatives of the natural log prob.
      *
-     * @param value at a given value
+     * @param atValue at a given value
      * @return the partial derivatives of the log of the probability function at the supplied value.
      * For continuous variables this is called the PDF (probability density function).
      * For discrete variables this is called the PMF (probability mass function).
      */
-    Map<VertexId, DoubleTensor> dLogProb(T value);
+    Map<VertexId, DoubleTensor> dLogProb(T atValue, Set<Vertex> withRespectTo);
+
+    default Map<VertexId, DoubleTensor> dLogProb(T atValue, Vertex... withRespectTo) {
+        return dLogProb(atValue, new HashSet<>(Arrays.asList(withRespectTo)));
+    }
 
     T getValue();
 
@@ -39,8 +46,12 @@ public interface Probabilistic<T> extends Observable<T> {
         return logProb(getValue());
     }
 
-    default Map<VertexId, DoubleTensor> dLogProbAtValue() {
-        return dLogProb(getValue());
+    default Map<VertexId, DoubleTensor> dLogProbAtValue(Set<Vertex> withRespectTo) {
+        return dLogProb(getValue(), withRespectTo);
+    }
+
+    default Map<VertexId, DoubleTensor> dLogProbAtValue(Vertex... withRespectTo) {
+        return dLogProb(getValue(), new HashSet<>(Arrays.asList(withRespectTo)));
     }
 
     static <V extends Vertex & Probabilistic> List<V> keepOnlyProbabilisticVertices(Iterable<? extends Vertex> vertices) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/ProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/ProxyVertex.java
@@ -5,7 +5,7 @@ package io.improbable.keanu.vertices;
  * parent.  It typically has no parents at creation time - the parent is node is "hooked up" at a later point.
  */
 public interface ProxyVertex<T extends Vertex<?>> {
-    public void setParent(T newParent);
+    void setParent(T newParent);
 
-    public boolean hasParent();
+    boolean hasParent();
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
@@ -69,20 +69,12 @@ public class BernoulliVertex extends BoolVertex implements ProbabilisticBoolean 
             throw new UnsupportedOperationException("The probability of the Bernoulli being true must be differentiable");
         }
 
-//        PartialDerivatives probTruePartialDerivatives = ((Differentiable) probTrue).getDualNumber().getPartialDerivatives();
-
         if (withRespectTo.contains(probTrue)) {
             DoubleTensor dLogPdp = Bernoulli.withParameters(probTrue.getValue()).dLogProb(value);
             return Collections.singletonMap(probTrue, dLogPdp);
         }
 
         return Collections.emptyMap();
-
-//        PartialDerivatives partials = probTruePartialDerivatives
-//            .multiplyBy(dLogPdp)
-//            .sum(true, TensorShape.dimensionRange(0, value.getRank()));
-//
-//        return partials.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
@@ -11,7 +11,6 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -64,7 +63,7 @@ public class BernoulliVertex extends BoolVertex implements ProbabilisticBoolean 
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(BooleanTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(BooleanTensor value, Set<? extends Vertex> withRespectTo) {
 
         if (!(probTrue instanceof Differentiable)) {
             throw new UnsupportedOperationException("The probability of the Bernoulli being true must be differentiable");
@@ -74,7 +73,7 @@ public class BernoulliVertex extends BoolVertex implements ProbabilisticBoolean 
 
         if (withRespectTo.contains(probTrue)) {
             DoubleTensor dLogPdp = Bernoulli.withParameters(probTrue.getValue()).dLogProb(value);
-            return Collections.singletonMap(probTrue.getId(), dLogPdp);
+            return Collections.singletonMap(probTrue, dLogPdp);
         }
 
         return Collections.emptyMap();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBoolean.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBoolean.java
@@ -1,13 +1,16 @@
 package io.improbable.keanu.vertices.bool.probabilistic;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticBoolean extends Probabilistic<BooleanTensor> {
+
     default double logPmf(boolean value) {
         return logPmf(BooleanTensor.scalar(value));
     }
@@ -20,15 +23,15 @@ public interface ProbabilisticBoolean extends Probabilistic<BooleanTensor> {
         return logProb(value);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(boolean value) {
-        return dLogPmf(BooleanTensor.scalar(value));
+    default Map<VertexId, DoubleTensor> dLogPmf(boolean value, Set<Vertex> withRespectTo) {
+        return dLogPmf(BooleanTensor.scalar(value), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(boolean[] values) {
-        return dLogPmf(BooleanTensor.create(values));
+    default Map<VertexId, DoubleTensor> dLogPmf(boolean[] values, Set<Vertex> withRespectTo) {
+        return dLogPmf(BooleanTensor.create(values), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(BooleanTensor value) {
-        return dLogProb(value);
+    default Map<VertexId, DoubleTensor> dLogPmf(BooleanTensor value, Set<Vertex> withRespectTo) {
+        return dLogProb(value, withRespectTo);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBoolean.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBoolean.java
@@ -7,7 +7,6 @@ import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticBoolean extends Probabilistic<BooleanTensor> {
 
@@ -23,15 +22,15 @@ public interface ProbabilisticBoolean extends Probabilistic<BooleanTensor> {
         return logProb(value);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(boolean value, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPmf(boolean value, Set<Vertex> withRespectTo) {
         return dLogPmf(BooleanTensor.scalar(value), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(boolean[] values, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPmf(boolean[] values, Set<Vertex> withRespectTo) {
         return dLogPmf(BooleanTensor.create(values), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(BooleanTensor value, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPmf(BooleanTensor value, Set<Vertex> withRespectTo) {
         return dLogProb(value, withRespectTo);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
@@ -18,14 +18,4 @@ public interface Differentiable {
     default DualNumber getDualNumber() {
         return Differentiator.calculateDual((Vertex & Differentiable) this);
     }
-
-    static <V extends Vertex & Differentiable> List<V> keepOnlyDifferentiableVertices(List<? extends Vertex<?>> vertices) {
-        ImmutableList.Builder<V> differentiableVertices = ImmutableList.builder();
-        for (Vertex v : vertices) {
-            if (v instanceof Differentiable) {
-                differentiableVertices.add((V) v);
-            }
-        }
-        return differentiableVertices.build();
-    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
@@ -31,7 +31,7 @@ public class Differentiator {
         alreadyQueued.add(ofVertex);
 
         Map<Vertex, PartialDerivatives> dwrtOf = new HashMap<>();
-        collectPartials(singletonMap(ofVertex, dWrtOfVertex), dwrtOf);
+        collectPartials(singletonMap(ofVertex, dWrtOfVertex), dwrtOf, ofVertex.getShape().length);
 
         Map<VertexId, PartialDerivatives> wrtOf = new HashMap<>();
 
@@ -46,7 +46,7 @@ public class Differentiator {
             if (visiting instanceof Differentiable) {
                 Differentiable visitingDifferentiable = ((Differentiable) visiting);
                 Map<Vertex, PartialDerivatives> partialDerivatives = visitingDifferentiable.reverseModeAutoDifferentiation(dwrtOf.get(visiting));
-                collectPartials(partialDerivatives, dwrtOf);
+                collectPartials(partialDerivatives, dwrtOf, visiting.getShape().length);
             }
 
             if (!visiting.isProbabilistic()) {
@@ -62,7 +62,7 @@ public class Differentiator {
         return wrtOfToOfWrt(wrtOf).get(ofVertex.getId());
     }
 
-    private static void collectPartials(Map<Vertex, PartialDerivatives> partialDerivatives, Map<Vertex, PartialDerivatives> dwrtOf) {
+    private static void collectPartials(Map<Vertex, PartialDerivatives> partialDerivatives, Map<Vertex, PartialDerivatives> dwrtOf, int prevRank) {
 
         for (Map.Entry<Vertex, PartialDerivatives> v : partialDerivatives.entrySet()) {
 
@@ -72,7 +72,7 @@ public class Differentiator {
 
             PartialDerivatives dwrtV;
             if (TensorShape.isScalar(wrtShape)) {
-                dwrtV = partialsOf.sum(false, -wrtShape.length, -1);
+                dwrtV = partialsOf.sum(false, TensorShape.dimensionRange(-prevRank, 0));
             } else {
                 dwrtV = partialsOf;
             }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
@@ -52,8 +52,8 @@ public class DoubleIfVertex extends DoubleVertex implements NonProbabilistic<Dou
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
         BooleanTensor predicateValue = predicate.getValue();
-        partials.put(thn, derivativeOfOutputsWithRespectToSelf.multiplyBy(predicateValue.toDoubleMask()));
-        partials.put(els, derivativeOfOutputsWithRespectToSelf.multiplyBy(predicateValue.not().toDoubleMask()));
+        partials.put(thn, derivativeOfOutputsWithRespectToSelf.multiplyBy(predicateValue.toDoubleMask(), true));
+        partials.put(els, derivativeOfOutputsWithRespectToSelf.multiplyBy(predicateValue.not().toDoubleMask(), true));
         return partials;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleProxyVertex.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
+import java.util.Collections;
 import java.util.Map;
 
 import com.google.common.collect.Iterables;
@@ -9,12 +10,13 @@ import com.google.common.collect.Iterables;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
+import io.improbable.keanu.vertices.ProxyVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
-import io.improbable.keanu.vertices.ProxyVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class DoubleProxyVertex extends DoubleVertex implements ProxyVertex<DoubleVertex>, NonProbabilistic<DoubleTensor> {
 
@@ -61,6 +63,11 @@ public class DoubleProxyVertex extends DoubleVertex implements ProxyVertex<Doubl
     @Override
     public DualNumber calculateDualNumber(Map<Vertex, DualNumber> dualNumbers) {
         return dualNumbers.get(getParent());
+    }
+
+    @Override
+    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
+        return Collections.singletonMap(getParent(), derivativeOfOutputsWithRespectToSelf);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
@@ -7,7 +7,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
+
 import io.improbable.keanu.network.LambdaSection;
+import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
@@ -18,26 +21,48 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
 public class LogProbGradientCalculator {
 
-    private final Set<? extends Vertex> logProbOfVertices;
-    private final Set<? extends Vertex> wrtVertices;
+    private final Set<? extends Vertex<?>> logProbOfVertices;
+    private final Set<? extends Vertex<?>> wrtVertices;
 
     private final Map<Vertex, Set<DoubleVertex>> parentToLatentLookup;
     private final Map<Vertex, Set<DoubleVertex>> verticesWithNonzeroDiffWrtLatent;
 
-    public LogProbGradientCalculator(List<? extends Vertex> logProbOfVerticesList, List<? extends Vertex> wrtVerticesList) {
-        this.logProbOfVertices = new HashSet<>(logProbOfVerticesList);
+    public LogProbGradientCalculator(List<? extends Vertex> logProbOfVerticesList, List<? extends Vertex<?>> wrtVerticesList) {
+        this.logProbOfVertices = new HashSet<>((List<Vertex<?>>) logProbOfVerticesList);
         this.wrtVertices = new HashSet<>(wrtVerticesList);
 
-        parentToLatentLookup = getWrtParents(logProbOfVertices);
-        verticesWithNonzeroDiffWrtLatent = getParentsWithNonzeroDiffWrt(logProbOfVertices, parentToLatentLookup);
+        parentToLatentLookup = getParentsThatAreConnectedToWrtVertices(logProbOfVertices);
+        verticesWithNonzeroDiffWrtLatent = getVerticesWithNonzeroDiffWrt(logProbOfVertices, parentToLatentLookup);
     }
 
-    private Map<Vertex, Set<DoubleVertex>> getParentsWithNonzeroDiffWrt(Set<? extends Vertex> ofVertices, Map<Vertex, Set<DoubleVertex>> parentToWrtVertices) {
+    /**
+     * @return the partial derivatives with respect to a give set of latent vertices
+     */
+    public Map<VertexId, DoubleTensor> getJointLogProbGradientWrtLatents() {
+        PartialDerivatives diffOfLogWrt = new PartialDerivatives(new HashMap<>());
+
+        for (final Vertex<?> ofVertex : logProbOfVertices) {
+            diffOfLogWrt = diffOfLogWrt.add(reverseModeLogProbGradientWrtLatents(ofVertex));
+        }
+
+        return diffOfLogWrt.asMap();
+    }
+
+    /**
+     * The Vertex::dLogProb method returns a partial derivative of the Log Prob with respect to each parent
+     * and with respect to it's own value. This method finds which one of these partials will be non-zero due to being
+     * connected to a vertex that we are taking the derivative with respect to.
+     *
+     * @param ofVertices          the vertices that the derivative is being calculated "of" with respect to the wrtVertices
+     * @param parentToWrtVertices a lookup
+     * @return a lookup map for a given vertex to a set of the wrt vertices that it descends
+     */
+    private Map<Vertex, Set<DoubleVertex>> getVerticesWithNonzeroDiffWrt(Set<? extends Vertex<?>> ofVertices, Map<Vertex, Set<DoubleVertex>> parentToWrtVertices) {
         return ofVertices.stream()
             .collect(Collectors.toMap(
                 v -> v,
                 v -> {
-                    Set<DoubleVertex> parents = ((Set<Vertex>) v.getParents()).stream()
+                    Set<DoubleVertex> parents = v.getParents().stream()
                         .map(parent -> (DoubleVertex) parent)
                         .filter(parentToWrtVertices::containsKey)
                         .collect(Collectors.toSet());
@@ -51,11 +76,19 @@ public class LogProbGradientCalculator {
             ));
     }
 
-    private Map<Vertex, Set<DoubleVertex>> getWrtParents(Set<? extends Vertex> ofVertices) {
+    /**
+     * This method finds which one of the vertex's parents are connected to a vertex that we are taking the derivative
+     * with respect to.
+     *
+     * @param ofVertices the vertices that the derivative is being calculated "of" with respect to the wrtVertices
+     * @return a lookup map for a given vertex to a set of vertices that are directly connected to the dLogProb result
+     * of the ofVertices and a vertex that we are finding the gradient with respect to.
+     */
+    private Map<Vertex, Set<DoubleVertex>> getParentsThatAreConnectedToWrtVertices(Set<? extends Vertex> ofVertices) {
 
         Map<Vertex, Set<DoubleVertex>> probabilisticParentLookup = new HashMap<>();
 
-        for (Vertex probabilisticVertex : ofVertices) {
+        for (Vertex<?> probabilisticVertex : ofVertices) {
 
             Set<? extends Vertex> parents = probabilisticVertex.getParents();
 
@@ -65,9 +98,8 @@ public class LogProbGradientCalculator {
 
                 Set<Vertex> latentAndObservedVertices = upstreamLambdaSection.getLatentAndObservedVertices();
                 Set<DoubleVertex> latentVertices = latentAndObservedVertices.stream()
-                    .filter(v -> !v.isObserved() && v instanceof DoubleVertex)
+                    .filter(this::isLatentDoubleVertex)
                     .map(v -> (DoubleVertex) v)
-                    .filter(wrtVertices::contains)
                     .collect(Collectors.toSet());
 
                 if (!latentVertices.isEmpty()) {
@@ -80,26 +112,24 @@ public class LogProbGradientCalculator {
         return probabilisticParentLookup;
     }
 
-    /**
-     * @return the partial derivatives with respect to any latents upstream
-     */
-    public Map<VertexId, DoubleTensor> getJointLogProbGradientWrtLatents() {
-        PartialDerivatives diffOfLogWrt = new PartialDerivatives(new HashMap<>());
-
-        for (final Vertex<?> ofVertex : logProbOfVertices) {
-            diffOfLogWrt = reverseModeLogProbGradientWrtLatents(ofVertex, diffOfLogWrt);
-        }
-
-        return diffOfLogWrt.asMap();
+    private boolean isLatentDoubleVertex(Vertex v) {
+        return !v.isObserved() && wrtVertices.contains(v) && v instanceof DoubleVertex;
     }
 
-    public <T> PartialDerivatives reverseModeLogProbGradientWrtLatents(final Vertex<T> ofVertex,
-                                                                       final PartialDerivatives diffOfLogProbWrt) {
+    /**
+     * @param ofVertex starting point for reverse mode autodiff
+     * @return partial derivatives of the "ofVertex" wrt to any "this.wrtVertices" that it descends.
+     */
+    private PartialDerivatives reverseModeLogProbGradientWrtLatents(final Vertex ofVertex) {
+        Preconditions.checkArgument(
+            ofVertex instanceof Probabilistic<?>,
+            "Cannot get logProb gradient on non-probabilistic vertex %s", ofVertex
+        );
 
         Set<DoubleVertex> verticesWithNonzeroDiff = verticesWithNonzeroDiffWrtLatent.get(ofVertex);
-        final Map<Vertex, DoubleTensor> dlogProbOfVertexWrtVertices = ((Probabilistic<T>) ofVertex).dLogProbAtValue(verticesWithNonzeroDiff);
+        final Map<Vertex, DoubleTensor> dlogProbOfVertexWrtVertices = ((Probabilistic<?>) ofVertex).dLogProbAtValue(verticesWithNonzeroDiff);
 
-        PartialDerivatives dOfWrtLatents = new PartialDerivatives(new HashMap<>());
+        PartialDerivatives dOfWrtLatentsAccumulated = new PartialDerivatives(new HashMap<>());
 
         for (Map.Entry<Vertex, DoubleTensor> dlogProbWrtVertex : dlogProbOfVertexWrtVertices.entrySet()) {
 
@@ -107,23 +137,24 @@ public class LogProbGradientCalculator {
             DoubleTensor dLogProbOfWrtVertexWithDiff = dlogProbWrtVertex.getValue();
 
             if (vertexWithDiff.equals(ofVertex)) {
-                dOfWrtLatents.putWithRespectTo(vertexWithDiff.getId(), dLogProbOfWrtVertexWithDiff);
+                dOfWrtLatentsAccumulated.putWithRespectTo(vertexWithDiff.getId(), dLogProbOfWrtVertexWithDiff);
             } else {
 
                 PartialDerivatives partialWrtVertexWithDiff = new PartialDerivatives(new HashMap<>());
-                int[] shapeOfLogProbWrtVertexWithDiff = TensorShape.prependOnes(dLogProbOfWrtVertexWithDiff.getShape(), 2);
-                partialWrtVertexWithDiff.putWithRespectTo(vertexWithDiff.getId(), dLogProbOfWrtVertexWithDiff.reshape(shapeOfLogProbWrtVertexWithDiff));
+                int[] shapeOfLogProbWrtVertexWithDiff = TensorShape.concat(Tensor.SCALAR_SHAPE, dLogProbOfWrtVertexWithDiff.getShape());
+                DoubleTensor reshapedToOfWrtPartialFormat = dLogProbOfWrtVertexWithDiff.reshape(shapeOfLogProbWrtVertexWithDiff);
+                partialWrtVertexWithDiff.putWithRespectTo(vertexWithDiff.getId(), reshapedToOfWrtPartialFormat);
 
                 PartialDerivatives dOfWrtLatentsContributionFromParent = Differentiator
                     .reverseModeAutoDiff(vertexWithDiff, partialWrtVertexWithDiff, this.parentToLatentLookup.get(vertexWithDiff))
                     .sum(true, 0, 1);
 
-                dOfWrtLatents = dOfWrtLatents.add(dOfWrtLatentsContributionFromParent);
+                dOfWrtLatentsAccumulated = dOfWrtLatentsAccumulated.add(dOfWrtLatentsContributionFromParent);
             }
 
         }
 
-        return diffOfLogProbWrt.add(dOfWrtLatents);
+        return dOfWrtLatentsAccumulated;
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
@@ -141,13 +141,10 @@ public class LogProbGradientCalculator {
             } else {
 
                 PartialDerivatives partialWrtVertexWithDiff = new PartialDerivatives(new HashMap<>());
-                int[] shapeOfLogProbWrtVertexWithDiff = TensorShape.concat(Tensor.SCALAR_SHAPE, dLogProbOfWrtVertexWithDiff.getShape());
-                DoubleTensor reshapedToOfWrtPartialFormat = dLogProbOfWrtVertexWithDiff.reshape(shapeOfLogProbWrtVertexWithDiff);
-                partialWrtVertexWithDiff.putWithRespectTo(vertexWithDiff.getId(), reshapedToOfWrtPartialFormat);
+                partialWrtVertexWithDiff.putWithRespectTo(vertexWithDiff.getId(), dLogProbOfWrtVertexWithDiff);
 
                 PartialDerivatives dOfWrtLatentsContributionFromParent = Differentiator
-                    .reverseModeAutoDiff(vertexWithDiff, partialWrtVertexWithDiff, this.parentToLatentLookup.get(vertexWithDiff))
-                    .sum(true, 0, 1);
+                    .reverseModeAutoDiff(vertexWithDiff, partialWrtVertexWithDiff, this.parentToLatentLookup.get(vertexWithDiff));
 
                 dOfWrtLatentsAccumulated = dOfWrtLatentsAccumulated.add(dOfWrtLatentsContributionFromParent);
             }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
@@ -36,7 +36,7 @@ public class LogProbGradientCalculator {
     }
 
     /**
-     * @return the partial derivatives with respect to a give set of latent vertices
+     * @return the partial derivatives with respect to a given set of latent vertices
      */
     public Map<VertexId, DoubleTensor> getJointLogProbGradientWrtLatents() {
         PartialDerivatives diffOfLogWrt = new PartialDerivatives(new HashMap<>());
@@ -49,13 +49,13 @@ public class LogProbGradientCalculator {
     }
 
     /**
-     * The Vertex::dLogProb method returns a partial derivative of the Log Prob with respect to each parent
-     * and with respect to it's own value. This method finds which one of these partials will be non-zero due to being
-     * connected to a vertex that we are taking the derivative with respect to.
+     * The dLogProb(x) method on Vertex returns a partial derivative of the Log Prob with respect to each
+     * of its arguments and with respect to its value, x. This method searches these partials for any that
+     * are parents of the vertices we are taking the derivative with respect to
      *
      * @param ofVertices          the vertices that the derivative is being calculated "of" with respect to the wrtVertices
      * @param parentToWrtVertices a lookup
-     * @return a lookup map for a given vertex to a set of the wrt vertices that it descends
+     * @return a map for a given vertex to a set of the wrt vertices that it is connected to
      */
     private Map<Vertex, Set<DoubleVertex>> getVerticesWithNonzeroDiffWrt(Set<? extends Vertex<?>> ofVertices, Map<Vertex, Set<DoubleVertex>> parentToWrtVertices) {
         return ofVertices.stream()
@@ -77,11 +77,11 @@ public class LogProbGradientCalculator {
     }
 
     /**
-     * This method finds which one of the vertex's parents are connected to a vertex that we are taking the derivative
-     * with respect to.
+     * This method finds connections between a vertex's parents and any vertices that we are taking the derivative
+     * wrt to
      *
      * @param ofVertices the vertices that the derivative is being calculated "of" with respect to the wrtVertices
-     * @return a lookup map for a given vertex to a set of vertices that are directly connected to the dLogProb result
+     * @return a map for a given vertex to a set of vertices that are directly connected to the dLogProb result
      * of the ofVertices and a vertex that we are finding the gradient with respect to.
      */
     private Map<Vertex, Set<DoubleVertex>> getParentsThatAreConnectedToWrtVertices(Set<? extends Vertex> ofVertices) {
@@ -106,7 +106,6 @@ public class LogProbGradientCalculator {
                     probabilisticParentLookup.put(parent, latentVertices);
                 }
             }
-
         }
 
         return probabilisticParentLookup;
@@ -137,6 +136,7 @@ public class LogProbGradientCalculator {
             DoubleTensor dLogProbOfWrtVertexWithDiff = dlogProbWrtVertex.getValue();
 
             if (vertexWithDiff.equals(ofVertex)) {
+
                 dOfWrtLatentsAccumulated.putWithRespectTo(vertexWithDiff.getId(), dLogProbOfWrtVertexWithDiff);
             } else {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
@@ -10,8 +10,6 @@ import java.util.stream.Collectors;
 import com.google.common.base.Preconditions;
 
 import io.improbable.keanu.network.LambdaSection;
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
@@ -98,7 +96,7 @@ public class LogProbGradientCalculator {
 
                 Set<Vertex> latentAndObservedVertices = upstreamLambdaSection.getLatentAndObservedVertices();
                 Set<DoubleVertex> latentVertices = latentAndObservedVertices.stream()
-                    .filter(this::isLatentDoubleVertex)
+                    .filter(this::isLatentDoubleVertexAndInWrtTo)
                     .map(v -> (DoubleVertex) v)
                     .collect(Collectors.toSet());
 
@@ -111,12 +109,12 @@ public class LogProbGradientCalculator {
         return probabilisticParentLookup;
     }
 
-    private boolean isLatentDoubleVertex(Vertex v) {
+    private boolean isLatentDoubleVertexAndInWrtTo(Vertex v) {
         return !v.isObserved() && wrtVertices.contains(v) && v instanceof DoubleVertex;
     }
 
     /**
-     * @param ofVertex starting point for reverse mode autodiff
+     * @param ofVertex the vertex we are taking the derivative of
      * @return partial derivatives of the "ofVertex" wrt to any "this.wrtVertices" that it descends.
      */
     private PartialDerivatives reverseModeLogProbGradientWrtLatents(final Vertex ofVertex) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -244,13 +244,14 @@ public class PartialDerivatives {
             int[] partialWrtShape = extractWrtShape(partial.getShape(), multiplier.getRank());
             int[] resultShape = TensorShape.concat(multiplier.getShape(), partialWrtShape);
 
-            return DoubleTensor.ones(resultShape).times(partial)
-                .times(multiplierFromLeft);
+            return DoubleTensor.ones(resultShape).times(partial).times(multiplierFromLeft);
         }
-                return partial.times(multiplierFromLeft);
+
+        return partial.times(multiplierFromLeft);
     }
 
-    private DoubleTensor elementWiseMultiplyAlongWrt(DoubleTensor partial, DoubleTensor multiplier){
+    private DoubleTensor elementWiseMultiplyAlongWrt(DoubleTensor partial, DoubleTensor multiplier) {
+
         int[] partialWrtShape = extractWrtShape(partial.getShape(), multiplier.getRank());
         if (TensorShape.isScalar(partialWrtShape)) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
@@ -14,40 +14,40 @@ public class ArcTan2Vertex extends DoubleBinaryOpVertex {
     /**
      * Calculates the signed angle, in radians, between the positive x-axis and a ray to the point (x, y) from the origin
      *
-     * @param left  x coordinate
-     * @param right y coordinate
+     * @param x x coordinate
+     * @param y y coordinate
      */
-    public ArcTan2Vertex(DoubleVertex left, DoubleVertex right) {
-        super(left, right);
+    public ArcTan2Vertex(DoubleVertex x, DoubleVertex y) {
+        super(x, y);
     }
 
     @Override
-    protected DoubleTensor op(DoubleTensor l, DoubleTensor r) {
-        return l.atan2(r);
+    protected DoubleTensor op(DoubleTensor x, DoubleTensor y) {
+        return x.atan2(y);
     }
 
     @Override
-    protected DualNumber dualOp(DualNumber a, DualNumber b) {
-        DoubleTensor denominator = ((b.getValue().pow(2)).plusInPlace((a.getValue().pow(2))));
+    protected DualNumber dualOp(DualNumber x, DualNumber y) {
+        DoubleTensor denominator = ((y.getValue().pow(2)).plusInPlace((x.getValue().pow(2))));
 
-        PartialDerivatives thisInfA = a.getPartialDerivatives().multiplyBy(b.getValue().div(denominator));
-        PartialDerivatives thisInfB = b.getPartialDerivatives().multiplyBy((a.getValue().div(denominator)).unaryMinusInPlace());
-        PartialDerivatives newInf = thisInfA.add(thisInfB);
-        return new DualNumber(a.getValue().atan2(b.getValue()), newInf);
+        PartialDerivatives thisInfX = x.getPartialDerivatives().multiplyBy((y.getValue().div(denominator)).unaryMinusInPlace());
+        PartialDerivatives thisInfY = y.getPartialDerivatives().multiplyBy(x.getValue().div(denominator));
+        PartialDerivatives newInf = thisInfX.add(thisInfY);
+        return new DualNumber(x.getValue().atan2(y.getValue()), newInf);
     }
 
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        DoubleTensor leftValue = left.getValue();
-        DoubleTensor rightValue = right.getValue();
+        DoubleTensor xValue = left.getValue();
+        DoubleTensor yValue = right.getValue();
 
-        DoubleTensor denominator = rightValue.pow(2).plusInPlace(leftValue.pow(2));
-        DoubleTensor dOutWrtLeft = rightValue.divInPlace(denominator);
-        DoubleTensor dOutWrtRight = leftValue.div(denominator).unaryMinusInPlace();
+        DoubleTensor denominator = yValue.pow(2).plusInPlace(xValue.pow(2));
+        DoubleTensor dOutWrtX = yValue.div(denominator).unaryMinusInPlace();
+        DoubleTensor dOutWrtY = xValue.div(denominator);
 
-        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtLeft));
-        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtRight));
+        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtX, true));
+        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtY, true));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
@@ -32,8 +32,8 @@ public class DivisionVertex extends DoubleBinaryOpVertex {
         DoubleTensor rightValue = right.getValue();
         DoubleTensor dOutWrtLeft = rightValue.reciprocal();
         DoubleTensor dOutWrtRight = leftValue.div(rightValue.pow(2.0)).unaryMinusInPlace();
-        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtLeft));
-        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtRight));
+        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtLeft, true));
+        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtRight, true));
         return partials;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
@@ -39,8 +39,8 @@ public class PowerVertex extends DoubleBinaryOpVertex {
         DoubleTensor leftPowRight = getValue();
         DoubleTensor dOutWrtLeft = rightValue.div(leftValue).timesInPlace(leftPowRight);
         DoubleTensor dOutWrtRight = leftPowRight.times(leftValue.log());
-        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtLeft));
-        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtRight));
+        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtLeft, true));
+        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtRight, true));
         return partials;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
@@ -40,7 +40,7 @@ public class ArcCosVertex extends DoubleUnaryOpVertex {
             .unaryMinusInPlace();
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput, true));
 
         return partials;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
@@ -40,7 +40,7 @@ public class ArcSinVertex extends DoubleUnaryOpVertex {
             .reciprocalInPlace();
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput, true));
 
         return partials;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
@@ -38,7 +38,7 @@ public class ArcTanVertex extends DoubleUnaryOpVertex {
         DoubleTensor dSelfWrtInput = inputValue.pow(2).plusInPlace(1).reciprocalInPlace();
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput, true));
 
         return partials;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
@@ -33,7 +33,7 @@ public class CosVertex extends DoubleUnaryOpVertex {
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().sin().unaryMinusInPlace()));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().sin().unaryMinusInPlace(), true));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
@@ -33,7 +33,7 @@ public class ExpVertex extends DoubleUnaryOpVertex {
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(getValue()));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(getValue(), true));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
@@ -33,7 +33,7 @@ public class LogVertex extends DoubleUnaryOpVertex {
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().reciprocal()));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().reciprocal(), true));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
@@ -42,7 +42,7 @@ public class SigmoidVertex extends DoubleUnaryOpVertex {
         DoubleTensor derivativeOfSigmoidWrtInput = sigmoidOfInput.minus(sigmoidOfInput.pow(2));
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(derivativeOfSigmoidWrtInput));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(derivativeOfSigmoidWrtInput, true));
         return partials;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
@@ -33,7 +33,7 @@ public class SinVertex extends DoubleUnaryOpVertex {
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().cos()));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().cos(), true));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
@@ -36,7 +36,7 @@ public class TanVertex extends DoubleUnaryOpVertex {
         DoubleTensor dTandInput = inputVertex.getValue().cos().powInPlace(2).reciprocalInPlace();
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dTandInput));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dTandInput, true));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -2,8 +2,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import static io.improbable.keanu.distributions.dual.Diffs.A;
 import static io.improbable.keanu.distributions.dual.Diffs.B;
-import static io.improbable.keanu.distributions.dual.Diffs.MU;
-import static io.improbable.keanu.distributions.dual.Diffs.SIGMA;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
@@ -95,21 +93,21 @@ public class BetaVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = distribution().dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(alpha)) {
-            dLogProbWrtParameters.put(alpha.getId(), dlnP.get(A).getValue());
+            dLogProbWrtParameters.put(alpha, dlnP.get(A).getValue());
         }
 
         if (withRespectTo.contains(beta)) {
-            dLogProbWrtParameters.put(beta.getId(), dlnP.get(B).getValue());
+            dLogProbWrtParameters.put(beta, dlnP.get(B).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;
@@ -118,8 +116,8 @@ public class BetaVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdalpha,
-                                                             DoubleTensor dLogPdbeta,
-                                                             DoubleTensor dLogPdx) {
+                                                                 DoubleTensor dLogPdbeta,
+                                                                 DoubleTensor dLogPdx) {
         PartialDerivatives dLogPdInputsFromAlpha = alpha.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdalpha);
         PartialDerivatives dLogPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdbeta);
         PartialDerivatives dLogPdInputs = dLogPdInputsFromAlpha.add(dLogPdInputsFromBeta);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.A;
 import static io.improbable.keanu.distributions.dual.Diffs.B;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -14,14 +13,11 @@ import java.util.Set;
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.Beta;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class BetaVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -111,25 +107,6 @@ public class BetaVertex extends DoubleVertex implements ProbabilisticDouble {
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(A).getValue(), dlnP.get(B).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdalpha,
-                                                                 DoubleTensor dLogPdbeta,
-                                                                 DoubleTensor dLogPdx) {
-        PartialDerivatives dLogPdInputsFromAlpha = alpha.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdalpha);
-        PartialDerivatives dLogPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdbeta);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromAlpha.add(dLogPdInputsFromBeta);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
@@ -94,21 +94,21 @@ public class CauchyVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = Cauchy.withParameters(location.getValue(), scale.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(location)) {
-            dLogProbWrtParameters.put(location.getId(), dlnP.get(L).getValue());
+            dLogProbWrtParameters.put(location, dlnP.get(L).getValue());
         }
 
         if (withRespectTo.contains(scale)) {
-            dLogProbWrtParameters.put(scale.getId(), dlnP.get(S).getValue());
+            dLogProbWrtParameters.put(scale, dlnP.get(S).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.L;
 import static io.improbable.keanu.distributions.dual.Diffs.S;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -13,14 +12,11 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Cauchy;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class CauchyVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -112,26 +108,6 @@ public class CauchyVertex extends DoubleVertex implements ProbabilisticDouble {
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(L).getValue(), dlnP.get(S).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlocation,
-                                                                 DoubleTensor dLogPdscale,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputsFromLocation = location.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlocation);
-        PartialDerivatives dLogPdInputsFromScale = scale.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdscale);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromLocation.add(dLogPdInputsFromScale);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -10,7 +10,6 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -65,7 +64,7 @@ public class ChiSquaredVertex extends DoubleVertex implements ProbabilisticDoubl
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -3,11 +3,13 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.ChiSquared;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -63,7 +65,7 @@ public class ChiSquaredVertex extends DoubleVertex implements ProbabilisticDoubl
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
@@ -2,7 +2,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import static io.improbable.keanu.distributions.dual.Diffs.C;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,14 +9,11 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Dirichlet;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -88,28 +84,10 @@ public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(C).getValue(), dlnP.get(X).getValue());
     }
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
         return Dirichlet.withParameters(concentration.getValue()).sample(getShape(), random);
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdc,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputs = concentration.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdc);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-
-        return summed.asMap();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
@@ -1,15 +1,20 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
+import static io.improbable.keanu.distributions.dual.Diffs.A;
+import static io.improbable.keanu.distributions.dual.Diffs.B;
 import static io.improbable.keanu.distributions.dual.Diffs.C;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Dirichlet;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -71,9 +76,22 @@ public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
         Diffs dlnP = Dirichlet.withParameters(concentration.getValue()).dLogProb(value);
-        return convertDualNumbersToDiff(dlnP.get(C).getValue(), dlnP.get(X).getValue());
+
+        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+
+        if (withRespectTo.contains(concentration)) {
+            dLogProbWrtParameters.put(concentration.getId(), dlnP.get(C).getValue());
+        }
+
+        if (withRespectTo.contains(this)) {
+            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+        }
+
+        return dLogProbWrtParameters;
+
+//        return convertDualNumbersToDiff(dlnP.get(C).getValue(), dlnP.get(X).getValue());
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
@@ -1,7 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.dual.Diffs.A;
-import static io.improbable.keanu.distributions.dual.Diffs.B;
 import static io.improbable.keanu.distributions.dual.Diffs.C;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
@@ -76,17 +74,17 @@ public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = Dirichlet.withParameters(concentration.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(concentration)) {
-            dLogProbWrtParameters.put(concentration.getId(), dlnP.get(C).getValue());
+            dLogProbWrtParameters.put(concentration, dlnP.get(C).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;
@@ -100,7 +98,7 @@ public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble
     }
 
     private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdc,
-                                                             DoubleTensor dLogPdx) {
+                                                                 DoubleTensor dLogPdx) {
 
         PartialDerivatives dLogPdInputs = concentration.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdc);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -2,7 +2,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import static io.improbable.keanu.distributions.dual.Diffs.LAMBDA;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -12,14 +11,11 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Exponential;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class ExponentialVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -83,23 +79,6 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(LAMBDA).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlambda,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputs = lambda.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlambda);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -1,7 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.dual.Diffs.A;
-import static io.improbable.keanu.distributions.dual.Diffs.B;
 import static io.improbable.keanu.distributions.dual.Diffs.LAMBDA;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
@@ -71,17 +69,17 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = Exponential.withParameters(lambda.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(lambda)) {
-            dLogProbWrtParameters.put(lambda.getId(), dlnP.get(LAMBDA).getValue());
+            dLogProbWrtParameters.put(lambda, dlnP.get(LAMBDA).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;
@@ -90,7 +88,7 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
     }
 
     private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdlambda,
-                                                             DoubleTensor dLogPdx) {
+                                                                 DoubleTensor dLogPdx) {
 
         PartialDerivatives dLogPdInputs = lambda.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdlambda);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -78,21 +78,21 @@ public class GammaVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = Gamma.withParameters(theta.getValue(), k.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(theta)) {
-            dLogProbWrtParameters.put(theta.getId(), dlnP.get(THETA).getValue());
+            dLogProbWrtParameters.put(theta, dlnP.get(THETA).getValue());
         }
 
         if (withRespectTo.contains(k)) {
-            dLogProbWrtParameters.put(k.getId(), dlnP.get(K).getValue());
+            dLogProbWrtParameters.put(k, dlnP.get(K).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -7,12 +7,15 @@ import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrepend
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Gamma;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -75,10 +78,26 @@ public class GammaVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
         Diffs dlnP = Gamma.withParameters(theta.getValue(), k.getValue()).dLogProb(value);
 
-        return convertDualNumbersToDiff(dlnP.get(THETA).getValue(), dlnP.get(K).getValue(), dlnP.get(X).getValue());
+        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+
+        if (withRespectTo.contains(theta)) {
+            dLogProbWrtParameters.put(theta.getId(), dlnP.get(THETA).getValue());
+        }
+
+        if (withRespectTo.contains(k)) {
+            dLogProbWrtParameters.put(k.getId(), dlnP.get(K).getValue());
+        }
+
+        if (withRespectTo.contains(this)) {
+            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+        }
+
+        return dLogProbWrtParameters;
+
+//        return convertDualNumbersToDiff(dlnP.get(THETA).getValue(), dlnP.get(K).getValue(), dlnP.get(X).getValue());
     }
 
     private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdtheta,

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.K;
 import static io.improbable.keanu.distributions.dual.Diffs.THETA;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -13,14 +12,11 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Gamma;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class GammaVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -96,26 +92,6 @@ public class GammaVertex extends DoubleVertex implements ProbabilisticDouble {
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(THETA).getValue(), dlnP.get(K).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdtheta,
-                                                                 DoubleTensor dLogPdk,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputsFromTheta = theta.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdtheta);
-        PartialDerivatives dLogPdInputsFromK = k.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdk);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromTheta.add(dLogPdInputsFromK);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -95,21 +95,21 @@ public class GaussianVertex extends DoubleVertex implements ProbabilisticDouble 
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = Gaussian.withParameters(mu.getValue(), sigma.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(mu)) {
-            dLogProbWrtParameters.put(mu.getId(), dlnP.get(MU).getValue());
+            dLogProbWrtParameters.put(mu, dlnP.get(MU).getValue());
         }
 
         if (withRespectTo.contains(sigma)) {
-            dLogProbWrtParameters.put(sigma.getId(), dlnP.get(SIGMA).getValue());
+            dLogProbWrtParameters.put(sigma, dlnP.get(SIGMA).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.MU;
 import static io.improbable.keanu.distributions.dual.Diffs.SIGMA;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -13,15 +12,12 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Gaussian;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class GaussianVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -113,27 +109,6 @@ public class GaussianVertex extends DoubleVertex implements ProbabilisticDouble 
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(SIGMA).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
-                                                                 DoubleTensor dLogPdsigma,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdmu);
-        PartialDerivatives dLogPdInputsFromSigma = sigma.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdsigma);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromSigma);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.A;
 import static io.improbable.keanu.distributions.dual.Diffs.B;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -13,14 +12,11 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.InverseGamma;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class InverseGammaVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -109,26 +105,6 @@ public class InverseGammaVertex extends DoubleVertex implements ProbabilisticDou
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(A).getValue(), dlnP.get(B).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdalpha,
-                                                                 DoubleTensor dLogPdbeta,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputsFromAlpha = alpha.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdalpha);
-        PartialDerivatives dLogPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdbeta);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromAlpha.add(dLogPdInputsFromBeta);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -91,21 +91,21 @@ public class InverseGammaVertex extends DoubleVertex implements ProbabilisticDou
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = InverseGamma.withParameters(alpha.getValue(), beta.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(alpha)) {
-            dLogProbWrtParameters.put(alpha.getId(), dlnP.get(A).getValue());
+            dLogProbWrtParameters.put(alpha, dlnP.get(A).getValue());
         }
 
         if (withRespectTo.contains(beta)) {
-            dLogProbWrtParameters.put(beta.getId(), dlnP.get(B).getValue());
+            dLogProbWrtParameters.put(beta, dlnP.get(B).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
@@ -3,9 +3,11 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -55,12 +57,14 @@ public class KDEVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
         Map<VertexId, DoubleTensor> partialDerivatives = new HashMap<>();
 
-        DoubleTensor dlnPdfs = dPdx(value).divInPlace(pdf(value));
+        if(withRespectTo.contains(this)) {
+            DoubleTensor dlnPdfs = dPdx(value).divInPlace(pdf(value));
+            partialDerivatives.put(getId(), dlnPdfs);
+        }
 
-        partialDerivatives.put(getId(), dlnPdfs);
         return partialDerivatives;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -57,12 +56,12 @@ public class KDEVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
-        Map<VertexId, DoubleTensor> partialDerivatives = new HashMap<>();
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
+        Map<Vertex, DoubleTensor> partialDerivatives = new HashMap<>();
 
-        if(withRespectTo.contains(this)) {
+        if (withRespectTo.contains(this)) {
             DoubleTensor dlnPdfs = dPdx(value).divInPlace(pdf(value));
-            partialDerivatives.put(getId(), dlnPdfs);
+            partialDerivatives.put(this, dlnPdfs);
         }
 
         return partialDerivatives;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.BETA;
 import static io.improbable.keanu.distributions.dual.Diffs.MU;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -13,14 +12,11 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Laplace;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class LaplaceVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -99,26 +95,6 @@ public class LaplaceVertex extends DoubleVertex implements ProbabilisticDouble {
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(BETA).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
-                                                                 DoubleTensor dLogPdbeta,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdmu);
-        PartialDerivatives dLogPdInputsFromBeta = beta.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdbeta);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromBeta);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -81,21 +81,21 @@ public class LaplaceVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = Laplace.withParameters(mu.getValue(), beta.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(mu)) {
-            dLogProbWrtParameters.put(mu.getId(), dlnP.get(MU).getValue());
+            dLogProbWrtParameters.put(mu, dlnP.get(MU).getValue());
         }
 
         if (withRespectTo.contains(beta)) {
-            dLogProbWrtParameters.put(beta.getId(), dlnP.get(BETA).getValue());
+            dLogProbWrtParameters.put(beta, dlnP.get(BETA).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.MU;
 import static io.improbable.keanu.distributions.dual.Diffs.SIGMA;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -13,14 +12,11 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.LogNormal;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class LogNormalVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -103,26 +99,6 @@ public class LogNormalVertex extends DoubleVertex implements ProbabilisticDouble
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(SIGMA).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
-                                                                 DoubleTensor dLogPdsigma,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdmu);
-        PartialDerivatives dLogPdInputsFromSigma = sigma.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdsigma);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromSigma);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -85,21 +85,21 @@ public class LogNormalVertex extends DoubleVertex implements ProbabilisticDouble
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = LogNormal.withParameters(mu.getValue(), sigma.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(mu)) {
-            dLogProbWrtParameters.put(mu.getId(), dlnP.get(MU).getValue());
+            dLogProbWrtParameters.put(mu, dlnP.get(MU).getValue());
         }
 
         if (withRespectTo.contains(sigma)) {
-            dLogProbWrtParameters.put(sigma.getId(), dlnP.get(SIGMA).getValue());
+            dLogProbWrtParameters.put(sigma, dlnP.get(SIGMA).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.MU;
 import static io.improbable.keanu.distributions.dual.Diffs.S;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -13,14 +12,11 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Logistic;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class LogisticVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -91,26 +87,6 @@ public class LogisticVertex extends DoubleVertex implements ProbabilisticDouble 
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(S).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
-                                                                 DoubleTensor dLogPds,
-                                                                 DoubleTensor dLogPdx) {
-
-        PartialDerivatives dLogPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdmu);
-        PartialDerivatives dLogPdInputsFromS = s.getDualNumber().getPartialDerivatives().multiplyBy(dLogPds);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromMu.add(dLogPdInputsFromS);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdx.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdx.getShape(), dLogPdx.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -73,21 +73,21 @@ public class LogisticVertex extends DoubleVertex implements ProbabilisticDouble 
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = Logistic.withParameters(mu.getValue(), s.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(mu)) {
-            dLogProbWrtParameters.put(mu.getId(), dlnP.get(MU).getValue());
+            dLogProbWrtParameters.put(mu, dlnP.get(MU).getValue());
         }
 
         if (withRespectTo.contains(s)) {
-            dLogProbWrtParameters.put(s.getId(), dlnP.get(S).getValue());
+            dLogProbWrtParameters.put(s, dlnP.get(S).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -7,12 +7,15 @@ import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrepend
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Logistic;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -70,14 +73,31 @@ public class LogisticVertex extends DoubleVertex implements ProbabilisticDouble 
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
         Diffs dlnP = Logistic.withParameters(mu.getValue(), s.getValue()).dLogProb(value);
-        return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(S).getValue(), dlnP.get(X).getValue());
+
+        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+
+        if (withRespectTo.contains(mu)) {
+            dLogProbWrtParameters.put(mu.getId(), dlnP.get(MU).getValue());
+        }
+
+        if (withRespectTo.contains(s)) {
+            dLogProbWrtParameters.put(s.getId(), dlnP.get(S).getValue());
+        }
+
+        if (withRespectTo.contains(this)) {
+            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+        }
+
+        return dLogProbWrtParameters;
+
+//        return convertDualNumbersToDiff(dlnP.get(MU).getValue(), dlnP.get(S).getValue(), dlnP.get(X).getValue());
     }
 
     private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdmu,
-                                                             DoubleTensor dLogPds,
-                                                             DoubleTensor dLogPdx) {
+                                                                 DoubleTensor dLogPds,
+                                                                 DoubleTensor dLogPdx) {
 
         PartialDerivatives dLogPdInputsFromMu = mu.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdmu);
         PartialDerivatives dLogPdInputsFromS = s.getDualNumber().getPartialDerivatives().multiplyBy(dLogPds);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -1,10 +1,12 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.MultivariateGaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -68,7 +70,7 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Probabil
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -7,7 +7,6 @@ import io.improbable.keanu.distributions.continuous.MultivariateGaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -70,7 +69,7 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Probabil
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
@@ -93,21 +93,21 @@ public class ParetoVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         Diffs dlnP = Pareto.withParameters(location.getValue(), scale.getValue()).dLogProb(value);
 
-        Map<VertexId, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
+        Map<Vertex, DoubleTensor> dLogProbWrtParameters = new HashMap<>();
 
         if (withRespectTo.contains(location)) {
-            dLogProbWrtParameters.put(location.getId(), dlnP.get(L).getValue());
+            dLogProbWrtParameters.put(location, dlnP.get(L).getValue());
         }
 
         if (withRespectTo.contains(scale)) {
-            dLogProbWrtParameters.put(scale.getId(), dlnP.get(S).getValue());
+            dLogProbWrtParameters.put(scale, dlnP.get(S).getValue());
         }
 
         if (withRespectTo.contains(this)) {
-            dLogProbWrtParameters.put(this.getId(), dlnP.get(X).getValue());
+            dLogProbWrtParameters.put(this, dlnP.get(X).getValue());
         }
 
         return dLogProbWrtParameters;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
@@ -3,7 +3,6 @@ package io.improbable.keanu.vertices.dbl.probabilistic;
 import static io.improbable.keanu.distributions.dual.Diffs.L;
 import static io.improbable.keanu.distributions.dual.Diffs.S;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
@@ -13,15 +12,12 @@ import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Pareto;
 import io.improbable.keanu.distributions.dual.Diffs;
-import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class ParetoVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -111,27 +107,6 @@ public class ParetoVertex extends DoubleVertex implements ProbabilisticDouble {
         }
 
         return dLogProbWrtParameters;
-
-//        return convertDualNumbersToDiff(dlnP.get(L).getValue(), dlnP.get(S).getValue(), dlnP.get(X).getValue());
-    }
-
-    private Map<VertexId, DoubleTensor> convertDualNumbersToDiff(DoubleTensor dLogPdLocation,
-                                                                 DoubleTensor dLogPdScale,
-                                                                 DoubleTensor dLogPdX) {
-
-        PartialDerivatives dLogPdInputsFromLocation = location.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdLocation);
-        PartialDerivatives dLogPdInputsFromScale = scale.getDualNumber().getPartialDerivatives().multiplyBy(dLogPdScale);
-        PartialDerivatives dLogPdInputs = dLogPdInputsFromLocation.add(dLogPdInputsFromScale);
-
-        if (!this.isObserved()) {
-            dLogPdInputs.putWithRespectTo(getId(), dLogPdX.reshape(
-                shapeToDesiredRankByPrependingOnes(dLogPdX.getShape(), dLogPdX.getRank() + getValue().getRank()))
-            );
-        }
-
-        PartialDerivatives summed = dLogPdInputs.sum(true, TensorShape.dimensionRange(0, getShape().length));
-
-        return summed.asMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -39,9 +39,6 @@ public interface ProbabilisticDouble extends Probabilistic<DoubleTensor> {
     }
 
     default Map<Vertex, DoubleTensor> dLogPdf(DoubleTensor value, Set<Vertex> withRespectTo) {
-        if (withRespectTo.isEmpty()) {
-            throw new IllegalArgumentException("Must take dLogPdf wrt something");
-        }
         return dLogProb(value, withRespectTo);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -1,9 +1,13 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticDouble extends Probabilistic<DoubleTensor> {
@@ -19,15 +23,30 @@ public interface ProbabilisticDouble extends Probabilistic<DoubleTensor> {
         return logProb(value);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPdf(double value) {
-        return dLogPdf(DoubleTensor.scalar(value));
+    default Map<VertexId, DoubleTensor> dLogPdf(double value, Set<Vertex> withRespectTo) {
+        return dLogPdf(DoubleTensor.scalar(value), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPdf(double[] values) {
-        return dLogPdf(DoubleTensor.create(values));
+    default Map<VertexId, DoubleTensor> dLogPdf(double value, Vertex... withRespectTo) {
+        return dLogPdf(DoubleTensor.scalar(value), new HashSet<>(Arrays.asList(withRespectTo)));
     }
 
-    default Map<VertexId,DoubleTensor> dLogPdf(DoubleTensor value) {
-        return dLogProb(value);
+    default Map<VertexId, DoubleTensor> dLogPdf(double[] values, Set<Vertex> withRespectTo) {
+        return dLogPdf(DoubleTensor.create(values), withRespectTo);
+    }
+
+    default Map<VertexId, DoubleTensor> dLogPdf(double[] values, Vertex... withRespectTo) {
+        return dLogPdf(DoubleTensor.create(values), new HashSet<>(Arrays.asList(withRespectTo)));
+    }
+
+    default Map<VertexId, DoubleTensor> dLogPdf(DoubleTensor value, Set<Vertex> withRespectTo) {
+        if (withRespectTo.isEmpty()) {
+            throw new IllegalArgumentException("Must take dLogPdf wrt something");
+        }
+        return dLogProb(value, withRespectTo);
+    }
+
+    default Map<VertexId, DoubleTensor> dLogPdf(DoubleTensor value, Vertex... withRespectTo) {
+        return dLogPdf(value, new HashSet<>(Arrays.asList(withRespectTo)));
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticDouble extends Probabilistic<DoubleTensor> {
     default double logPdf(double value) {
@@ -23,30 +22,30 @@ public interface ProbabilisticDouble extends Probabilistic<DoubleTensor> {
         return logProb(value);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPdf(double value, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPdf(double value, Set<Vertex> withRespectTo) {
         return dLogPdf(DoubleTensor.scalar(value), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPdf(double value, Vertex... withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPdf(double value, Vertex... withRespectTo) {
         return dLogPdf(DoubleTensor.scalar(value), new HashSet<>(Arrays.asList(withRespectTo)));
     }
 
-    default Map<VertexId, DoubleTensor> dLogPdf(double[] values, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPdf(double[] values, Set<Vertex> withRespectTo) {
         return dLogPdf(DoubleTensor.create(values), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPdf(double[] values, Vertex... withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPdf(double[] values, Vertex... withRespectTo) {
         return dLogPdf(DoubleTensor.create(values), new HashSet<>(Arrays.asList(withRespectTo)));
     }
 
-    default Map<VertexId, DoubleTensor> dLogPdf(DoubleTensor value, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPdf(DoubleTensor value, Set<Vertex> withRespectTo) {
         if (withRespectTo.isEmpty()) {
             throw new IllegalArgumentException("Must take dLogPdf wrt something");
         }
         return dLogProb(value, withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPdf(DoubleTensor value, Vertex... withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPdf(DoubleTensor value, Vertex... withRespectTo) {
         return dLogPdf(value, new HashSet<>(Arrays.asList(withRespectTo)));
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -14,7 +14,6 @@ import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.SmoothUniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -125,7 +124,7 @@ public class SmoothUniformVertex extends DoubleVertex implements ProbabilisticDo
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
 
         if (withRespectTo.contains(this)) {
             final DoubleTensor min = xMin.getValue();
@@ -134,7 +133,7 @@ public class SmoothUniformVertex extends DoubleVertex implements ProbabilisticDo
             final DoubleTensor dPdx = distribution.dLogProb(value).get(X).getValue();
             final DoubleTensor density = distribution.logProb(value);
             final DoubleTensor dLogPdx = dPdx.divInPlace(density);
-            return singletonMap(getId(), dLogPdx);
+            return singletonMap(this, dLogPdx);
         }
 
         return Collections.emptyMap();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -6,11 +6,14 @@ import static io.improbable.keanu.distributions.dual.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.SmoothUniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -122,15 +125,19 @@ public class SmoothUniformVertex extends DoubleVertex implements ProbabilisticDo
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
-        final DoubleTensor min = xMin.getValue();
-        final DoubleTensor max = xMax.getValue();
-        ContinuousDistribution distribution = SmoothUniform.withParameters(min, max, this.edgeSharpness);
-        final DoubleTensor dPdx = distribution.dLogProb(value).get(X).getValue();
-        final DoubleTensor density = distribution.logProb(value);
-        final DoubleTensor dLogPdx = dPdx.divInPlace(density);
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
 
-        return singletonMap(getId(), dLogPdx);
+        if (withRespectTo.contains(this)) {
+            final DoubleTensor min = xMin.getValue();
+            final DoubleTensor max = xMax.getValue();
+            ContinuousDistribution distribution = SmoothUniform.withParameters(min, max, this.edgeSharpness);
+            final DoubleTensor dPdx = distribution.dLogProb(value).get(X).getValue();
+            final DoubleTensor density = distribution.logProb(value);
+            final DoubleTensor dLogPdx = dPdx.divInPlace(density);
+            return singletonMap(getId(), dLogPdx);
+        }
+
+        return Collections.emptyMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -5,11 +5,13 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatch
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.StudentT;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -57,10 +59,14 @@ public class StudentTVertex extends DoubleVertex implements ProbabilisticDouble 
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor t) {
-        Diffs diff = StudentT.withParameters(v.getValue()).dLogProb(t);
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor t, Set<Vertex> withRespect) {
         Map<VertexId, DoubleTensor> m = new HashMap<>();
-        m.put(getId(), diff.get(T).getValue());
+
+        if (withRespect.contains(this)) {
+            Diffs diff = StudentT.withParameters(v.getValue()).dLogProb(t);
+            m.put(getId(), diff.get(T).getValue());
+        }
+
         return m;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -12,7 +12,6 @@ import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -59,12 +58,12 @@ public class StudentTVertex extends DoubleVertex implements ProbabilisticDouble 
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor t, Set<Vertex> withRespect) {
-        Map<VertexId, DoubleTensor> m = new HashMap<>();
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor t, Set<? extends Vertex> withRespect) {
+        Map<Vertex, DoubleTensor> m = new HashMap<>();
 
         if (withRespect.contains(this)) {
             Diffs diff = StudentT.withParameters(v.getValue()).dLogProb(t);
-            m.put(getId(), diff.get(T).getValue());
+            m.put(this, diff.get(T).getValue());
         }
 
         return m;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import io.improbable.keanu.distributions.continuous.Triangular;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -111,7 +110,7 @@ public class TriangularVertex extends DoubleVertex implements ProbabilisticDoubl
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -4,9 +4,11 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNon
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Triangular;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -109,7 +111,7 @@ public class TriangularVertex extends DoubleVertex implements ProbabilisticDoubl
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -5,10 +5,13 @@ import static java.util.Collections.singletonMap;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -87,12 +90,17 @@ public class UniformVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value) {
-        DoubleTensor dLogPdx = DoubleTensor.zeros(this.xMax.getShape());
-        dLogPdx = dLogPdx.setWithMaskInPlace(value.getGreaterThanMask(xMax.getValue()), Double.NEGATIVE_INFINITY);
-        dLogPdx = dLogPdx.setWithMaskInPlace(value.getLessThanOrEqualToMask(xMin.getValue()), Double.POSITIVE_INFINITY);
+    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
 
-        return singletonMap(getId(), dLogPdx);
+        if (withRespectTo.contains(this)) {
+            DoubleTensor dLogPdx = DoubleTensor.zeros(this.xMax.getShape());
+            dLogPdx = dLogPdx.setWithMaskInPlace(value.getGreaterThanMask(xMax.getValue()), Double.NEGATIVE_INFINITY);
+            dLogPdx = dLogPdx.setWithMaskInPlace(value.getLessThanOrEqualToMask(xMin.getValue()), Double.POSITIVE_INFINITY);
+
+            return singletonMap(getId(), dLogPdx);
+        }
+
+        return Collections.emptyMap();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -90,14 +89,14 @@ public class UniformVertex extends DoubleVertex implements ProbabilisticDouble {
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(DoubleTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
 
         if (withRespectTo.contains(this)) {
             DoubleTensor dLogPdx = DoubleTensor.zeros(this.xMax.getShape());
             dLogPdx = dLogPdx.setWithMaskInPlace(value.getGreaterThanMask(xMax.getValue()), Double.NEGATIVE_INFINITY);
             dLogPdx = dLogPdx.setWithMaskInPlace(value.getLessThanOrEqualToMask(xMin.getValue()), Double.POSITIVE_INFINITY);
 
-            return singletonMap(getId(), dLogPdx);
+            return singletonMap(this, dLogPdx);
         }
 
         return Collections.emptyMap();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toMap;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.discrete.Categorical;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -53,7 +54,7 @@ public class CategoricalVertex<T> extends Vertex<T> implements Probabilistic<T> 
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(T value) {
+    public Map<VertexId, DoubleTensor> dLogProb(T value, Set<Vertex> withRespectTo) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
@@ -12,7 +12,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -54,7 +53,7 @@ public class CategoricalVertex<T> extends Vertex<T> implements Probabilistic<T> 
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(T value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(T value, Set<? extends Vertex> withRespectTo) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
@@ -12,7 +12,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -66,7 +65,7 @@ public class BinomialVertex extends IntegerVertex implements ProbabilisticIntege
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(IntegerTensor value, Set<? extends Vertex> withRespectTo) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
@@ -5,11 +5,13 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatch
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.discrete.Binomial;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -64,7 +66,7 @@ public class BinomialVertex extends IntegerVertex implements ProbabilisticIntege
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value, Set<Vertex> withRespectTo) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertex.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.intgr.probabilistic;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -10,6 +11,7 @@ import io.improbable.keanu.distributions.discrete.Multinomial;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -47,7 +49,7 @@ public class MultinomialVertex extends IntegerVertex implements ProbabilisticInt
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value, Set<Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertex.java
@@ -12,7 +12,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -39,6 +38,7 @@ public class MultinomialVertex extends IntegerVertex implements ProbabilisticInt
     public MultinomialVertex(IntegerVertex n, DoubleVertex p) {
         this(n.getShape(), n, p);
     }
+
     public MultinomialVertex(int n, DoubleVertex p) {
         this(ConstantVertex.of(n), p);
     }
@@ -49,7 +49,7 @@ public class MultinomialVertex extends IntegerVertex implements ProbabilisticInt
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(IntegerTensor value, Set<? extends Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -4,6 +4,7 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatch
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.discrete.Poisson;
 import io.improbable.keanu.tensor.NumberTensor;
@@ -71,7 +72,7 @@ public class PoissonVertex extends IntegerVertex implements ProbabilisticInteger
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value, Set<Vertex> withRespectTo) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -12,7 +12,6 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.CastDoubleVertex;
@@ -72,7 +71,7 @@ public class PoissonVertex extends IntegerVertex implements ProbabilisticInteger
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(IntegerTensor value, Set<? extends Vertex> withRespectTo) {
         return Collections.emptyMap();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
@@ -7,7 +7,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticInteger extends Probabilistic<IntegerTensor> {
     default double logPmf(int value) {
@@ -22,15 +21,15 @@ public interface ProbabilisticInteger extends Probabilistic<IntegerTensor> {
         return logProb(value);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(int value, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPmf(int value, Set<Vertex> withRespectTo) {
         return dLogPmf(IntegerTensor.scalar(value), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(int[] values, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPmf(int[] values, Set<Vertex> withRespectTo) {
         return dLogPmf(IntegerTensor.create(values), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(IntegerTensor value, Set<Vertex> withRespectTo) {
+    default Map<Vertex, DoubleTensor> dLogPmf(IntegerTensor value, Set<Vertex> withRespectTo) {
         return dLogProb(value, withRespectTo);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
@@ -1,10 +1,12 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 
 public interface ProbabilisticInteger extends Probabilistic<IntegerTensor> {
@@ -20,15 +22,15 @@ public interface ProbabilisticInteger extends Probabilistic<IntegerTensor> {
         return logProb(value);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(int value) {
-        return dLogPmf(IntegerTensor.scalar(value));
+    default Map<VertexId, DoubleTensor> dLogPmf(int value, Set<Vertex> withRespectTo) {
+        return dLogPmf(IntegerTensor.scalar(value), withRespectTo);
     }
 
-    default Map<VertexId, DoubleTensor> dLogPmf(int[] values) {
-        return dLogPmf(IntegerTensor.create(values));
+    default Map<VertexId, DoubleTensor> dLogPmf(int[] values, Set<Vertex> withRespectTo) {
+        return dLogPmf(IntegerTensor.create(values), withRespectTo);
     }
 
-    default Map<VertexId,DoubleTensor> dLogPmf(IntegerTensor value) {
-        return dLogProb(value);
+    default Map<VertexId, DoubleTensor> dLogPmf(IntegerTensor value, Set<Vertex> withRespectTo) {
+        return dLogProb(value, withRespectTo);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -4,6 +4,7 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNon
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.improbable.keanu.distributions.discrete.UniformInt;
 import io.improbable.keanu.tensor.Tensor;
@@ -81,7 +82,7 @@ public class UniformIntVertex extends IntegerVertex implements ProbabilisticInte
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value) {
+    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value, Set<Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -11,7 +11,6 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
@@ -82,7 +81,7 @@ public class UniformIntVertex extends IntegerVertex implements ProbabilisticInte
     }
 
     @Override
-    public Map<VertexId, DoubleTensor> dLogProb(IntegerTensor value, Set<Vertex> withRespectTo) {
+    public Map<Vertex, DoubleTensor> dLogProb(IntegerTensor value, Set<? extends Vertex> withRespectTo) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/KDEApproximationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/KDEApproximationTest.java
@@ -88,7 +88,7 @@ public class KDEApproximationTest {
             DoubleTensor.scalar(sigma)
         ).dLogProb(xTensor);
 
-        DoubleTensor approximateDerivative = KDE.dLogPdf(xTensor).get(KDE.getId());
+        DoubleTensor approximateDerivative = KDE.dLogPdf(xTensor, KDE).get(KDE.getId());
         DoubleTensor expectedDerivative = diffLog.get(Diffs.X).getValue();
         isCloseMostOfTheTime(expectedDerivative, approximateDerivative, correctPercentage, DELTA);
     }
@@ -106,7 +106,7 @@ public class KDEApproximationTest {
         KDEVertex KDE = GaussianKDE.approximate(samples);
 
         DoubleTensor x = DoubleTensor.linspace(-1., 1., 100);
-        DoubleTensor approximateDerivative = KDE.dLogPdf(x).get(KDE.getId());
+        DoubleTensor approximateDerivative = KDE.dLogPdf(x, KDE).get(KDE.getId());
         DoubleTensor expectedDerivative = gaussian.dLogProb(x).get(gaussian.getId());
 
         isCloseMostOfTheTime(expectedDerivative, approximateDerivative, correctPercentage, DELTA);

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/KDEApproximationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/KDEApproximationTest.java
@@ -88,7 +88,7 @@ public class KDEApproximationTest {
             DoubleTensor.scalar(sigma)
         ).dLogProb(xTensor);
 
-        DoubleTensor approximateDerivative = KDE.dLogPdf(xTensor, KDE).get(KDE.getId());
+        DoubleTensor approximateDerivative = KDE.dLogPdf(xTensor, KDE).get(KDE);
         DoubleTensor expectedDerivative = diffLog.get(Diffs.X).getValue();
         isCloseMostOfTheTime(expectedDerivative, approximateDerivative, correctPercentage, DELTA);
     }
@@ -106,8 +106,8 @@ public class KDEApproximationTest {
         KDEVertex KDE = GaussianKDE.approximate(samples);
 
         DoubleTensor x = DoubleTensor.linspace(-1., 1., 100);
-        DoubleTensor approximateDerivative = KDE.dLogPdf(x, KDE).get(KDE.getId());
-        DoubleTensor expectedDerivative = gaussian.dLogProb(x).get(gaussian.getId());
+        DoubleTensor approximateDerivative = KDE.dLogPdf(x, KDE).get(KDE);
+        DoubleTensor expectedDerivative = gaussian.dLogProb(x, gaussian).get(gaussian);
 
         isCloseMostOfTheTime(expectedDerivative, approximateDerivative, correctPercentage, DELTA);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/network/ModelCompositionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/ModelCompositionTest.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.network;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -132,8 +133,8 @@ public class ModelCompositionTest {
         Set<Vertex> latentOuterVertices = ImmutableSet.of(trueLocation, gaussOutputVertex);
         Set<Vertex> filteredVertices = new HashSet<>(outerNet.getTopLevelLatentVertices());
 
-        assertEquals(latentOuterVertices.containsAll(filteredVertices), true);
-        assertEquals(filteredVertices.containsAll(latentOuterVertices), true);
+        assertTrue(latentOuterVertices.containsAll(filteredVertices));
+        assertTrue(filteredVertices.containsAll(latentOuterVertices));
     }
 
     private void triggerCompositionWarnings(List<VertexLabel> outputs,
@@ -198,8 +199,8 @@ public class ModelCompositionTest {
         shouldMatch.addPrefix(prefix);
         VertexId shouldNotMatch = new VertexId();
 
-        assertEquals(shouldMatch.prefixMatches(prefix), true);
-        assertEquals(shouldNotMatch.prefixMatches(prefix), false);
+        assertTrue(shouldMatch.prefixMatches(prefix));
+        assertFalse(shouldNotMatch.prefixMatches(prefix));
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/network/ModelCompositionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/ModelCompositionTest.java
@@ -62,7 +62,7 @@ public class ModelCompositionTest {
             innerNet, inputVertices, ImmutableList.of(new VertexLabel("Output1"))
         );
 
-        gaussOutputVertex = (DoubleVertex)outputs.get(new VertexLabel("Output1"));
+        gaussOutputVertex = (DoubleVertex) outputs.get(new VertexLabel("Output1"));
 
         outerNet = new BayesianNetwork(gaussOutputVertex.getConnectedGraph());
     }
@@ -101,7 +101,7 @@ public class ModelCompositionTest {
 
     @Test
     public void idOrderingStillImpliesTopologicalOrdering() {
-        for (Vertex v: outerNet.getVertices()) {
+        for (Vertex v : outerNet.getVertices()) {
             Set<Vertex> parentSet = v.getParents();
             for (Vertex parent : parentSet) {
                 assertTrue(v.getId().compareTo(parent.getId()) > 0);

--- a/keanu-project/src/test/java/io/improbable/keanu/network/ModelCompositionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/ModelCompositionTest.java
@@ -59,7 +59,9 @@ public class ModelCompositionTest {
         Map<VertexLabel, Vertex> inputVertices = ImmutableMap.of(new VertexLabel("Location"), trueLocation);
 
         Map<VertexLabel, Vertex> outputs = ModelComposition.composeModel(
-            innerNet, inputVertices, ImmutableList.of(new VertexLabel("Output1")));
+            innerNet, inputVertices, ImmutableList.of(new VertexLabel("Output1"))
+        );
+
         gaussOutputVertex = (DoubleVertex)outputs.get(new VertexLabel("Output1"));
 
         outerNet = new BayesianNetwork(gaussOutputVertex.getConnectedGraph());

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
@@ -1,13 +1,16 @@
 package io.improbable.keanu.vertices.bool.probabilistic;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.testGradientAcrossMultipleHyperParameterValues;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.testGradientAcrossMultipleHyperParameterValues;
 
 import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
 
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
@@ -51,7 +54,7 @@ public class BernoulliVertexTest {
         DoubleVertex C = A.times(B);
         BernoulliVertex D = new BernoulliVertex(C);
 
-        Map<VertexId, DoubleTensor> dLogPmf = D.dLogPmf(BooleanTensor.create(new boolean[]{true, false}));
+        Map<VertexId, DoubleTensor> dLogPmf = D.dLogPmf(BooleanTensor.create(new boolean[]{true, false}), ImmutableSet.of(A, B));
 
         DoubleTensor expectedWrtA = DoubleTensor.create(new double[]{(1.0 / 0.125) * 0.5, (-1.0 / 0.88) * 0.2});
         DoubleTensor expectedWrtB = DoubleTensor.create(new double[]{(1.0 / 0.125) * 0.25, (-1.0 / 0.88) * 0.6});
@@ -129,7 +132,7 @@ public class BernoulliVertexTest {
             true, true
         }, shape);
 
-        Map<VertexId, DoubleTensor> dLogPmf = D.dLogPmf(atValue);
+        Map<VertexId, DoubleTensor> dLogPmf = D.dLogPmf(atValue, ImmutableSet.of(A, B));
 
         DoubleTensor expectedWrtA = atValue.setDoubleIf(
             AValue.reciprocal(),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
@@ -17,7 +17,7 @@ import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOpt
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
@@ -54,13 +54,13 @@ public class BernoulliVertexTest {
         DoubleVertex C = A.times(B);
         BernoulliVertex D = new BernoulliVertex(C);
 
-        Map<VertexId, DoubleTensor> dLogPmf = D.dLogPmf(BooleanTensor.create(new boolean[]{true, false}), ImmutableSet.of(A, B));
+        Map<Vertex, DoubleTensor> dLogPmf = D.dLogPmf(BooleanTensor.create(new boolean[]{true, false}), ImmutableSet.of(A, B));
 
         DoubleTensor expectedWrtA = DoubleTensor.create(new double[]{(1.0 / 0.125) * 0.5, (-1.0 / 0.88) * 0.2});
         DoubleTensor expectedWrtB = DoubleTensor.create(new double[]{(1.0 / 0.125) * 0.25, (-1.0 / 0.88) * 0.6});
 
-        assertEquals(expectedWrtA, dLogPmf.get(A.getId()));
-        assertEquals(expectedWrtB, dLogPmf.get(B.getId()));
+        assertEquals(expectedWrtA, dLogPmf.get(A));
+        assertEquals(expectedWrtB, dLogPmf.get(B));
     }
 
     @Test
@@ -132,7 +132,7 @@ public class BernoulliVertexTest {
             true, true
         }, shape);
 
-        Map<VertexId, DoubleTensor> dLogPmf = D.dLogPmf(atValue, ImmutableSet.of(A, B));
+        Map<Vertex, DoubleTensor> dLogPmf = D.dLogPmf(atValue, ImmutableSet.of(A, B));
 
         DoubleTensor expectedWrtA = atValue.setDoubleIf(
             AValue.reciprocal(),
@@ -164,8 +164,8 @@ public class BernoulliVertexTest {
             0.0
         );
 
-        assertEquals(expectedWrtA, dLogPmf.get(A.getId()));
-        assertEquals(expectedWrtB, dLogPmf.get(B.getId()));
+        assertEquals(expectedWrtA, dLogPmf.get(A));
+        assertEquals(expectedWrtB, dLogPmf.get(B));
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
@@ -10,15 +10,16 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
@@ -54,27 +55,31 @@ public class BernoulliVertexTest {
         DoubleVertex C = A.times(B);
         BernoulliVertex D = new BernoulliVertex(C);
 
-        Map<Vertex, DoubleTensor> dLogPmf = D.dLogPmf(BooleanTensor.create(new boolean[]{true, false}), ImmutableSet.of(A, B));
+        D.observe(BooleanTensor.create(new boolean[]{true, false}));
+
+        LogProbGradientCalculator logProbGradientCalculator = new LogProbGradientCalculator(ImmutableList.of(D), ImmutableList.of(A, B));
+
+        Map<VertexId, DoubleTensor> dLogPmf = logProbGradientCalculator.getJointLogProbGradientWrtLatents();
 
         DoubleTensor expectedWrtA = DoubleTensor.create(new double[]{(1.0 / 0.125) * 0.5, (-1.0 / 0.88) * 0.2});
         DoubleTensor expectedWrtB = DoubleTensor.create(new double[]{(1.0 / 0.125) * 0.25, (-1.0 / 0.88) * 0.6});
 
-        assertEquals(expectedWrtA, dLogPmf.get(A));
-        assertEquals(expectedWrtB, dLogPmf.get(B));
+        assertEquals(expectedWrtA, dLogPmf.get(A.getId()));
+        assertEquals(expectedWrtB, dLogPmf.get(B.getId()));
     }
 
     @Test
     public void doesCalculateDiffLogProbWithRespectToHyperParamFiniteElement() {
 
         DoubleVertex A = new GaussianVertex(0, 1);
-        DoubleTensor startA = DoubleTensor.scalar(-5);
-        DoubleTensor endA = DoubleTensor.scalar(5);
+        DoubleTensor startA = DoubleTensor.scalar(0.1);
+        DoubleTensor endA = DoubleTensor.scalar(0.9);
         A.setAndCascade(startA);
 
-        BernoulliVertex D = new BernoulliVertex(A.sigmoid());
+        BernoulliVertex D = new BernoulliVertex(A);
         D.observe(true);
 
-        double increment = 0.15;
+        double increment = 0.1;
         double gradientDelta = 1e-5;
 
         testGradientAcrossMultipleHyperParameterValues(
@@ -132,7 +137,11 @@ public class BernoulliVertexTest {
             true, true
         }, shape);
 
-        Map<Vertex, DoubleTensor> dLogPmf = D.dLogPmf(atValue, ImmutableSet.of(A, B));
+        D.observe(atValue);
+
+        LogProbGradientCalculator logProbGradientCalculator = new LogProbGradientCalculator(ImmutableList.of(D), ImmutableList.of(A, B));
+
+        Map<VertexId, DoubleTensor> dLogPmf = logProbGradientCalculator.getJointLogProbGradientWrtLatents();
 
         DoubleTensor expectedWrtA = atValue.setDoubleIf(
             AValue.reciprocal(),
@@ -164,8 +173,8 @@ public class BernoulliVertexTest {
             0.0
         );
 
-        assertEquals(expectedWrtA, dLogPmf.get(A));
-        assertEquals(expectedWrtB, dLogPmf.get(B));
+        assertEquals(expectedWrtA, dLogPmf.get(A.getId()));
+        assertEquals(expectedWrtB, dLogPmf.get(B.getId()));
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
@@ -1,0 +1,127 @@
+package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.distributions.continuous.Gaussian;
+import io.improbable.keanu.distributions.dual.Diffs;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+
+public class LogProbGradientCalculatorTest {
+
+    @Test
+    public void canFindGradientOfSingleVariateGaussianWrtSelf() {
+        GaussianVertex A = new GaussianVertex(0, 1);
+        A.setValue(0.5);
+
+        LogProbGradientCalculator calculator = new LogProbGradientCalculator(ImmutableList.of(A), ImmutableList.of(A));
+
+        Map<VertexId, DoubleTensor> gradient = calculator.getJointLogProbGradientWrtLatents();
+        DoubleTensor dALogProbWrtAValue = gradient.get(A.getId());
+
+        Gaussian distribution = Gaussian.withParameters(DoubleTensor.ZERO_SCALAR, DoubleTensor.ONE_SCALAR);
+        DoubleTensor expected = distribution.dLogProb(DoubleTensor.scalar(0.5)).get(Diffs.X).getValue();
+
+        assertThat(dALogProbWrtAValue, equalTo(expected));
+    }
+
+    @Test
+    public void canFindGradientOfSingleVariantGaussianWrtSingleVariateLatent() {
+
+        GaussianVertex A = new GaussianVertex(0, 1);
+        GaussianVertex B = new GaussianVertex(A, 1);
+        B.setValue(0.5);
+
+        LogProbGradientCalculator calculator = new LogProbGradientCalculator(ImmutableList.of(B), ImmutableList.of(A));
+
+        Map<VertexId, DoubleTensor> gradient = calculator.getJointLogProbGradientWrtLatents();
+        DoubleTensor dBLogProbWrtAValue = gradient.get(A.getId());
+
+        DoubleTensor expectedDLogProbWrtA = B.dLogProb(DoubleTensor.scalar(0.5), A).get(A);
+
+        assertThat(dBLogProbWrtAValue, equalTo(expectedDLogProbWrtA));
+    }
+
+    @Test
+    public void canFindGradientOfSingleVariantGaussianWrtMultivariateLatent() {
+
+        GaussianVertex A = new GaussianVertex(new int[]{3, 2}, 0, 1);
+        GaussianVertex B = new GaussianVertex(A, 1);
+        DoubleTensor bValue = DoubleTensor.create(new double[]{0.1, 0.2, 0.3, -0.2, -0.5, 0.9}, 3, 2);
+        B.setValue(bValue);
+
+        LogProbGradientCalculator calculator = new LogProbGradientCalculator(ImmutableList.of(B), ImmutableList.of(A));
+
+        Map<VertexId, DoubleTensor> gradient = calculator.getJointLogProbGradientWrtLatents();
+        DoubleTensor dBLogProbWrtAValue = gradient.get(A.getId());
+
+        DoubleTensor expectedDLogProbWrtA = B.dLogProb(bValue, A).get(A);
+
+        assertThat(dBLogProbWrtAValue, equalTo(expectedDLogProbWrtA));
+    }
+
+    @Test
+    public void canFindGradientOfMultivariantGaussianWrtSingleVariateLatent() {
+
+        GaussianVertex A = new GaussianVertex(0, 1);
+        GaussianVertex B = new GaussianVertex(new int[]{3, 2}, A, 1);
+        DoubleTensor bValue = DoubleTensor.create(new double[]{0.1, 0.2, 0.3, -0.2, -0.5, 0.9}, 3, 2);
+        B.setValue(bValue);
+
+        LogProbGradientCalculator calculator = new LogProbGradientCalculator(ImmutableList.of(B), ImmutableList.of(A));
+
+        Map<VertexId, DoubleTensor> gradient = calculator.getJointLogProbGradientWrtLatents();
+        DoubleTensor dBLogProbWrtAValue = gradient.get(A.getId());
+
+        double expectedDLogProbWrtA = B.dLogProb(bValue, A).get(A).sum();
+
+        assertThat(dBLogProbWrtAValue.scalar(), equalTo(expectedDLogProbWrtA));
+        assertThat(dBLogProbWrtAValue.getLength(), equalTo(1L));
+    }
+
+    @Test
+    public void canFindGradientOfMultivariantGaussianWrtSingleVariateLatentWithOp() {
+
+        GaussianVertex A = new GaussianVertex(0, 1);
+        DoubleTensor aValue = DoubleTensor.scalar(0.2);
+        A.setValue(aValue);
+        GaussianVertex C = new GaussianVertex(new int[]{3, 2}, 0, 1);
+        DoubleTensor cValue = DoubleTensor.create(new double[]{-0.1, -0.2, -0.3, 0.2, 0.5, -0.9}, 3, 2);
+        C.setValue(cValue);
+        DoubleVertex D = A.times(C);
+        GaussianVertex B = new GaussianVertex(D, 1);
+        DoubleTensor bValue = DoubleTensor.create(new double[]{0.1, 0.2, 0.3, -0.2, -0.5, 0.9}, 3, 2);
+        B.setValue(bValue);
+
+        LogProbGradientCalculator calculator = new LogProbGradientCalculator(ImmutableList.of(B), ImmutableList.of(A, C));
+
+        Map<VertexId, DoubleTensor> gradient = calculator.getJointLogProbGradientWrtLatents();
+        DoubleTensor dBLogProbWrtAValue = gradient.get(A.getId());
+        DoubleTensor dBLogProbWrtCValue = gradient.get(C.getId());
+
+        double expectedDLogProbWrtA = B.dLogProb(bValue, D).get(D).times(cValue).sum();
+        DoubleTensor expectedDLogProbWrtC = B.dLogProb(bValue, D).get(D).times(aValue);
+
+        assertThat(dBLogProbWrtAValue, equalTo(DoubleTensor.scalar(expectedDLogProbWrtA)));
+        assertThat(dBLogProbWrtCValue, equalTo(expectedDLogProbWrtC));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesThrowOnLogProbDiffOnNonProbabilistic() {
+        DoubleVertex A = ConstantVertex.of(5.0);
+        DoubleVertex B = A.times(4);
+        LogProbGradientCalculator calculator = new LogProbGradientCalculator(ImmutableList.of(B), ImmutableList.of(A));
+        calculator.getJointLogProbGradientWrtLatents();
+    }
+
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 
+import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.Gaussian;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -29,7 +30,7 @@ public class LogProbGradientCalculatorTest {
         Map<VertexId, DoubleTensor> gradient = calculator.getJointLogProbGradientWrtLatents();
         DoubleTensor dALogProbWrtAValue = gradient.get(A.getId());
 
-        Gaussian distribution = Gaussian.withParameters(DoubleTensor.ZERO_SCALAR, DoubleTensor.ONE_SCALAR);
+        ContinuousDistribution distribution = Gaussian.withParameters(DoubleTensor.ZERO_SCALAR, DoubleTensor.ONE_SCALAR);
         DoubleTensor expected = distribution.dLogProb(DoubleTensor.scalar(0.5)).get(Diffs.X).getValue();
 
         assertThat(dALogProbWrtAValue, equalTo(expected));

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2VertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2VertexTest.java
@@ -26,16 +26,16 @@ public class ArcTan2VertexTest {
 
     @Test
     public void calculatesDualNumberOfTwoScalarsTan2() {
-        double a = 0.5;
-        double b = Math.sqrt(3) / 2.0;
-        double wrtA = b / (Math.pow(b, 2) + Math.pow(0.5, 2));
-        double wrtB = -0.5 / (Math.pow(b, 2) + Math.pow(0.5, 2));
+        double x = 0.5;
+        double y = Math.sqrt(3) / 2.0;
+        double wrtX = -y / (Math.pow(y, 2) + Math.pow(x, 2));
+        double wrtY = x / (Math.pow(y, 2) + Math.pow(x, 2));
 
         calculatesDualNumberOfTwoScalars(
-            a,
-            b,
-            wrtA,
-            wrtB,
+            x,
+            y,
+            wrtX,
+            wrtY,
             DoubleVertex::atan2
         );
     }
@@ -55,8 +55,8 @@ public class ArcTan2VertexTest {
         calculatesDualNumberOfTwoMatricesElementWiseOperator(
             DoubleTensor.create(new double[]{1.0, 2.0, 3.0, 4.0}, 1, 4),
             DoubleTensor.create(new double[]{2.0, 3.0, 4.0, 5.0}, 1, 4),
-            DoubleTensor.create(new double[]{2. / (1 + 4), 3. / (4 + 9), 4. / (9. + 16), 5. / (16 + 25)}).diag().reshape(1, 4, 1, 4),
-            DoubleTensor.create(new double[]{-1. / (1 + 4), -2. / (4 + 9), -3. / (9 + 16), -4. / (16 + 25)}).diag().reshape(1, 4, 1, 4),
+            DoubleTensor.create(new double[]{-2. / (1 + 4), -3. / (4 + 9), -4. / (9. + 16), -5. / (16 + 25)}).diag().reshape(1, 4, 1, 4),
+            DoubleTensor.create(new double[]{1. / (1 + 4), 2. / (4 + 9), 3. / (9 + 16), 4. / (16 + 25)}).diag().reshape(1, 4, 1, 4),
             DoubleVertex::atan2
         );
     }
@@ -66,8 +66,8 @@ public class ArcTan2VertexTest {
         calculatesDualNumberOfAVectorsAndScalar(
             DoubleTensor.create(new double[]{1.0, 2.0, 3.0, 4.0}),
             2,
-            DoubleTensor.create(new double[]{2. / (1. + 4.), 2. / (4. + 4.), 2. / (9. + 4.), 2. / (16. + 4.)}).diag().reshape(1, 4, 1, 4),
-            DoubleTensor.create(new double[]{-1. / (1. + 4.), -2. / (4. + 4.), -3. / (9. + 4.), -4. / (16. + 4.)}).reshape(1, 4, 1, 1),
+            DoubleTensor.create(new double[]{-2. / (1. + 4.), -2. / (4. + 4.), -2. / (9. + 4.), -2. / (16. + 4.)}).diag().reshape(1, 4, 1, 4),
+            DoubleTensor.create(new double[]{1. / (1. + 4.), 2. / (4. + 4.), 3. / (9. + 4.), 4. / (16. + 4.)}).reshape(1, 4, 1, 1),
             DoubleVertex::atan2
         );
     }
@@ -77,8 +77,8 @@ public class ArcTan2VertexTest {
         calculatesDualNumberOfAScalarAndVector(
             2,
             DoubleTensor.create(new double[]{1.0, 2.0, 3.0, 4.0}),
-            DoubleTensor.create(new double[]{1. / (4. + 1.), 2. / (4. + 4.), 3. / (4. + 9.), 4. / (4. + 16.)}).reshape(1, 4, 1, 1),
-            DoubleTensor.create(new double[]{-2. / (4. + 1.), -2. / (4. + 4.), -2. / (4. + 9.), -2. / (4. + 16.)}).diag().reshape(1, 4, 1, 4),
+            DoubleTensor.create(new double[]{-1. / (4. + 1.), -2. / (4. + 4.), -3. / (4. + 9.), -4. / (4. + 16.)}).reshape(1, 4, 1, 1),
+            DoubleTensor.create(new double[]{2. / (4. + 1.), 2. / (4. + 4.), 2. / (4. + 9.), 2. / (4. + 16.)}).diag().reshape(1, 4, 1, 4),
             DoubleVertex::atan2
         );
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -17,10 +17,9 @@ import io.improbable.keanu.distributions.gradient.Beta;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class BetaVertexTest {
 
@@ -62,13 +61,11 @@ public class BetaVertexTest {
         betaTensor.setValue(3.0);
 
         BetaVertex tensorBetaVertex = new BetaVertex(alphaTensor, betaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorBetaVertex.dLogPdf(0.5, alphaTensor, betaTensor, tensorBetaVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorBetaVertex.dLogPdf(0.5, alphaTensor, betaTensor, tensorBetaVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(betaLogDiff.dPdalpha, actual.withRespectTo(alphaTensor.getId()).scalar(), 1e-5);
-        assertEquals(betaLogDiff.dPdbeta, actual.withRespectTo(betaTensor.getId()).scalar(), 1e-5);
-        assertEquals(betaLogDiff.dPdx, actual.withRespectTo(tensorBetaVertex.getId()).scalar(), 1e-5);
+        assertEquals(betaLogDiff.dPdalpha, actualDerivatives.get(alphaTensor).scalar(), 1e-5);
+        assertEquals(betaLogDiff.dPdbeta, actualDerivatives.get(betaTensor).scalar(), 1e-5);
+        assertEquals(betaLogDiff.dPdx, actualDerivatives.get(tensorBetaVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -62,7 +62,7 @@ public class BetaVertexTest {
         betaTensor.setValue(3.0);
 
         BetaVertex tensorBetaVertex = new BetaVertex(alphaTensor, betaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorBetaVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorBetaVertex.dLogPdf(0.5, alphaTensor, betaTensor, tensorBetaVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertexTest.java
@@ -1,7 +1,8 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 import static org.junit.Assert.assertEquals;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,7 +63,7 @@ public class CauchyVertexTest {
         scaleTensor.setValue(1.0);
 
         CauchyVertex tensorCauchyVertex = new CauchyVertex(locationTensor, scaleTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorCauchyVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorCauchyVertex.dLogPdf(0.5, locationTensor, scaleTensor, tensorCauchyVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertexTest.java
@@ -17,10 +17,9 @@ import io.improbable.keanu.distributions.gradient.Cauchy;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class CauchyVertexTest {
 
@@ -63,13 +62,11 @@ public class CauchyVertexTest {
         scaleTensor.setValue(1.0);
 
         CauchyVertex tensorCauchyVertex = new CauchyVertex(locationTensor, scaleTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorCauchyVertex.dLogPdf(0.5, locationTensor, scaleTensor, tensorCauchyVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorCauchyVertex.dLogPdf(0.5, locationTensor, scaleTensor, tensorCauchyVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(cauchyLogDiff.dPdlocation, actual.withRespectTo(locationTensor.getId()).scalar(), 1e-5);
-        assertEquals(cauchyLogDiff.dPdscale, actual.withRespectTo(scaleTensor.getId()).scalar(), 1e-5);
-        assertEquals(cauchyLogDiff.dPdx, actual.withRespectTo(tensorCauchyVertex.getId()).scalar(), 1e-5);
+        assertEquals(cauchyLogDiff.dPdlocation, actualDerivatives.get(locationTensor).scalar(), 1e-5);
+        assertEquals(cauchyLogDiff.dPdscale, actualDerivatives.get(scaleTensor).scalar(), 1e-5);
+        assertEquals(cauchyLogDiff.dPdx, actualDerivatives.get(tensorCauchyVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
@@ -18,7 +18,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import umontreal.ssj.probdistmulti.DirichletDist;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
@@ -169,7 +169,7 @@ public class DirichletVertexTest {
 
             double diffLnDensityApproxExpected = (lnDensityA2 - lnDensityA1) / (2 * gradientDelta);
 
-            Map<VertexId, DoubleTensor> diffln = dirichlet.dLogProbAtValue();
+            Map<VertexId, DoubleTensor> diffln = dirichlet.dLogProbAtValue(concentrationHyperParam);
 
             double actualDiff = diffln.get(concentrationHyperParam.getId()).getValue(0, 0) + diffln.get(concentrationHyperParam.getId()).getValue(0, 1);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
@@ -169,9 +169,9 @@ public class DirichletVertexTest {
 
             double diffLnDensityApproxExpected = (lnDensityA2 - lnDensityA1) / (2 * gradientDelta);
 
-            Map<VertexId, DoubleTensor> diffln = dirichlet.dLogProbAtValue(concentrationHyperParam);
+            Map<Vertex, DoubleTensor> diffln = dirichlet.dLogProbAtValue(concentrationHyperParam);
 
-            double actualDiff = diffln.get(concentrationHyperParam.getId()).getValue(0, 0) + diffln.get(concentrationHyperParam.getId()).getValue(0, 1);
+            double actualDiff = diffln.get(concentrationHyperParam).getValue(0, 0) + diffln.get(concentrationHyperParam).getValue(0, 1);
 
             assertEquals(diffLnDensityApproxExpected, actualDiff, 0.001);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -1,8 +1,9 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +69,7 @@ public class ExponentialVertexTest {
         bTensor.setValue(2.5);
 
         ExponentialVertex tensorExponentialVertex = new ExponentialVertex(bTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorExponentialVertex.dLogPdf(1.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorExponentialVertex.dLogPdf(1.5, bTensor, tensorExponentialVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -18,10 +18,9 @@ import io.improbable.keanu.distributions.continuous.Exponential;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class ExponentialVertexTest {
 
@@ -69,12 +68,10 @@ public class ExponentialVertexTest {
         bTensor.setValue(2.5);
 
         ExponentialVertex tensorExponentialVertex = new ExponentialVertex(bTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorExponentialVertex.dLogPdf(1.5, bTensor, tensorExponentialVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorExponentialVertex.dLogPdf(1.5, bTensor, tensorExponentialVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(exponentialLogDiff.dPdlambda, actual.withRespectTo(bTensor.getId()).scalar(), 1e-5);
-        assertEquals(exponentialLogDiff.dPdx, actual.withRespectTo(tensorExponentialVertex.getId()).scalar(), 1e-5);
+        assertEquals(exponentialLogDiff.dPdlambda, actualDerivatives.get(bTensor).scalar(), 1e-5);
+        assertEquals(exponentialLogDiff.dPdx, actualDerivatives.get(tensorExponentialVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -63,7 +63,7 @@ public class GammaVertexTest {
         kTensor.setValue(Nd4jDoubleTensor.scalar(5.5));
 
         GammaVertex tensorGamma = new GammaVertex(thetaTensor, kTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorGamma.dLogPdf(Nd4jDoubleTensor.scalar(1.5));
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorGamma.dLogPdf(Nd4jDoubleTensor.scalar(1.5), thetaTensor, kTensor, tensorGamma);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -17,10 +17,9 @@ import io.improbable.keanu.distributions.gradient.Gamma;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class GammaVertexTest {
 
@@ -63,13 +62,11 @@ public class GammaVertexTest {
         kTensor.setValue(Nd4jDoubleTensor.scalar(5.5));
 
         GammaVertex tensorGamma = new GammaVertex(thetaTensor, kTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorGamma.dLogPdf(Nd4jDoubleTensor.scalar(1.5), thetaTensor, kTensor, tensorGamma);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorGamma.dLogPdf(Nd4jDoubleTensor.scalar(1.5), thetaTensor, kTensor, tensorGamma);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(gammaLogDiff.dPdtheta, actual.withRespectTo(thetaTensor.getId()).scalar(), 1e-5);
-        assertEquals(gammaLogDiff.dPdk, actual.withRespectTo(kTensor.getId()).scalar(), 1e-5);
-        assertEquals(gammaLogDiff.dPdx, actual.withRespectTo(tensorGamma.getId()).scalar(), 1e-5);
+        assertEquals(gammaLogDiff.dPdtheta, actualDerivatives.get(thetaTensor).scalar(), 1e-5);
+        assertEquals(gammaLogDiff.dPdk, actualDerivatives.get(kTensor).scalar(), 1e-5);
+        assertEquals(gammaLogDiff.dPdx, actualDerivatives.get(tensorGamma).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -17,10 +17,9 @@ import io.improbable.keanu.distributions.gradient.Gaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class GaussianVertexTest {
 
@@ -63,13 +62,11 @@ public class GaussianVertexTest {
         sigmaTensor.setValue(1.0);
 
         GaussianVertex tensorGaussianVertex = new GaussianVertex(muTensor, sigmaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5, muTensor, sigmaTensor, tensorGaussianVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5, muTensor, sigmaTensor, tensorGaussianVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(gaussianLogDiff.dPdmu, actual.withRespectTo(muTensor.getId()).scalar(), 1e-5);
-        assertEquals(gaussianLogDiff.dPdsigma, actual.withRespectTo(sigmaTensor.getId()).scalar(), 1e-5);
-        assertEquals(gaussianLogDiff.dPdx, actual.withRespectTo(tensorGaussianVertex.getId()).scalar(), 1e-5);
+        assertEquals(gaussianLogDiff.dPdmu, actualDerivatives.get(muTensor).scalar(), 1e-5);
+        assertEquals(gaussianLogDiff.dPdsigma, actualDerivatives.get(sigmaTensor).scalar(), 1e-5);
+        assertEquals(gaussianLogDiff.dPdx, actualDerivatives.get(tensorGaussianVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -63,7 +63,7 @@ public class GaussianVertexTest {
         sigmaTensor.setValue(1.0);
 
         GaussianVertex tensorGaussianVertex = new GaussianVertex(muTensor, sigmaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5, muTensor, sigmaTensor, tensorGaussianVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -1,7 +1,8 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 import static org.junit.Assert.assertEquals;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +17,7 @@ import io.improbable.keanu.distributions.gradient.Cauchy;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -52,7 +53,7 @@ public class HalfCauchyVertexTest {
     public void matchesKnownLogDensityOfVector() {
 
         CauchyDistribution distribution = new CauchyDistribution(0.0, 1.0);
-        double expectedLogDensity = distribution.logDensity(0.25) + distribution.logDensity(0.75)  + 2.0 * Math.log(2.0);
+        double expectedLogDensity = distribution.logDensity(0.25) + distribution.logDensity(0.75) + 2.0 * Math.log(2.0);
         HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(1);
         ProbabilisticDoubleTensorContract.matchesKnownLogDensityOfVector(tensorHalfCauchyVertex, new double[]{0.25, 0.75}, expectedLogDensity);
     }
@@ -73,12 +74,10 @@ public class HalfCauchyVertexTest {
         scaleTensor.setValue(1.0);
 
         HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(scaleTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorHalfCauchyVertex.dLogPdf(0.5, scaleTensor, tensorHalfCauchyVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorHalfCauchyVertex.dLogPdf(0.5, scaleTensor, tensorHalfCauchyVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(cauchyLogDiff.dPdscale, actual.withRespectTo(scaleTensor.getId()).scalar(), 1e-5);
-        assertEquals(cauchyLogDiff.dPdx, actual.withRespectTo(tensorHalfCauchyVertex.getId()).scalar(), 1e-5);
+        assertEquals(cauchyLogDiff.dPdscale, actualDerivatives.get(scaleTensor).scalar(), 1e-5);
+        assertEquals(cauchyLogDiff.dPdx, actualDerivatives.get(tensorHalfCauchyVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -73,7 +73,7 @@ public class HalfCauchyVertexTest {
         scaleTensor.setValue(1.0);
 
         HalfCauchyVertex tensorHalfCauchyVertex = new HalfCauchyVertex(scaleTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorHalfCauchyVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorHalfCauchyVertex.dLogPdf(0.5, scaleTensor, tensorHalfCauchyVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -20,7 +20,6 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class HalfCauchyVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
@@ -1,7 +1,8 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 import static org.junit.Assert.assertEquals;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,10 +17,9 @@ import io.improbable.keanu.distributions.gradient.Gaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class HalfGaussianVertexTest {
 
@@ -73,12 +73,10 @@ public class HalfGaussianVertexTest {
         sigmaTensor.setValue(1.0);
 
         HalfGaussianVertex tensorGaussianVertex = new HalfGaussianVertex(sigmaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5, sigmaTensor, tensorGaussianVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5, sigmaTensor, tensorGaussianVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(gaussianLogDiff.dPdsigma, actual.withRespectTo(sigmaTensor.getId()).scalar(), 1e-5);
-        assertEquals(gaussianLogDiff.dPdx, actual.withRespectTo(tensorGaussianVertex.getId()).scalar(), 1e-5);
+        assertEquals(gaussianLogDiff.dPdsigma, actualDerivatives.get(sigmaTensor).scalar(), 1e-5);
+        assertEquals(gaussianLogDiff.dPdx, actualDerivatives.get(tensorGaussianVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
@@ -73,7 +73,7 @@ public class HalfGaussianVertexTest {
         sigmaTensor.setValue(1.0);
 
         HalfGaussianVertex tensorGaussianVertex = new HalfGaussianVertex(sigmaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorGaussianVertex.dLogPdf(0.5, sigmaTensor, tensorGaussianVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
@@ -16,10 +16,9 @@ import io.improbable.keanu.distributions.gradient.InverseGamma;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class InverseGammaVertexTest {
 
@@ -60,13 +59,11 @@ public class InverseGammaVertexTest {
         bTensor.setValue(1.0);
 
         InverseGammaVertex tensorInverseGammaVertex = new InverseGammaVertex(aTensor, bTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorInverseGammaVertex.dLogPdf(0.5, aTensor, bTensor, tensorInverseGammaVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorInverseGammaVertex.dLogPdf(0.5, aTensor, bTensor, tensorInverseGammaVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(inverseGammaLogDiff.dPda, actual.withRespectTo(aTensor.getId()).scalar(), 1e-5);
-        assertEquals(inverseGammaLogDiff.dPdb, actual.withRespectTo(bTensor.getId()).scalar(), 1e-5);
-        assertEquals(inverseGammaLogDiff.dPdx, actual.withRespectTo(tensorInverseGammaVertex.getId()).scalar(), 1e-5);
+        assertEquals(inverseGammaLogDiff.dPda, actualDerivatives.get(aTensor).scalar(), 1e-5);
+        assertEquals(inverseGammaLogDiff.dPdb, actualDerivatives.get(bTensor).scalar(), 1e-5);
+        assertEquals(inverseGammaLogDiff.dPdx, actualDerivatives.get(tensorInverseGammaVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
@@ -60,7 +60,7 @@ public class InverseGammaVertexTest {
         bTensor.setValue(1.0);
 
         InverseGammaVertex tensorInverseGammaVertex = new InverseGammaVertex(aTensor, bTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorInverseGammaVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorInverseGammaVertex.dLogPdf(0.5, aTensor, bTensor, tensorInverseGammaVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
@@ -17,10 +17,9 @@ import io.improbable.keanu.distributions.gradient.Laplace;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class LaplaceVertexTest {
 
@@ -63,13 +62,11 @@ public class LaplaceVertexTest {
         betaTensor.setValue(1.0);
 
         LaplaceVertex tensorLaplaceVertex = new LaplaceVertex(muTensor, betaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorLaplaceVertex.dLogPdf(0.5, muTensor, betaTensor, tensorLaplaceVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorLaplaceVertex.dLogPdf(0.5, muTensor, betaTensor, tensorLaplaceVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(laplaceLogDiff.dPdmu, actual.withRespectTo(muTensor.getId()).scalar(), 1e-5);
-        assertEquals(laplaceLogDiff.dPdbeta, actual.withRespectTo(betaTensor.getId()).scalar(), 1e-5);
-        assertEquals(laplaceLogDiff.dPdx, actual.withRespectTo(tensorLaplaceVertex.getId()).scalar(), 1e-5);
+        assertEquals(laplaceLogDiff.dPdmu, actualDerivatives.get(muTensor).scalar(), 1e-5);
+        assertEquals(laplaceLogDiff.dPdbeta, actualDerivatives.get(betaTensor).scalar(), 1e-5);
+        assertEquals(laplaceLogDiff.dPdx, actualDerivatives.get(tensorLaplaceVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
@@ -63,7 +63,7 @@ public class LaplaceVertexTest {
         betaTensor.setValue(1.0);
 
         LaplaceVertex tensorLaplaceVertex = new LaplaceVertex(muTensor, betaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorLaplaceVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorLaplaceVertex.dLogPdf(0.5, muTensor, betaTensor, tensorLaplaceVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertexTest.java
@@ -62,7 +62,7 @@ public class LogNormalVertexTest {
         sigmaTensor.setValue(1.0);
 
         LogNormalVertex tensorLogNormalVertex = new LogNormalVertex(muTensor, sigmaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorLogNormalVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorLogNormalVertex.dLogPdf(0.5, muTensor, sigmaTensor, tensorLogNormalVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertexTest.java
@@ -17,10 +17,9 @@ import io.improbable.keanu.distributions.gradient.LogNormal;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class LogNormalVertexTest {
     private static final double DELTA = 0.0001;
@@ -62,13 +61,11 @@ public class LogNormalVertexTest {
         sigmaTensor.setValue(1.0);
 
         LogNormalVertex tensorLogNormalVertex = new LogNormalVertex(muTensor, sigmaTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorLogNormalVertex.dLogPdf(0.5, muTensor, sigmaTensor, tensorLogNormalVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorLogNormalVertex.dLogPdf(0.5, muTensor, sigmaTensor, tensorLogNormalVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(logNormalLogDiff.dPdmu, actual.withRespectTo(muTensor.getId()).scalar(), 1e-5);
-        assertEquals(logNormalLogDiff.dPdsigma, actual.withRespectTo(sigmaTensor.getId()).scalar(), 1e-5);
-        assertEquals(logNormalLogDiff.dPdx, actual.withRespectTo(tensorLogNormalVertex.getId()).scalar(), 1e-5);
+        assertEquals(logNormalLogDiff.dPdmu, actualDerivatives.get(muTensor).scalar(), 1e-5);
+        assertEquals(logNormalLogDiff.dPdsigma, actualDerivatives.get(sigmaTensor).scalar(), 1e-5);
+        assertEquals(logNormalLogDiff.dPdx, actualDerivatives.get(tensorLogNormalVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -1,7 +1,8 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 import static org.junit.Assert.assertEquals;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +61,7 @@ public class LogisticVertexTest {
         bTensor.setValue(0.5);
 
         LogisticVertex tensorLogisticVertex = new LogisticVertex(aTensor, bTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorLogisticVertex.dLogPdf(1.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = tensorLogisticVertex.dLogPdf(1.5, aTensor, bTensor, tensorLogisticVertex);
 
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -16,10 +16,9 @@ import io.improbable.keanu.distributions.gradient.Logistic;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class LogisticVertexTest {
 
@@ -61,13 +60,11 @@ public class LogisticVertexTest {
         bTensor.setValue(0.5);
 
         LogisticVertex tensorLogisticVertex = new LogisticVertex(aTensor, bTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = tensorLogisticVertex.dLogPdf(1.5, aTensor, bTensor, tensorLogisticVertex);
+        Map<Vertex, DoubleTensor> actualDerivatives = tensorLogisticVertex.dLogPdf(1.5, aTensor, bTensor, tensorLogisticVertex);
 
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
-
-        assertEquals(logisticLogDiff.dPda, actual.withRespectTo(aTensor.getId()).scalar(), 1e-5);
-        assertEquals(logisticLogDiff.dPdb, actual.withRespectTo(bTensor.getId()).scalar(), 1e-5);
-        assertEquals(logisticLogDiff.dPdx, actual.withRespectTo(tensorLogisticVertex.getId()).scalar(), 1e-5);
+        assertEquals(logisticLogDiff.dPda, actualDerivatives.get(aTensor).scalar(), 1e-5);
+        assertEquals(logisticLogDiff.dPdb, actualDerivatives.get(bTensor).scalar(), 1e-5);
+        assertEquals(logisticLogDiff.dPdx, actualDerivatives.get(tensorLogisticVertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
@@ -18,11 +18,9 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class ParetoVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
@@ -17,6 +17,7 @@ import io.improbable.keanu.distributions.gradient.Pareto;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
@@ -61,12 +62,11 @@ public class ParetoVertexTest {
         scaleTensor.setValue(1.5);
 
         ParetoVertex vertex = new ParetoVertex(locationTensor, scaleTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = vertex.dLogPdf(2.5, locationTensor, scaleTensor, vertex);
-        PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
+        Map<Vertex, DoubleTensor> actualDerivatives = vertex.dLogPdf(2.5, locationTensor, scaleTensor, vertex);
 
-        assertEquals(paretoLogDiff.dPdLocation, actual.withRespectTo(locationTensor.getId()).scalar(), 1e-5);
-        assertEquals(paretoLogDiff.dPdScale, actual.withRespectTo(scaleTensor.getId()).scalar(), 1e-5);
-        assertEquals(paretoLogDiff.dPdX, actual.withRespectTo(vertex.getId()).scalar(), 1e-5);
+        assertEquals(paretoLogDiff.dPdLocation, actualDerivatives.get(locationTensor).scalar(), 1e-5);
+        assertEquals(paretoLogDiff.dPdScale, actualDerivatives.get(scaleTensor).scalar(), 1e-5);
+        assertEquals(paretoLogDiff.dPdX, actualDerivatives.get(vertex).scalar(), 1e-5);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
@@ -61,7 +61,7 @@ public class ParetoVertexTest {
         scaleTensor.setValue(1.5);
 
         ParetoVertex vertex = new ParetoVertex(locationTensor, scaleTensor);
-        Map<VertexId, DoubleTensor> actualDerivatives = vertex.dLogPdf(2.5);
+        Map<VertexId, DoubleTensor> actualDerivatives = vertex.dLogPdf(2.5, locationTensor, scaleTensor, vertex);
         PartialDerivatives actual = new PartialDerivatives(actualDerivatives);
 
         assertEquals(paretoLogDiff.dPdLocation, actual.withRespectTo(locationTensor.getId()).scalar(), 1e-5);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -221,16 +221,16 @@ public class ProbabilisticDoubleTensorContract {
     void hasNoGradientWithRespectToItsValueWhenObserved(V vertexUnderTest) {
         DoubleTensor ones = DoubleTensor.ones(vertexUnderTest.getValue().getShape());
         vertexUnderTest.observe(ones);
-        assertNull(vertexUnderTest.dLogProb(ones).get(vertexUnderTest.getId()));
+        assertNull(vertexUnderTest.dLogProb(ones).get(vertexUnderTest));
     }
 
-    public static void matchesKnownLogDensityOfVector(Probabilistic vertexUnderTest, double[] vector, double expectedLogDensity) {
+    public static void matchesKnownLogDensityOfVector(Probabilistic<DoubleTensor> vertexUnderTest, double[] vector, double expectedLogDensity) {
 
         double actualDensity = vertexUnderTest.logProb(DoubleTensor.create(vector, vector.length, 1));
         assertEquals(expectedLogDensity, actualDensity, 1e-5);
     }
 
-    public static void matchesKnownLogDensityOfScalar(Probabilistic vertexUnderTest, double scalar, double expectedLogDensity) {
+    public static void matchesKnownLogDensityOfScalar(Probabilistic<DoubleTensor> vertexUnderTest, double scalar, double expectedLogDensity) {
 
         double actualDensity = vertexUnderTest.logProb(DoubleTensor.scalar(scalar));
         assertEquals(expectedLogDensity, actualDensity, 1e-5);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -200,7 +200,7 @@ public class ProbabilisticDoubleTensorContract {
 
         hyperParameterVertex.setAndCascade(hyperParameterValue);
 
-        Map<VertexId, DoubleTensor> diffln = vertexUnderTest.dLogProbAtValue();
+        Map<VertexId, DoubleTensor> diffln = vertexUnderTest.dLogProbAtValue(hyperParameterVertex);
 
         double actualDiffLnDensity = diffln.get(hyperParameterVertex.getId()).scalar();
 
@@ -254,7 +254,8 @@ public class ProbabilisticDoubleTensorContract {
         V tensorVertex = vertexUnderTestSupplier.get();
 
         Map<VertexId, DoubleTensor> actualDerivatives = tensorVertex.dLogProb(
-            DoubleTensor.create(vector, new int[]{vector.length, 1})
+            DoubleTensor.create(vector, new int[]{vector.length, 1}),
+            tensorVertex
         );
 
         HashSet<VertexId> hyperParameterVertices = new HashSet<>(actualDerivatives.keySet());

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -246,7 +246,7 @@ public class ProbabilisticDoubleTensorContract {
 
             expectedPartialDerivatives = expectedPartialDerivatives.add(
                 new PartialDerivatives(
-                    scalarVertex.dLogPdf(vector[i])
+                    scalarVertex.dLogPdf(vector[i], scalarVertex)
                 )
             );
         }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertexTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class SmoothUniformVertexTest {
@@ -51,27 +51,27 @@ public class SmoothUniformVertexTest {
         SmoothUniformVertex smoothUniformVertex = new SmoothUniformVertex(0, 1, 10);
         SmoothUniformVertex tensorSmoothUniformVertex = new SmoothUniformVertex(0, 1, 10);
 
-        Map<VertexId, DoubleTensor> derivativeFlatRegion = smoothUniformVertex.dLogPdf(0.5, smoothUniformVertex);
-        Map<VertexId, DoubleTensor> tensorDerivativeFlatRegion = tensorSmoothUniformVertex.dLogPdf(0.5, tensorSmoothUniformVertex);
+        Map<Vertex, DoubleTensor> derivativeFlatRegion = smoothUniformVertex.dLogPdf(0.5, smoothUniformVertex);
+        Map<Vertex, DoubleTensor> tensorDerivativeFlatRegion = tensorSmoothUniformVertex.dLogPdf(0.5, tensorSmoothUniformVertex);
 
-        assertEquals(derivativeFlatRegion.get(smoothUniformVertex.getId()).scalar(),
-            tensorDerivativeFlatRegion.get(tensorSmoothUniformVertex.getId()).scalar(),
+        assertEquals(derivativeFlatRegion.get(smoothUniformVertex).scalar(),
+            tensorDerivativeFlatRegion.get(tensorSmoothUniformVertex).scalar(),
             DELTA
         );
 
-        Map<VertexId, DoubleTensor> derivativeLeftRegion = smoothUniformVertex.dLogPdf(-0.5, smoothUniformVertex);
-        Map<VertexId, DoubleTensor> tensorDerivativeLeftRegion = tensorSmoothUniformVertex.dLogPdf(-0.5, tensorSmoothUniformVertex);
+        Map<Vertex, DoubleTensor> derivativeLeftRegion = smoothUniformVertex.dLogPdf(-0.5, smoothUniformVertex);
+        Map<Vertex, DoubleTensor> tensorDerivativeLeftRegion = tensorSmoothUniformVertex.dLogPdf(-0.5, tensorSmoothUniformVertex);
 
-        assertEquals(derivativeLeftRegion.get(smoothUniformVertex.getId()).scalar(),
-            tensorDerivativeLeftRegion.get(tensorSmoothUniformVertex.getId()).scalar(),
+        assertEquals(derivativeLeftRegion.get(smoothUniformVertex).scalar(),
+            tensorDerivativeLeftRegion.get(tensorSmoothUniformVertex).scalar(),
             DELTA
         );
 
-        Map<VertexId, DoubleTensor> derivativeRightRegion = smoothUniformVertex.dLogPdf(1.5, smoothUniformVertex);
-        Map<VertexId, DoubleTensor> tensorDerivativeRightRegion = tensorSmoothUniformVertex.dLogPdf(1.5, tensorSmoothUniformVertex);
+        Map<Vertex, DoubleTensor> derivativeRightRegion = smoothUniformVertex.dLogPdf(1.5, smoothUniformVertex);
+        Map<Vertex, DoubleTensor> tensorDerivativeRightRegion = tensorSmoothUniformVertex.dLogPdf(1.5, tensorSmoothUniformVertex);
 
-        assertEquals(derivativeRightRegion.get(smoothUniformVertex.getId()).scalar(),
-            tensorDerivativeRightRegion.get(tensorSmoothUniformVertex.getId()).scalar(),
+        assertEquals(derivativeRightRegion.get(smoothUniformVertex).scalar(),
+            tensorDerivativeRightRegion.get(tensorSmoothUniformVertex).scalar(),
             DELTA
         );
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertexTest.java
@@ -51,24 +51,24 @@ public class SmoothUniformVertexTest {
         SmoothUniformVertex smoothUniformVertex = new SmoothUniformVertex(0, 1, 10);
         SmoothUniformVertex tensorSmoothUniformVertex = new SmoothUniformVertex(0, 1, 10);
 
-        Map<VertexId, DoubleTensor> derivativeFlatRegion = smoothUniformVertex.dLogPdf(0.5);
-        Map<VertexId, DoubleTensor> tensorDerivativeFlatRegion = tensorSmoothUniformVertex.dLogPdf(0.5);
+        Map<VertexId, DoubleTensor> derivativeFlatRegion = smoothUniformVertex.dLogPdf(0.5, smoothUniformVertex);
+        Map<VertexId, DoubleTensor> tensorDerivativeFlatRegion = tensorSmoothUniformVertex.dLogPdf(0.5, tensorSmoothUniformVertex);
 
         assertEquals(derivativeFlatRegion.get(smoothUniformVertex.getId()).scalar(),
             tensorDerivativeFlatRegion.get(tensorSmoothUniformVertex.getId()).scalar(),
             DELTA
         );
 
-        Map<VertexId, DoubleTensor> derivativeLeftRegion = smoothUniformVertex.dLogPdf(-0.5);
-        Map<VertexId, DoubleTensor> tensorDerivativeLeftRegion = tensorSmoothUniformVertex.dLogPdf(-0.5);
+        Map<VertexId, DoubleTensor> derivativeLeftRegion = smoothUniformVertex.dLogPdf(-0.5, smoothUniformVertex);
+        Map<VertexId, DoubleTensor> tensorDerivativeLeftRegion = tensorSmoothUniformVertex.dLogPdf(-0.5, tensorSmoothUniformVertex);
 
         assertEquals(derivativeLeftRegion.get(smoothUniformVertex.getId()).scalar(),
             tensorDerivativeLeftRegion.get(tensorSmoothUniformVertex.getId()).scalar(),
             DELTA
         );
 
-        Map<VertexId, DoubleTensor> derivativeRightRegion = smoothUniformVertex.dLogPdf(1.5);
-        Map<VertexId, DoubleTensor> tensorDerivativeRightRegion = tensorSmoothUniformVertex.dLogPdf(1.5);
+        Map<VertexId, DoubleTensor> derivativeRightRegion = smoothUniformVertex.dLogPdf(1.5, smoothUniformVertex);
+        Map<VertexId, DoubleTensor> tensorDerivativeRightRegion = tensorSmoothUniformVertex.dLogPdf(1.5, tensorSmoothUniformVertex);
 
         assertEquals(derivativeRightRegion.get(smoothUniformVertex.getId()).scalar(),
             tensorDerivativeRightRegion.get(tensorSmoothUniformVertex.getId()).scalar(),

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertexTest.java
@@ -1,6 +1,11 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import static java.lang.Math.pow;
+
+import static junit.framework.TestCase.assertEquals;
+
+import java.util.List;
+
 import org.apache.commons.math3.distribution.TDistribution;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Assert;
@@ -9,10 +14,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-
-import static java.lang.Math.pow;
-import static junit.framework.TestCase.assertEquals;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class StudentTVertexTest {
     private static final double DELTA = 0.0001;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertexTest.java
@@ -88,7 +88,7 @@ public class StudentTVertexTest {
 
         for (double t = -4.5; t <= 4.5; t += 0.5) {
             double expected;
-            double actual = studentT.dLogPdf(t).get(studentT.getId()).scalar();
+            double actual = studentT.dLogPdf(t, studentT).get(studentT.getId()).scalar();
             switch (v) {
                 case 1:
                     expected = (-2 * t) / (pow(t, 2) + 1.);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertexTest.java
@@ -88,7 +88,7 @@ public class StudentTVertexTest {
 
         for (double t = -4.5; t <= 4.5; t += 0.5) {
             double expected;
-            double actual = studentT.dLogPdf(t, studentT).get(studentT.getId()).scalar();
+            double actual = studentT.dLogPdf(t, studentT).get(studentT).scalar();
             switch (v) {
                 case 1:
                     expected = (-2 * t) / (pow(t, 2) + 1.);


### PR DESCRIPTION
This PR puts the previous work with reverse mode auto diff to use. The dLogProb of a probabilistic vertex now returns the diff with respect to the parents instead of with respect to *any* latent upstream vertices. This allows us to start the reverse mode auto diff at the probabilistic vertex and propagate back to a specified latent vertex.

Most files changed are just refactors but the big changes are in `LogProbGradientCalculator` and `Differentiator` classes have some significant changes.