### PR TITLE
Feature/improve testing

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -12,8 +12,6 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
-import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
 
 public class ScalarDoubleTensor implements DoubleTensor {
 
@@ -482,7 +480,7 @@ public class ScalarDoubleTensor implements DoubleTensor {
 
     @Override
     public DoubleTensor sqrtInPlace() {
-        return pow(0.5);
+        return powInPlace(0.5);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import org.apache.commons.math3.util.Pair;
 
 import io.improbable.keanu.kotlin.DoubleOperators;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -36,8 +36,7 @@ public class TensorTestOperations {
 
         for (int i = 0; i < flatIncrement.size(); i++) {
             flatIncrement.set(i, INCREMENT_AMOUNT);
-            DoubleTensor newInput = initialInput.plus(incrementTensor);
-            inputVertex.setValue(newInput);
+            inputVertex.setValue(initialInput.plus(incrementTensor));
 
             DoubleTensor newOutput = outputVertex.lazyEval();
             DoubleTensor differenceInOutput = newOutput.minus(initialOutput);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators;
 
-import static org.junit.Assert.assertEquals;
+import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 
@@ -33,6 +34,7 @@ public class TensorTestOperations {
         int[] dimensionsToSumOver = getWrtDimensions(inputVertex, outputVertex);
         DoubleTensor incrementTensor = DoubleTensor.zeros(inputVertex.getShape());
         Tensor.FlattenedView<Double> flatIncrement = incrementTensor.getFlattenedView();
+        Double boxedDelta = DELTA;
 
         for (int i = 0; i < flatIncrement.size(); i++) {
             flatIncrement.set(i, INCREMENT_AMOUNT);
@@ -41,7 +43,7 @@ public class TensorTestOperations {
             DoubleTensor newOutput = outputVertex.eval();
             DoubleTensor differenceInOutput = newOutput.minus(initialOutput);
             DoubleTensor differenceUsingGradient = outputWrtInput.times(incrementTensor).sum(dimensionsToSumOver);
-            checkIndividualErrors(differenceInOutput, differenceUsingGradient, DELTA);
+            assertThat(differenceUsingGradient, allCloseTo(boxedDelta, differenceInOutput));
         }
     }
 
@@ -56,17 +58,6 @@ public class TensorTestOperations {
         }
 
         return wrtDimensions;
-    }
-
-    private static void checkIndividualErrors(DoubleTensor expected, DoubleTensor actual, double delta) {
-        Tensor.FlattenedView<Double> flatExpected = expected.getFlattenedView();
-        Tensor.FlattenedView<Double> flatActual = actual.getFlattenedView();
-
-        assertEquals(flatExpected.size(), flatActual.size());
-
-        for (int i = 0; i < flatExpected.size(); i++) {
-            assertEquals(flatExpected.get(i), flatActual.get(i), delta);
-        }
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -38,7 +38,7 @@ public class TensorTestOperations {
             flatIncrement.set(i, INCREMENT_AMOUNT);
             inputVertex.setValue(initialInput.plus(incrementTensor));
 
-            DoubleTensor newOutput = outputVertex.lazyEval();
+            DoubleTensor newOutput = outputVertex.eval();
             DoubleTensor differenceInOutput = newOutput.minus(initialOutput);
             DoubleTensor differenceUsingGradient = outputWrtInput.times(incrementTensor).sum(dimensionsToSumOver);
             checkIndividualErrors(differenceInOutput, differenceUsingGradient, DELTA);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -28,7 +28,7 @@ public class TensorTestOperations {
                                                      final double DELTA) {
         DoubleTensor initialInput = inputVertex.getValue();
 
-        DoubleTensor initialOutput = outputVertex.lazyEval();
+        DoubleTensor initialOutput = outputVertex.eval();
         DoubleTensor outputWrtInput = outputVertex.getDualNumber().getPartialDerivatives().withRespectTo(inputVertex);
         int[] dimensionsToSumOver = getWrtDimensions(inputVertex, outputVertex);
         DoubleTensor incrementTensor = DoubleTensor.zeros(inputVertex.getShape());

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -1,0 +1,73 @@
+package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+
+public class TensorTestOperations {
+
+    public static void finiteDifferenceMatchesGradient(List<DoubleVertex> inputVertices,
+                                                       DoubleVertex outputVertex,
+                                                       final double INCREMENT_AMOUNT,
+                                                       final double DELTA) {
+        setInitialConditions(inputVertices);
+        inputVertices.forEach(v -> runGradientTestOnSingleInput(v, outputVertex, INCREMENT_AMOUNT, DELTA));
+    }
+
+    private static void setInitialConditions(List<DoubleVertex> inputVertices) {
+        inputVertices.forEach(v -> v.setValue(v.sample()));
+    }
+
+    private static void runGradientTestOnSingleInput(DoubleVertex inputVertex,
+                                                     DoubleVertex outputVertex,
+                                                     final double INCREMENT_AMOUNT,
+                                                     final double DELTA) {
+        DoubleTensor initialInput = inputVertex.getValue();
+
+        DoubleTensor initialOutput = outputVertex.lazyEval();
+        DoubleTensor outputWrtInput = outputVertex.getDualNumber().getPartialDerivatives().withRespectTo(inputVertex);
+        int[] dimensionsToSumOver = getWrtDimensions(inputVertex, outputVertex);
+        DoubleTensor incrementTensor = DoubleTensor.zeros(inputVertex.getShape());
+        Tensor.FlattenedView<Double> flatIncrement = incrementTensor.getFlattenedView();
+
+        for (int i = 0; i < flatIncrement.size(); i++) {
+            flatIncrement.set(i, INCREMENT_AMOUNT);
+            DoubleTensor newInput = initialInput.plus(incrementTensor);
+            inputVertex.setValue(newInput);
+
+            DoubleTensor newOutput = outputVertex.lazyEval();
+            DoubleTensor differenceInOutput = newOutput.minus(initialOutput);
+            DoubleTensor differenceUsingGradient = outputWrtInput.times(incrementTensor).sum(dimensionsToSumOver);
+            checkIndividualErrors(differenceInOutput, differenceUsingGradient, DELTA);
+        }
+    }
+
+    private static int[] getWrtDimensions(DoubleVertex wrtVertex,
+                                          DoubleVertex ofVertex) {
+        int wrtRank = wrtVertex.getShape().length;
+        int ofRank = ofVertex.getShape().length;
+        int[] wrtDimensions = new int[wrtRank];
+
+        for (int i = 0; i < wrtRank; i++) {
+            wrtDimensions[i] = ofRank + i;
+        }
+
+        return wrtDimensions;
+    }
+
+    private static void checkIndividualErrors(DoubleTensor expected, DoubleTensor actual, double delta) {
+        Tensor.FlattenedView<Double> flatExpected = expected.getFlattenedView();
+        Tensor.FlattenedView<Double> flatActual = actual.getFlattenedView();
+
+        assertEquals(flatExpected.size(), flatActual.size());
+
+        for (int i = 0; i < flatExpected.size(); i++) {
+            assertEquals(flatExpected.get(i), flatActual.get(i), delta);
+        }
+    }
+
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -1,10 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
 import static org.junit.Assert.assertEquals;
 
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
@@ -13,7 +15,6 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
-import org.nd4j.linalg.factory.Nd4j;
 
 public class ConcatenationVertexTest {
 
@@ -435,6 +436,17 @@ public class ConcatenationVertexTest {
         );
 
         assertEquals(concatPartialForward.withRespectTo(f), concatPartialReverse.withRespectTo(f));
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputA = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex inputB = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex inputC = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = new ConcatenationVertex(0, inputA, inputB, inputC);
+        final double INCREMENT = 10.0;
+        final double DELTA = 1e-10;
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -444,9 +444,7 @@ public class ConcatenationVertexTest {
         DoubleVertex inputB = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex inputC = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = new ConcatenationVertex(0, inputA, inputB, inputC);
-        final double INCREMENT = 10.0;
-        final double DELTA = 1e-10;
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -1,11 +1,14 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.HashSet;
 
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
@@ -271,4 +274,16 @@ public class MatrixMultiplicationVertexTest {
         assertEquals(expectedDydalpha, dydalphaForward);
         assertEquals(expectedDydalpha, dydalphaReverse);
     }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputA = new UniformVertex(new int[]{2,5}, -10.0, 10.0);
+        DoubleVertex inputB = new UniformVertex(new int[]{5,4}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputA.matrixMultiply(inputB);
+        final double INCREMENT = 10;
+        final double DELTA = 1e-10;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB), outputVertex, INCREMENT, DELTA);
+    }
+
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -277,8 +277,8 @@ public class MatrixMultiplicationVertexTest {
 
     @Test
     public void changesMatchGradient() {
-        DoubleVertex inputA = new UniformVertex(new int[]{2,5}, -10.0, 10.0);
-        DoubleVertex inputB = new UniformVertex(new int[]{5,4}, -10.0, 10.0);
+        DoubleVertex inputA = new UniformVertex(new int[]{2, 5}, -10.0, 10.0);
+        DoubleVertex inputB = new UniformVertex(new int[]{5, 4}, -10.0, 10.0);
         DoubleVertex outputVertex = inputA.matrixMultiply(inputB);
         final double INCREMENT = 10;
         final double DELTA = 1e-10;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -155,9 +155,7 @@ public class SliceVertexTest {
     public void changesMatchGradient() {
         DoubleVertex cube = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         SliceVertex slice = new SliceVertex(cube, 0, 0);
-        final double INCREMENT = 10.0;
-        final double DELTA = 1e-10;
-        finiteDifferenceMatchesGradient(ImmutableList.of(cube), slice, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(cube), slice, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -1,6 +1,14 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
@@ -8,9 +16,6 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SliceVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 public class SliceVertexTest {
 
@@ -144,6 +149,15 @@ public class SliceVertexTest {
         SliceVertex dimenTwoFace = new SliceVertex(cube, 2, 0);
         Assert.assertArrayEquals(new double[]{1, 3, 5, 7}, dimenTwoFace.getValue().asFlatDoubleArray(), 1e-6);
         Assert.assertArrayEquals(new int[]{2, 2}, dimenTwoFace.getShape());
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex cube = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        SliceVertex slice = new SliceVertex(cube, 0, 0);
+        final double INCREMENT = 10.0;
+        final double DELTA = 1e-10;
+        finiteDifferenceMatchesGradient(ImmutableList.of(cube), slice, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
@@ -59,7 +59,7 @@ public class ArcCosVertexTest {
 
     @Test
     public void changesMatchGradient() {
-        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -0.25, 0.25);
         DoubleVertex outputVertex = inputVertex.times(3).acos();
         final double INCREMENT = 0.001;
         final double DELTA = 1e-4;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
@@ -1,10 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class ArcCosVertexTest {
 
@@ -47,6 +55,16 @@ public class ArcCosVertexTest {
             }),
             DoubleVertex::acos
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.times(3).acos();
+        final double INCREMENT = 0.001;
+        final double DELTA = 1e-5;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
@@ -62,7 +62,7 @@ public class ArcCosVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).acos();
         final double INCREMENT = 0.001;
-        final double DELTA = 1e-5;
+        final double DELTA = 1e-4;
 
         finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
@@ -61,10 +61,8 @@ public class ArcCosVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -0.25, 0.25);
         DoubleVertex outputVertex = inputVertex.times(3).acos();
-        final double INCREMENT = 0.001;
-        final double DELTA = 1e-4;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
@@ -59,8 +59,8 @@ public class ArcSinVertexTest {
 
     @Test
     public void changesMatchGradient() {
-        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.times(3).asin();
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -0.25, 0.25);
+        DoubleVertex outputVertex = inputVertex.times(2.0).asin();
         final double INCREMENT = 0.001;
         final double DELTA = 1e-4;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
@@ -62,7 +62,7 @@ public class ArcSinVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).asin();
         final double INCREMENT = 0.001;
-        final double DELTA = 1e-5;
+        final double DELTA = 1e-4;
 
         finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
@@ -1,10 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class ArcSinVertexTest {
 
@@ -47,6 +55,16 @@ public class ArcSinVertexTest {
             }),
             DoubleVertex::asin
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.times(3).asin();
+        final double INCREMENT = 0.001;
+        final double DELTA = 1e-5;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
@@ -61,10 +61,8 @@ public class ArcSinVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -0.25, 0.25);
         DoubleVertex outputVertex = inputVertex.times(2.0).asin();
-        final double INCREMENT = 0.001;
-        final double DELTA = 1e-4;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
@@ -61,10 +61,8 @@ public class ArcTanVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -2.0, 2.0);
         DoubleVertex outputVertex = inputVertex.times(2).atan();
-        final double INCREMENT = 0.001;
-        final double DELTA = 1e-4;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
@@ -59,8 +59,8 @@ public class ArcTanVertexTest {
 
     @Test
     public void changesMatchGradient() {
-        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.times(3).atan();
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -2.0, 2.0);
+        DoubleVertex outputVertex = inputVertex.times(2).atan();
         final double INCREMENT = 0.001;
         final double DELTA = 1e-4;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
@@ -62,7 +62,7 @@ public class ArcTanVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).atan();
         final double INCREMENT = 0.001;
-        final double DELTA = 1e-5;
+        final double DELTA = 1e-4;
 
         finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
@@ -1,10 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class ArcTanVertexTest {
 
@@ -48,4 +56,15 @@ public class ArcTanVertexTest {
             DoubleVertex::atan
         );
     }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.times(3).atan();
+        final double INCREMENT = 0.001;
+        final double DELTA = 1e-5;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+    }
+
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
@@ -56,10 +56,8 @@ public class CosVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).cos();
-        final double INCREMENT = 0.001;
-        final double DELTA = 1e-5;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
@@ -1,10 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class CosVertexTest {
 
@@ -42,6 +50,16 @@ public class CosVertexTest {
             toDiagonalArray(new double[]{-Math.sin(0.1), -Math.sin(0.2), -Math.sin(0.3), -Math.sin(0.4)}),
             DoubleVertex::cos
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.times(3).cos();
+        final double INCREMENT = 0.001;
+        final double DELTA = 1e-5;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
@@ -1,10 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class ExpVertexTest {
 
@@ -42,6 +50,16 @@ public class ExpVertexTest {
             toDiagonalArray(new double[]{Math.exp(0.1), Math.exp(0.2), Math.exp(0.3), Math.exp(0.4)}),
             DoubleVertex::exp
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.div(3).exp();
+        final double INCREMENT = 0.001;
+        final double DELTA = 1e-5;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
@@ -56,10 +56,8 @@ public class ExpVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).exp();
-        final double INCREMENT = 0.001;
-        final double DELTA = 1e-5;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
@@ -56,10 +56,8 @@ public class LogVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 1.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).log();
-        final double INCREMENT = 0.001;
-        final double DELTA = 1e-5;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
@@ -54,10 +54,10 @@ public class LogVertexTest {
 
     @Test
     public void changesMatchGradient() {
-        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 0.0, 10.0);
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 1.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).log();
         final double INCREMENT = 0.001;
-        final double DELTA = 1e-6;
+        final double DELTA = 1e-5;
 
         finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
@@ -1,10 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class LogVertexTest {
 
@@ -42,6 +50,16 @@ public class LogVertexTest {
             toDiagonalArray(new double[]{1/0.1, 1/0.2, 1/0.3, 1/0.4}),
             DoubleVertex::log
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 0.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.div(3).log();
+        final double INCREMENT = 0.001;
+        final double DELTA = 1e-6;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
@@ -104,12 +104,10 @@ public class MatrixInverseVertexTest {
 
     @Test
     public void inverseDifferenceMatchesGradient() {
-        final double INCREMENT_AMOUNT = 0.001;
-        final double DELTA = 1e-6;
         DoubleVertex inputVertex = new UniformVertex(new int[]{3, 3}, 1.0, 25.0);
         DoubleVertex invertVertex = inputVertex.matrixInverse();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), invertVertex, INCREMENT_AMOUNT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), invertVertex, 0.001, 1e-6);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
@@ -1,14 +1,19 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
-import org.junit.Assert;
-import org.junit.Test;
 
 public class ReshapeVertexTest {
 
@@ -115,6 +120,16 @@ public class ReshapeVertexTest {
 
         Assert.assertArrayEquals(new int[]{1, 4, 2, 2}, forward.withRespectTo(A).getShape());
         Assert.assertArrayEquals(forward.withRespectTo(A).asFlatDoubleArray(), backward.withRespectTo(A).asFlatDoubleArray(), 1e-6);
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{4, 4}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.times(1.5).reshape(2, 2, 2, 2);
+        final double INCREMENT = 10.0;
+        final double DELTA = 1e-10;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
@@ -126,10 +126,8 @@ public class ReshapeVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{4, 4}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(1.5).reshape(2, 2, 2, 2);
-        final double INCREMENT = 10.0;
-        final double DELTA = 1e-10;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
@@ -1,12 +1,20 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.apache.commons.math3.analysis.function.Sigmoid;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class SigmoidVertexTest {
 
@@ -57,4 +65,15 @@ public class SigmoidVertexTest {
             DoubleVertex::sigmoid
         );
     }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.times(3).sigmoid();
+        final double INCREMENT = 0.001;
+        final double DELTA = 1e-6;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+    }
+
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
@@ -70,10 +70,8 @@ public class SigmoidVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).sigmoid();
-        final double INCREMENT = 0.001;
-        final double DELTA = 1e-6;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-6);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
@@ -1,10 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class SinVertexTest {
 
@@ -42,6 +50,16 @@ public class SinVertexTest {
             toDiagonalArray(new double[]{Math.cos(0.1), Math.cos(0.2), Math.cos(0.3), Math.cos(0.4)}),
             DoubleVertex::sin
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.div(3).sin();
+        final double INCREMENT = 0.001;
+        final double DELTA = 1e-5;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
@@ -56,10 +56,8 @@ public class SinVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).sin();
-        final double INCREMENT = 0.001;
-        final double DELTA = 1e-5;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -126,7 +127,8 @@ public class SumVertexTest {
         assertThat(dfdaReverse, equalTo(expectedDfdx));
     }
 
-    //@Test - XXX - The sum vertex produces dual numbers with "weird" shape.  Discuss.
+    @Test
+    @Ignore("Test Currently fails due to tensor shape differences")
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).sum();

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
@@ -132,10 +132,8 @@ public class SumVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).sum();
-        final double INCREMENT = 10.0;
-        final double DELTA = 1e-10;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
@@ -1,10 +1,13 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
@@ -122,4 +125,15 @@ public class SumVertexTest {
         assertThat(dfdaForward, equalTo(expectedDfdx));
         assertThat(dfdaReverse, equalTo(expectedDfdx));
     }
+
+    //@Test - XXX - The sum vertex produces dual numbers with "weird" shape.  Discuss.
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.times(3).sum();
+        final double INCREMENT = 10.0;
+        final double DELTA = 1e-10;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+    }
+
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
@@ -146,10 +146,8 @@ public class TakeVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).take(0, 0 , 0);
-        final double INCREMENT = 10.0;
-        final double DELTA = 1e-10;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -140,7 +141,8 @@ public class TakeVertexTest {
         Assert.assertArrayEquals(forward.withRespectTo(A).asFlatDoubleArray(), reverse.withRespectTo(A).asFlatDoubleArray(), 1e-6);
     }
 
-    //@Test - XXX another weird one with a scalar output
+    @Test
+    @Ignore("Currently fails due to partial derivative issues")
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).take(0, 0 , 0);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
@@ -1,12 +1,17 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
-import org.junit.Assert;
-import org.junit.Test;
 
 public class TakeVertexTest {
 
@@ -133,6 +138,16 @@ public class TakeVertexTest {
         Assert.assertArrayEquals(new int[]{1, 4, 2, 2}, forward.withRespectTo(A).getShape());
         Assert.assertArrayEquals(forward.withRespectTo(A).getShape(), reverse.withRespectTo(A).getShape());
         Assert.assertArrayEquals(forward.withRespectTo(A).asFlatDoubleArray(), reverse.withRespectTo(A).asFlatDoubleArray(), 1e-6);
+    }
+
+    //@Test - XXX another weird one with a scalar output
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.times(3).take(0, 0 , 0);
+        final double INCREMENT = 10.0;
+        final double DELTA = 1e-10;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
@@ -61,10 +61,8 @@ public class TanVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -1.0, 1.0);
         DoubleVertex outputVertex = inputVertex.div(3).tan();
-        final double INCREMENT = 0.0001;
-        final double DELTA = 1e-6;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.0001, 1e-6);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
@@ -59,7 +59,7 @@ public class TanVertexTest {
 
     @Test
     public void changesMatchGradient() {
-        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -1.0, 1.0);
         DoubleVertex outputVertex = inputVertex.div(3).tan();
         final double INCREMENT = 0.0001;
         final double DELTA = 1e-5;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
@@ -62,7 +62,7 @@ public class TanVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -1.0, 1.0);
         DoubleVertex outputVertex = inputVertex.div(3).tan();
         final double INCREMENT = 0.0001;
-        final double DELTA = 1e-5;
+        final double DELTA = 1e-6;
 
         finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
@@ -1,10 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class TanVertexTest {
 
@@ -47,6 +55,16 @@ public class TanVertexTest {
             }),
             DoubleVertex::tan
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.div(3).tan();
+        final double INCREMENT = 0.0001;
+        final double DELTA = 1e-5;
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, INCREMENT, DELTA);
     }
 
 }


### PR DESCRIPTION
Adding some new testing to systematically check our gradient calculations.  Few Notes:

 - Sum and Take produce weird shaped Tensors for their partial derivatives (eg for a 2 x 2 x 2 input they produce a 1 x 1 x 1 x 2 x 2 x 2 instead of a 1 x 1 x 2 x 2 x 2 which seems more correct).  As such I've just left the tests commented out for now.  Comments welcome, but I'm going to raise another ticket for investigating the take and sum stuff separately.

- I've fixed a bug where sqrtInPlace for Scalar Vertices wasn't correctly doing the operation in place.