### PR TITLE
Doomed test for equality to NaN

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/FitnessFunction.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/FitnessFunction.java
@@ -44,7 +44,7 @@ public class FitnessFunction {
     }
 
     public static boolean isValidInitialFitness(double fitnessValue) {
-        return fitnessValue == Double.NEGATIVE_INFINITY || fitnessValue == Double.NaN;
+        return fitnessValue == Double.NEGATIVE_INFINITY || Double.isNaN(fitnessValue);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -166,7 +166,7 @@ public class BayesianNetwork {
 
     public boolean isInImpossibleState() {
         double logOfMasterP = getLogOfMasterP();
-        return logOfMasterP == Double.NEGATIVE_INFINITY || logOfMasterP == Double.NaN;
+        return logOfMasterP == Double.NEGATIVE_INFINITY || Double.isNaN(logOfMasterP);
     }
 
     public static void setFromSampleAndCascade(List<? extends Vertex> vertices) {


### PR DESCRIPTION
This code checks to see if a floating point value is equal to the special Not A Number value (e.g., if (x == Double.NaN)). However, because of the special semantics of NaN, no value is equal to Nan, including NaN. Thus, x == Double.NaN always evaluates to false. To check to see if a value contained in x is the special Not A Number value, use Double.isNaN(x) (or Float.isNaN(x) if x is floating point precision).