### PR TITLE
Pass IntegerVertex to ChiSquaredVertex instead of IntegerTensor

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -45,8 +45,8 @@ public class ChiSquaredVertex extends DoubleVertex implements ProbabilisticDoubl
      *
      * @param k the number of degrees of freedom
      */
-    public ChiSquaredVertex(IntegerTensor k) {
-        this(k.getShape(), new ConstantIntegerVertex(k));
+    public ChiSquaredVertex(IntegerVertex k) {
+        this(k.getShape(), k);
     }
 
     public ChiSquaredVertex(int k) {


### PR DESCRIPTION
Because we don't pass tensors to other vertex constructors?