### PR TITLE
class overrides equals(Object), but does not override hashCode()

### DIFF
--- a/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/byrow/ObjectParserWithPublicFieldTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/byrow/ObjectParserWithPublicFieldTest.java
@@ -1,15 +1,17 @@
 package io.improbable.keanu.util.csv.pojo.byrow;
 
-import io.improbable.keanu.util.csv.pojo.CsvProperty;
-import io.improbable.keanu.util.csv.pojo.byrow.RowsAsObjectParser;
-import org.junit.Before;
-import org.junit.Test;
+import static java.util.stream.Collectors.toList;
+
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.improbable.keanu.util.csv.pojo.CsvProperty;
 
 public class ObjectParserWithPublicFieldTest {
 
@@ -93,9 +95,17 @@ public class ObjectParserWithPublicFieldTest {
 
         @Override
         public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
             TestPOJOWithPublicFieldsClass that = (TestPOJOWithPublicFieldsClass) o;
-            if (id != that.id) return false;
-            return myName.equals(that.myName);
+            return id == that.id &&
+                Objects.equals(myName, that.myName);
+        }
+
+        @Override
+        public int hashCode() {
+
+            return Objects.hash(myName, id);
         }
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/byrow/ObjectParserWithSetterMethodTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/byrow/ObjectParserWithSetterMethodTest.java
@@ -1,15 +1,17 @@
 package io.improbable.keanu.util.csv.pojo.byrow;
 
-import io.improbable.keanu.util.csv.pojo.CsvProperty;
-import io.improbable.keanu.util.csv.pojo.byrow.RowsAsObjectParser;
-import org.junit.Before;
-import org.junit.Test;
+import static java.util.stream.Collectors.toList;
+
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.improbable.keanu.util.csv.pojo.CsvProperty;
 
 public class ObjectParserWithSetterMethodTest {
 
@@ -80,14 +82,18 @@ public class ObjectParserWithSetterMethodTest {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-
             TestPOJOWithSettersClass that = (TestPOJOWithSettersClass) o;
+            return myInt == that.myInt &&
+                Float.compare(that.someFloat, someFloat) == 0 &&
+                myBoolean == that.myBoolean &&
+                Objects.equals(myString, that.myString) &&
+                Objects.equals(myDouble, that.myDouble);
+        }
 
-            if (myInt != that.myInt) return false;
-            if (myBoolean != that.myBoolean) return false;
-            if (Float.compare(that.someFloat, someFloat) != 0) return false;
-            if (!myString.equals(that.myString)) return false;
-            return myDouble.equals(that.myDouble);
+        @Override
+        public int hashCode() {
+
+            return Objects.hash(myString, myInt, myDouble, someFloat, myBoolean);
         }
     }
 }


### PR DESCRIPTION
This class overrides equals(Object), but does not override hashCode(), and inherits the implementation of hashCode() from java.lang.Object (which returns the identity hash code, an arbitrary value assigned to the object by the VM).  Therefore, the class is very likely to violate the invariant that equal objects must have equal hashcodes.