### PR TITLE
Use logGamma in logProb

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -4,8 +4,6 @@ import static io.improbable.keanu.distributions.dual.Diffs.A;
 import static io.improbable.keanu.distributions.dual.Diffs.B;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 
-import org.apache.commons.math3.special.Gamma;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -63,12 +63,12 @@ public class Beta implements ContinuousDistribution {
     @Override
     public Diffs dLogProb(DoubleTensor x) {
         final DoubleTensor oneMinusX = x.unaryMinus().plusInPlace(1);
-        final DoubleTensor digammaAlphaPlusBeta = alpha.plus(beta).applyInPlace(Gamma::digamma);
+        final DoubleTensor digammaAlphaPlusBeta = alpha.plus(beta).digammaInPlace();
         final DoubleTensor alphaMinusOneDivX = x.reciprocal().timesInPlace(alpha.minus(1));
 
         final DoubleTensor dLogPdx = alphaMinusOneDivX.minusInPlace(oneMinusX.reciprocal().timesInPlace(beta.minus(1)));
-        final DoubleTensor dLogPda = x.log().plusInPlace(digammaAlphaPlusBeta.minus(alpha.apply(Gamma::digamma)));
-        final DoubleTensor dLogPdb = oneMinusX.logInPlace().plusInPlace(digammaAlphaPlusBeta.minusInPlace(beta.apply(Gamma::digamma)));
+        final DoubleTensor dLogPda = x.log().plusInPlace(digammaAlphaPlusBeta.minus(alpha.digamma()));
+        final DoubleTensor dLogPdb = oneMinusX.logInPlace().plusInPlace(digammaAlphaPlusBeta.minusInPlace(beta.digamma()));
 
         return new Diffs()
             .put(A, dLogPda)

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -49,9 +49,9 @@ public class Beta implements ContinuousDistribution {
 
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
-        final DoubleTensor lnGammaAlpha = alpha.apply(Gamma::logGamma);
-        final DoubleTensor lnGammaBeta = beta.apply(Gamma::logGamma);
-        final DoubleTensor alphaPlusBetaLnGamma = (alpha.plus(beta)).applyInPlace(Gamma::logGamma);
+        final DoubleTensor lnGammaAlpha = alpha.logGamma();
+        final DoubleTensor lnGammaBeta = beta.logGamma();
+        final DoubleTensor alphaPlusBetaLnGamma = (alpha.plus(beta)).logGamma();
         final DoubleTensor alphaMinusOneTimesLnX = x.log().timesInPlace(alpha.minus(1));
         final DoubleTensor betaMinusOneTimesOneMinusXLn = x.unaryMinus().plusInPlace(1).logInPlace().timesInPlace(beta.minus(1));
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -51,7 +51,7 @@ public class Beta implements ContinuousDistribution {
     public DoubleTensor logProb(DoubleTensor x) {
         final DoubleTensor lnGammaAlpha = alpha.logGamma();
         final DoubleTensor lnGammaBeta = beta.logGamma();
-        final DoubleTensor alphaPlusBetaLnGamma = (alpha.plus(beta)).logGamma();
+        final DoubleTensor alphaPlusBetaLnGamma = (alpha.plus(beta)).logGammaInPlace();
         final DoubleTensor alphaMinusOneTimesLnX = x.log().timesInPlace(alpha.minus(1));
         final DoubleTensor betaMinusOneTimesOneMinusXLn = x.unaryMinus().plusInPlace(1).logInPlace().timesInPlace(beta.minus(1));
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
@@ -30,7 +30,7 @@ public class ChiSquared implements ContinuousDistribution {
     public DoubleTensor logProb(DoubleTensor x) {
         DoubleTensor halfK = k.toDouble().div(2);
         DoubleTensor numerator = halfK.minus(1).timesInPlace(x.log()).minusInPlace(x.div(2));
-        DoubleTensor denominator = halfK.times(LOG_TWO).plusInPlace(halfK.apply(Gamma::gamma).logInPlace());
+        DoubleTensor denominator = halfK.times(LOG_TWO).plusInPlace(halfK.logGamma());
         return numerator.minusInPlace(denominator);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/ChiSquared.java
@@ -1,7 +1,5 @@
 package io.improbable.keanu.distributions.continuous;
 
-import org.apache.commons.math3.special.Gamma;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
@@ -37,8 +37,8 @@ public class Dirichlet implements ContinuousDistribution {
             throw new IllegalArgumentException("Sum of values to calculate Dirichlet likelihood for must equal 1");
         }
         final double sumConcentrationLogged = concentration.minus(1.).timesInPlace(x.log()).sum();
-        final double sumLogGammaConcentration = concentration.apply(org.apache.commons.math3.special.Gamma::gamma).logInPlace().sum();
-        final double logGammaSumConcentration = Math.log(org.apache.commons.math3.special.Gamma.gamma(concentration.sum()));
+        final double sumLogGammaConcentration = concentration.logGamma().sum();
+        final double logGammaSumConcentration = org.apache.commons.math3.special.Gamma.logGamma(concentration.sum());
         return DoubleTensor.scalar(sumConcentrationLogged - sumLogGammaConcentration + logGammaSumConcentration);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
@@ -1,16 +1,16 @@
 package io.improbable.keanu.distributions.continuous;
 
+import static io.improbable.keanu.distributions.dual.Diffs.C;
+import static io.improbable.keanu.distributions.dual.Diffs.X;
+
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-import static io.improbable.keanu.distributions.dual.Diffs.C;
-import static io.improbable.keanu.distributions.dual.Diffs.X;
-
 public class Dirichlet implements ContinuousDistribution {
 
-    private static final double EPSILON =  0.00001;
+    private static final double EPSILON = 0.00001;
     private final DoubleTensor concentration;
 
     public static ContinuousDistribution withParameters(DoubleTensor concentration) {
@@ -23,9 +23,9 @@ public class Dirichlet implements ContinuousDistribution {
 
     @Override
     public DoubleTensor sample(int[] shape, KeanuRandom random) {
-       final ContinuousDistribution gamma = Gamma.withParameters(
-           DoubleTensor.ones(shape),
-           concentration
+        final ContinuousDistribution gamma = Gamma.withParameters(
+            DoubleTensor.ones(shape),
+            concentration
         );
         final DoubleTensor gammaSamples = gamma.sample(concentration.getShape(), random);
         return normalise(gammaSamples);
@@ -45,7 +45,7 @@ public class Dirichlet implements ContinuousDistribution {
     @Override
     public Diffs dLogProb(DoubleTensor x) {
         final DoubleTensor dLogPdc = x.log()
-            .minusInPlace(concentration.apply(org.apache.commons.math3.special.Gamma::digamma))
+            .minusInPlace(concentration.digamma())
             .plusInPlace(org.apache.commons.math3.special.Gamma.digamma(concentration.sum()));
         final DoubleTensor dLogPdx = concentration.minus(1).divInPlace(x);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -24,9 +24,9 @@ public class Gamma implements ContinuousDistribution {
     private final DoubleTensor k;
 
     /**
-     * @param theta  scale
-     * @param k      shape
-     * @return       a new ContinuousDistribution object
+     * @param theta scale
+     * @param k     shape
+     * @return a new ContinuousDistribution object
      */
     public static ContinuousDistribution withParameters(DoubleTensor theta, DoubleTensor k) {
         return new Gamma(theta, k);
@@ -92,8 +92,8 @@ public class Gamma implements ContinuousDistribution {
     }
 
     /**
-     * @param lambda   shape
-     * @param random   source of randomness
+     * @param lambda shape
+     * @param random source of randomness
      * @return a random number from the Exponential distribution
      */
     private static double exponentialSample(double lambda, KeanuRandom random) {
@@ -105,11 +105,11 @@ public class Gamma implements ContinuousDistribution {
 
     @Override
     public DoubleTensor logProb(DoubleTensor x) {
-        final DoubleTensor minusXOverTheta = x.div(theta).unaryMinusInPlace();
+        final DoubleTensor xOverTheta = x.div(theta);
         final DoubleTensor kLnTheta = k.times(theta.log());
-        final DoubleTensor xPowKMinus1 = x.pow(k.minus(1));
-        final DoubleTensor lnXToKMinus1 = (xPowKMinus1.divInPlace(k.apply(org.apache.commons.math3.special.Gamma::gamma))).logInPlace();
-        return minusXOverTheta.minusInPlace(kLnTheta).plusInPlace(lnXToKMinus1);
+        final DoubleTensor kMinus1LogX = k.minus(1).timesInPlace(x.log());
+        final DoubleTensor lgammaK = k.logGamma();
+        return kMinus1LogX.minusInPlace(lgammaK).minusInPlace(xOverTheta).minusInPlace(kLnTheta);
     }
 
     @Override
@@ -119,9 +119,9 @@ public class Gamma implements ContinuousDistribution {
         final DoubleTensor dLogPdk = x.log().minusInPlace(theta.log()).minusInPlace(k.apply(org.apache.commons.math3.special.Gamma::digamma));
 
         return new Diffs()
-        .put(THETA, dLogPdtheta)
-        .put(K, dLogPdk)
-        .put(X, dLogPdx);
+            .put(THETA, dLogPdtheta)
+            .put(K, dLogPdk)
+            .put(X, dLogPdx);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -116,7 +116,7 @@ public class Gamma implements ContinuousDistribution {
     public Diffs dLogProb(DoubleTensor x) {
         final DoubleTensor dLogPdx = k.minus(1.).divInPlace(x).minusInPlace(theta.reciprocal());
         final DoubleTensor dLogPdtheta = theta.times(k).plusInPlace(x.unaryMinus()).divInPlace(theta.pow(2.)).unaryMinusInPlace();
-        final DoubleTensor dLogPdk = x.log().minusInPlace(theta.log()).minusInPlace(k.apply(org.apache.commons.math3.special.Gamma::digamma));
+        final DoubleTensor dLogPdk = x.log().minusInPlace(theta.log()).minusInPlace(k.digamma());
 
         return new Diffs()
             .put(THETA, dLogPdtheta)

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -4,8 +4,6 @@ import static io.improbable.keanu.distributions.dual.Diffs.A;
 import static io.improbable.keanu.distributions.dual.Diffs.B;
 import static io.improbable.keanu.distributions.dual.Diffs.X;
 
-import org.apache.commons.math3.special.Gamma;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -35,7 +35,7 @@ public class InverseGamma implements ContinuousDistribution {
     public DoubleTensor logProb(DoubleTensor x) {
         final DoubleTensor aTimesLnB = alpha.times(beta.log());
         final DoubleTensor negAMinus1TimesLnX = x.log().timesInPlace(alpha.unaryMinus().minusInPlace(1));
-        final DoubleTensor lnGammaA = alpha.apply(Gamma::gamma).logInPlace();
+        final DoubleTensor lnGammaA = alpha.logGamma();
 
         return aTimesLnB.plus(negAMinus1TimesLnX).minusInPlace(lnGammaA).minusInPlace(beta.div(x));
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -42,7 +42,7 @@ public class InverseGamma implements ContinuousDistribution {
 
     @Override
     public Diffs dLogProb(DoubleTensor x) {
-        final DoubleTensor dPdalpha = x.log().unaryMinusInPlace().minusInPlace(alpha.apply(Gamma::digamma)).plusInPlace(beta.log());
+        final DoubleTensor dPdalpha = x.log().unaryMinusInPlace().minusInPlace(alpha.digamma()).plusInPlace(beta.log());
         final DoubleTensor dLogPdbeta = x.reciprocal().unaryMinusInPlace().plusInPlace(alpha.div(beta));
         final DoubleTensor dLogPdx = x.pow(2).reciprocalInPlace().timesInPlace(x.times(alpha.plus(1).unaryMinusInPlace()).plusInPlace(beta));
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -51,8 +51,8 @@ public class StudentT implements ContinuousDistribution {
         DoubleTensor vAsDouble = v.toDouble();
         DoubleTensor halfVPlusOne = vAsDouble.plus(1).divInPlace(2);
 
-        DoubleTensor logGammaHalfVPlusOne = halfVPlusOne.apply(Gamma::logGamma);
-        DoubleTensor logGammaHalfV = vAsDouble.div(2).applyInPlace(Gamma::logGamma);
+        DoubleTensor logGammaHalfVPlusOne = halfVPlusOne.logGamma();
+        DoubleTensor logGammaHalfV = vAsDouble.div(2).logGammaInPlace();
         DoubleTensor halfLogV = vAsDouble.log().divInPlace(2);
 
         return logGammaHalfVPlusOne

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -5,8 +5,6 @@ import static java.lang.Math.log;
 
 import static io.improbable.keanu.distributions.dual.Diffs.T;
 
-import org.apache.commons.math3.special.Gamma;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.dual.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -28,8 +26,8 @@ public class StudentT implements ContinuousDistribution {
      * ARL-TR-2168 March 2000
      * 5.1.23 page 36
      *
-     * @param v      Degrees of Freedom
-     * @return       a new ContinuousDistribution object
+     * @param v Degrees of Freedom
+     * @return a new ContinuousDistribution object
      */
     public static ContinuousDistribution withParameters(IntegerTensor v) {
         return new StudentT(v);

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
@@ -52,10 +52,11 @@ public class Binomial implements DiscreteDistribution {
 
         DoubleTensor kDouble = k.toDouble();
         DoubleTensor nDouble = n.toDouble();
-        DoubleTensor logPPowK = kDouble.times(p.log());
-        DoubleTensor log1MinusPPowNMinusK = nDouble.minus(kDouble).timesInPlace(p.unaryMinus().plusInPlace(1.0).logInPlace());
+        DoubleTensor kLogP = kDouble.times(p.log());
+        DoubleTensor logOneMinusP = p.unaryMinus().plusInPlace(1.0).logInPlace();
+        DoubleTensor nMinusKLogOneMinusP = nDouble.minus(kDouble).timesInPlace(logOneMinusP);
 
-        return logBinomialCoefficient.plusInPlace(logPPowK).plusInPlace(log1MinusPPowNMinusK);
+        return logBinomialCoefficient.plusInPlace(kLogP).plusInPlace(nMinusKLogOneMinusP);
     }
 
     private static DoubleTensor getLogBinomialCoefficient(IntegerTensor k, IntegerTensor n) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.distributions.discrete;
 
+import org.nd4j.linalg.util.ArrayUtil;
+
 import io.improbable.keanu.distributions.DiscreteDistribution;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import org.apache.commons.math3.util.CombinatoricsUtils;
-import org.nd4j.linalg.util.ArrayUtil;
 
 public class Binomial implements DiscreteDistribution {
 
@@ -50,29 +50,22 @@ public class Binomial implements DiscreteDistribution {
     public DoubleTensor logProb(IntegerTensor k) {
         DoubleTensor logBinomialCoefficient = getLogBinomialCoefficient(k, n);
 
-        DoubleTensor logBinomial = p.pow(k.toDouble())
-            .times(
-                p.unaryMinus().plusInPlace(1.0).powInPlace(n.minus(k).toDouble())
-            ).logInPlace();
+        DoubleTensor kDouble = k.toDouble();
+        DoubleTensor nDouble = n.toDouble();
+        DoubleTensor logPPowK = kDouble.times(p.log());
+        DoubleTensor log1MinusPPowNMinusK = nDouble.minus(kDouble).timesInPlace(p.unaryMinus().plusInPlace(1.0).logInPlace());
 
-        return logBinomialCoefficient.plusInPlace(logBinomial);
+        return logBinomialCoefficient.plusInPlace(logPPowK).plusInPlace(log1MinusPPowNMinusK);
     }
 
     private static DoubleTensor getLogBinomialCoefficient(IntegerTensor k, IntegerTensor n) {
-        Tensor.FlattenedView<Integer> nWrapped = n.getFlattenedView();
-        Tensor.FlattenedView<Integer> kWrapped = k.getFlattenedView();
 
-        int length = (int) k.getLength();
-        double[] logBinomialCoefficient = new double[length];
-        for (int i = 0; i < length; i++) {
-            logBinomialCoefficient[i] = getLogBinomialCoefficient(kWrapped.getOrScalar(i), nWrapped.getOrScalar(i));
-        }
+        DoubleTensor nDouble = n.toDouble();
+        DoubleTensor kDouble = k.toDouble();
+        DoubleTensor logNFactorial = nDouble.plus(1.0).logGammaInPlace();
+        DoubleTensor logKFactorial = kDouble.plus(1.0).logGammaInPlace();
+        DoubleTensor logNMinusKFactorial = nDouble.minus(kDouble).plusInPlace(1.0).logGammaInPlace();
 
-        return DoubleTensor.create(logBinomialCoefficient, k.getShape());
-    }
-
-    private static double getLogBinomialCoefficient(int k, int n) {
-        long binomialCoefficient = CombinatoricsUtils.binomialCoefficient(n, k);
-        return Math.log(binomialCoefficient);
+        return logNFactorial.minusInPlace(logKFactorial).minusInPlace(logNMinusKFactorial);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
@@ -54,7 +54,7 @@ public class Binomial implements DiscreteDistribution {
         DoubleTensor nDouble = n.toDouble();
         DoubleTensor kLogP = kDouble.times(p.log());
         DoubleTensor logOneMinusP = p.unaryMinus().plusInPlace(1.0).logInPlace();
-        DoubleTensor nMinusKLogOneMinusP = nDouble.minus(kDouble).timesInPlace(logOneMinusP);
+        DoubleTensor nMinusKLogOneMinusP = nDouble.minusInPlace(kDouble).timesInPlace(logOneMinusP);
 
         return logBinomialCoefficient.plusInPlace(kLogP).plusInPlace(nMinusKLogOneMinusP);
     }
@@ -65,7 +65,7 @@ public class Binomial implements DiscreteDistribution {
         DoubleTensor kDouble = k.toDouble();
         DoubleTensor logNFactorial = nDouble.plus(1.0).logGammaInPlace();
         DoubleTensor logKFactorial = kDouble.plus(1.0).logGammaInPlace();
-        DoubleTensor logNMinusKFactorial = nDouble.minus(kDouble).plusInPlace(1.0).logGammaInPlace();
+        DoubleTensor logNMinusKFactorial = nDouble.minusInPlace(kDouble).plusInPlace(1.0).logGammaInPlace();
 
         return logNFactorial.minusInPlace(logKFactorial).minusInPlace(logNMinusKFactorial);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Multinomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Multinomial.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.math3.special.Gamma;
 import org.nd4j.linalg.util.ArrayUtil;
 
 import com.google.common.base.Preconditions;
@@ -29,12 +28,11 @@ public class Multinomial implements DiscreteDistribution {
     }
 
     /**
-     * @see <a href="https://en.wikipedia.org/wiki/Multinomial_distribution">Multinomial Distribution</a>
-     * Generalisation of the Binomial distribution to variables with more than 2 possible values
-     *
      * @param n The number of draws from the variable
      * @param p The probability of observing each of the k values (which sum to 1)
      *          p is a Tensor whose first dimension must be of size k
+     * @see <a href="https://en.wikipedia.org/wiki/Multinomial_distribution">Multinomial Distribution</a>
+     * Generalisation of the Binomial distribution to variables with more than 2 possible values
      */
     private Multinomial(IntegerTensor n, DoubleTensor p) {
         Preconditions.checkArgument(
@@ -73,7 +71,8 @@ public class Multinomial implements DiscreteDistribution {
      * then I've now got a tensor of shape [a, b, k]
      * which I need to convert to a tensor of shape [k, a, b]
      * by doing a slice in the highest dimension and then concatenating again
-     * @param shape - the desired shape, not including the probabilities dimension
+     *
+     * @param shape   - the desired shape, not including the probabilities dimension
      * @param samples - the flat array of samples
      * @return
      */
@@ -83,7 +82,7 @@ public class Multinomial implements DiscreteDistribution {
             outputShape = ArrayUtils.remove(outputShape, 0);
         }
         IntegerTensor abkTensor = IntegerTensor.create(samples, ArrayUtils.add(outputShape, numCategories));
-        int[] kabArray = new int[] {};
+        int[] kabArray = new int[]{};
         for (int category = 0; category < numCategories; category++) {
             IntegerTensor abTensor = abkTensor.slice(outputShape.length, category);
             kabArray = ArrayUtils.addAll(kabArray, abTensor.asFlatIntegerArray());
@@ -115,7 +114,7 @@ public class Multinomial implements DiscreteDistribution {
                 break;
             }
         }
-        return index-1;
+        return index - 1;
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Multinomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Multinomial.java
@@ -136,8 +136,8 @@ public class Multinomial implements DiscreteDistribution {
             String.format("Inputs %s cannot be negative", k)
         );
 
-        DoubleTensor gammaN = n.plus(1).toDouble().applyInPlace(Gamma::logGamma);
-        DoubleTensor gammaKs = k.plus(1).toDouble().applyInPlace(Gamma::logGamma).sum(0);
+        DoubleTensor gammaN = n.plus(1).toDouble().logGammaInPlace();
+        DoubleTensor gammaKs = k.plus(1).toDouble().logGammaInPlace().sum(0);
         DoubleTensor kLogP = p.log().timesInPlace(k.toDouble()).sum(0);
         return kLogP.plusInPlace(gammaN).minusInPlace(gammaKs);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Multinomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Multinomial.java
@@ -72,8 +72,8 @@ public class Multinomial implements DiscreteDistribution {
      * which I need to convert to a tensor of shape [k, a, b]
      * by doing a slice in the highest dimension and then concatenating again
      *
-     * @param shape   - the desired shape, not including the probabilities dimension
-     * @param samples - the flat array of samples
+     * @param shape   the desired shape, not including the probabilities dimension
+     * @param samples the flat array of samples
      * @return
      */
     private IntegerTensor constructSampleTensor(int[] shape, int[] samples) {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -80,6 +80,6 @@ public class Poisson implements DiscreteDistribution {
         DoubleTensor kDouble = k.toDouble();
         DoubleTensor logFactorialK = kDouble.plus(1).logGammaInPlace();
 
-        return kDouble.times(mu.log()).minusInPlace(mu).minusInPlace(logFactorialK);
+        return kDouble.timesInPlace(mu.log()).minusInPlace(mu).minusInPlace(logFactorialK);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -79,7 +79,7 @@ public class Poisson implements DiscreteDistribution {
     public DoubleTensor logProb(IntegerTensor k) {
 
         DoubleTensor kDouble = k.toDouble();
-        DoubleTensor logFactorialK = kDouble.plus(1).applyInPlace(Gamma::logGamma);
+        DoubleTensor logFactorialK = kDouble.plus(1).logGammaInPlace();
 
         return kDouble.times(mu.log()).minusInPlace(mu).minusInPlace(logFactorialK);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -1,6 +1,5 @@
 package io.improbable.keanu.distributions.discrete;
 
-import org.apache.commons.math3.special.Gamma;
 import org.nd4j.linalg.util.ArrayUtil;
 
 import io.improbable.keanu.distributions.DiscreteDistribution;

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.distributions.discrete;
 
-import static org.apache.commons.math3.util.CombinatoricsUtils.factorial;
-
+import org.apache.commons.math3.special.Gamma;
 import org.nd4j.linalg.util.ArrayUtil;
 
 import io.improbable.keanu.distributions.DiscreteDistribution;
@@ -78,27 +77,10 @@ public class Poisson implements DiscreteDistribution {
 
     @Override
     public DoubleTensor logProb(IntegerTensor k) {
-        Tensor.FlattenedView<Double> muFlattenedView = mu.getFlattenedView();
-        Tensor.FlattenedView<Integer> kFlattenedView = k.getFlattenedView();
 
-        double[] result = new double[(int) k.getLength()];
-        for (int i = 0; i < result.length; i++) {
-            result[i] = Math.log(pmf(muFlattenedView.getOrScalar(i), kFlattenedView.getOrScalar(i)));
-        }
+        DoubleTensor kDouble = k.toDouble();
+        DoubleTensor logFactorialK = kDouble.plus(1).applyInPlace(Gamma::logGamma);
 
-        return DoubleTensor.create(result, k.getShape());
-    }
-
-    private static double pmf(double mu, int k) {
-        if (k >= 0 && k < 20) {
-            return (Math.pow(mu, k) / factorial(k)) * Math.exp(-mu);
-        } else if (k >= 20) {
-            double sumOfFactorial = 0;
-            for (int i = 1; i <= k; i++) {
-                sumOfFactorial += Math.log(i);
-            }
-            return Math.exp((k * Math.log(mu)) - sumOfFactorial - mu);
-        }
-        return 0;
+        return kDouble.times(mu.log()).minusInPlace(mu).minusInPlace(logFactorialK);
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -4,12 +4,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
 import io.improbable.keanu.kotlin.DoubleOperators;
 import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
-import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
 
 public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, DoubleOperators<DoubleTensor> {
 
@@ -148,6 +149,8 @@ public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, Double
 
     DoubleTensor logGamma();
 
+    DoubleTensor digamma();
+
     DoubleTensor sin();
 
     DoubleTensor cos();
@@ -234,6 +237,8 @@ public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, Double
     DoubleTensor logInPlace();
 
     DoubleTensor logGammaInPlace();
+
+    DoubleTensor digammaInPlace();
 
     DoubleTensor sinInPlace();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -146,6 +146,8 @@ public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, Double
 
     DoubleTensor log();
 
+    DoubleTensor logGamma();
+
     DoubleTensor sin();
 
     DoubleTensor cos();
@@ -230,6 +232,8 @@ public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, Double
     DoubleTensor sqrtInPlace();
 
     DoubleTensor logInPlace();
+
+    DoubleTensor logGammaInPlace();
 
     DoubleTensor sinInPlace();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -480,8 +480,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
 
     @Override
     public DoubleTensor logGammaInPlace() {
-        applyInPlace(Gamma::logGamma);
-        return this;
+        return applyInPlace(Gamma::logGamma);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -1038,12 +1038,12 @@ public class Nd4jDoubleTensor implements DoubleTensor {
 
     @Override
     public DoubleTensor toDouble() {
-        return this;
+        return duplicate();
     }
 
     @Override
     public IntegerTensor toInteger() {
-        return new Nd4jIntegerTensor(INDArrayExtensions.castToInteger(tensor, false));
+        return new Nd4jIntegerTensor(INDArrayExtensions.castToInteger(tensor, true));
     }
 
     private BooleanTensor fromMask(INDArray mask, int[] shape) {

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.LUDecomposition;
 import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.special.Gamma;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.ops.impl.transforms.comparison.CompareAndSet;
@@ -310,6 +311,11 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     }
 
     @Override
+    public DoubleTensor logGamma() {
+        return duplicate().logGammaInPlace();
+    }
+
+    @Override
     public DoubleTensor sin() {
         return duplicate().sinInPlace();
     }
@@ -469,6 +475,12 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     @Override
     public DoubleTensor logInPlace() {
         Transforms.log(tensor, false);
+        return this;
+    }
+
+    @Override
+    public DoubleTensor logGammaInPlace() {
+        applyInPlace(Gamma::logGamma);
         return this;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -316,6 +316,11 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     }
 
     @Override
+    public DoubleTensor digamma() {
+        return duplicate().digammaInPlace();
+    }
+
+    @Override
     public DoubleTensor sin() {
         return duplicate().sinInPlace();
     }
@@ -481,6 +486,11 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     @Override
     public DoubleTensor logGammaInPlace() {
         return applyInPlace(Gamma::logGamma);
+    }
+
+    @Override
+    public DoubleTensor digammaInPlace() {
+        return applyInPlace(Gamma::digamma);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.math3.special.Gamma;
 import org.apache.commons.math3.util.FastMath;
 
 import io.improbable.keanu.tensor.Tensor;
@@ -188,6 +189,11 @@ public class ScalarDoubleTensor implements DoubleTensor {
     @Override
     public DoubleTensor log() {
         return this.duplicate().logInPlace();
+    }
+
+    @Override
+    public DoubleTensor logGamma() {
+        return duplicate().logInPlace();
     }
 
     @Override
@@ -486,6 +492,12 @@ public class ScalarDoubleTensor implements DoubleTensor {
     @Override
     public DoubleTensor logInPlace() {
         value = Math.log(value);
+        return this;
+    }
+
+    @Override
+    public DoubleTensor logGammaInPlace() {
+        value = Gamma.logGamma(value);
         return this;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -197,6 +197,11 @@ public class ScalarDoubleTensor implements DoubleTensor {
     }
 
     @Override
+    public DoubleTensor digamma() {
+        return duplicate().digammaInPlace();
+    }
+
+    @Override
     public DoubleTensor sin() {
         return this.duplicate().sinInPlace();
     }
@@ -498,6 +503,12 @@ public class ScalarDoubleTensor implements DoubleTensor {
     @Override
     public DoubleTensor logGammaInPlace() {
         value = Gamma.logGamma(value);
+        return this;
+    }
+
+    @Override
+    public DoubleTensor digammaInPlace() {
+        value = Gamma.digamma(value);
         return this;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -193,7 +193,7 @@ public class ScalarDoubleTensor implements DoubleTensor {
 
     @Override
     public DoubleTensor logGamma() {
-        return duplicate().logInPlace();
+        return duplicate().logGammaInPlace();
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -480,7 +480,7 @@ public class Nd4jIntegerTensor implements IntegerTensor {
 
     @Override
     public IntegerTensor toInteger() {
-        return this;
+        return duplicate();
     }
 
     @Override

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertexTest.java
@@ -1,10 +1,11 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
-import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
 
 public class BinomialVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertexTest.java
@@ -37,22 +37,22 @@ public class BinomialVertexTest {
         for (int i = 0; i < n; i++) {
             double actual = testPoissonVertex.logPmf(i);
             double expected = distribution.logProbability(i);
-            assertEquals(expected, actual, 1e-3);
+            assertEquals(expected, actual, 1e-6);
         }
     }
 
     @Test
     public void logPmfIsCorrectForKnownVectorValues() {
         double p = 0.25;
-        int n = 50;
+        int n = 100;
         int k1 = 20;
-        int k2 = 30;
+        int k2 = 80;
 
         BinomialVertex testPoissonVertex = new BinomialVertex(new int[]{1, 2}, p, n);
         BinomialDistribution distribution = new BinomialDistribution(n, p);
 
         double actual = testPoissonVertex.logPmf(new int[]{k1, k2});
         double expected = distribution.logProbability(k1) + distribution.logProbability(k2);
-        assertEquals(expected, actual, 1e-3);
+        assertEquals(expected, actual, 1e-6);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
@@ -2,7 +2,6 @@ package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.math3.distribution.PoissonDistribution;
@@ -65,11 +64,11 @@ public class PoissonVertexTest {
 
         double logProb19 = poissonVertex.logPmf(19);
         double logProb20 = poissonVertex.logPmf(20);
-        double logProb30 = poissonVertex.logPmf(100);
+        double logProb100 = poissonVertex.logPmf(100);
 
         PoissonDistribution distribution = new PoissonDistribution(25);
         assertThat(logProb19, closeTo(distribution.logProbability(19), 1e-6));
         assertThat(logProb20, closeTo(distribution.logProbability(20), 1e-6));
-        assertThat(logProb30, closeTo(distribution.logProbability(100), 1e-6));
+        assertThat(logProb100, closeTo(distribution.logProbability(100), 1e-6));
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
@@ -1,8 +1,11 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
+import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -60,10 +63,13 @@ public class PoissonVertexTest {
 
         PoissonVertex poissonVertex = new PoissonVertex(mu);
 
-        double logProb = poissonVertex.logPmf(19);
-        double logProbThreshold = poissonVertex.logPmf(20);
-        double logProbAboveThreshold = poissonVertex.logPmf(21);
+        double logProb19 = poissonVertex.logPmf(19);
+        double logProb20 = poissonVertex.logPmf(20);
+        double logProb30 = poissonVertex.logPmf(100);
 
-        assertTrue(logProbAboveThreshold > logProbThreshold && logProbThreshold > logProb);
+        PoissonDistribution distribution = new PoissonDistribution(25);
+        assertThat(logProb19, closeTo(distribution.logProbability(19), 1e-6));
+        assertThat(logProb20, closeTo(distribution.logProbability(20), 1e-6));
+        assertThat(logProb30, closeTo(distribution.logProbability(100), 1e-6));
     }
 }


### PR DESCRIPTION
In order to convert our LogProbs to a graph we need to use common (and supported) ops. In many of our LogProbs we don't use gamma when we could and in some cases where we do use gamma we do gamma and then log, which is the logGamma. This PR uses logGamma in LogProb where it can in preparation for making LogProb return a graph.