### PR TITLE
Fix failing tests for Bayesian Methods for Hackers

### DIFF
--- a/keanu-examples/bayesianMethodsForHackers/src/main/java/examples/ChallengerDisaster.java
+++ b/keanu-examples/bayesianMethodsForHackers/src/main/java/examples/ChallengerDisaster.java
@@ -27,8 +27,8 @@ public class ChallengerDisaster {
         // as its proposal distribution. The suggested parameters were too wide, resulting
         // in bad proposals and by extension bad samples.
         // When it is easier to decouple the prior from the proposal distribution, we should revisit this
-        final double betaSigma = tauToSigma(0.01);
-        final double alphaSigma = tauToSigma(0.005);
+        final double betaSigma = convertTauToSigma(0.01);
+        final double alphaSigma = convertTauToSigma(0.005);
 
         GaussianVertex alpha = new GaussianVertex(0, alphaSigma);
         GaussianVertex beta = new GaussianVertex(0, betaSigma);
@@ -54,7 +54,7 @@ public class ChallengerDisaster {
         return cp;
     }
 
-    private static double tauToSigma(double tau) {
+    private static double convertTauToSigma(double tau) {
         return Math.sqrt(1.0 / tau);
     }
 

--- a/keanu-examples/bayesianMethodsForHackers/src/main/java/examples/ChallengerDisaster.java
+++ b/keanu-examples/bayesianMethodsForHackers/src/main/java/examples/ChallengerDisaster.java
@@ -18,17 +18,20 @@ import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
  */
 public class ChallengerDisaster {
     public static ChallengerPosteriors run() {
-
         ChallengerData data = ReadCsv.fromResources("challenger_data.csv")
             .asVectorizedColumnsDefinedBy(ChallengerData.class)
             .load();
 
-        double tau = 0.001;
-        double sigma = Math.sqrt(1.0 / tau);
-        GaussianVertex beta = new GaussianVertex(0, sigma);
-        beta.setValue(0);
-        GaussianVertex alpha = new GaussianVertex(0, sigma);
-        alpha.setValue(0);
+        // These hyperparameters differ from the alpha used in the example book
+        // This is because the sampling algorithm of choice uses the prior distribution
+        // as its proposal distribution. The suggested parameters were too wide, resulting
+        // in bad proposals and by extension bad samples.
+        // When it is easier to decouple the prior from the proposal distribution, we should revisit this
+        final double betaSigma = tauToSigma(0.01);
+        final double alphaSigma = tauToSigma(0.005);
+
+        GaussianVertex alpha = new GaussianVertex(0, alphaSigma);
+        GaussianVertex beta = new GaussianVertex(0, betaSigma);
 
         DoubleVertex temps = new ConstantDoubleVertex(data.temps);
         DoubleVertex logisticOutput = createLogisticFunction(beta, alpha, temps);
@@ -37,14 +40,9 @@ public class ChallengerDisaster {
         defect.observe(data.oRingFailure);
 
         BayesianNetwork net = new BayesianNetwork(defect.getConnectedGraph());
-        net.probeForNonZeroProbability(10000);
+        net.probeForNonZeroProbability(1000);
 
-//        SimulatedAnnealing.withDefaultConfig().getMaxAPosteriori(net, 10000);
-
-        System.out.println("Start Alpha " + alpha.getValue(0));
-        System.out.println("Start Beta " + beta.getValue(0));
-
-        int sampleCount = 120000;
+        final int sampleCount = 120000;
         NetworkSamples networkSamples = MetropolisHastings.withDefaultConfig()
             .getPosteriorSamples(net, net.getLatentVertices(), sampleCount)
             .drop(sampleCount / 10).downSample(net.getLatentVertices().size());
@@ -54,6 +52,10 @@ public class ChallengerDisaster {
         cp.mapBeta = networkSamples.getDoubleTensorSamples(beta).getAverages().scalar();
 
         return cp;
+    }
+
+    private static double tauToSigma(double tau) {
+        return Math.sqrt(1.0 / tau);
     }
 
     private static DoubleVertex createLogisticFunction(GaussianVertex beta, GaussianVertex alpha, DoubleVertex temp) {

--- a/keanu-examples/bayesianMethodsForHackers/src/main/java/examples/TextMessaging.java
+++ b/keanu-examples/bayesianMethodsForHackers/src/main/java/examples/TextMessaging.java
@@ -58,20 +58,20 @@ public class TextMessaging {
 
         return new TextMessagingResults(
             posteriorSamples.getIntegerTensorSamples(switchPoint).getScalarMode(),
-            posteriorSamples.getDoubleTensorSamples(earlyRate).getMode().scalar(),
+            posteriorSamples.getDoubleTensorSamples(earlyRate).getAverages().scalar(),
             posteriorSamples.getDoubleTensorSamples(lateRate).getMode().scalar()
         );
     }
 
     public static class TextMessagingResults {
         public final int switchPointMode;
-        public final double earlyRateMode;
-        public final double lateRateMode;
+        public final double earlyRateMean;
+        public final double lateRateMean;
 
-        TextMessagingResults(int switchPointMode, double earlyRateMode, double lateRateMode) {
+        TextMessagingResults(int switchPointMode, double earlyRateMean, double lateRateMean) {
             this.switchPointMode = switchPointMode;
-            this.earlyRateMode = earlyRateMode;
-            this.lateRateMode = lateRateMode;
+            this.earlyRateMean = earlyRateMean;
+            this.lateRateMean = lateRateMean;
         }
     }
 

--- a/keanu-examples/bayesianMethodsForHackers/src/test/java/examples/ChallengerDisasterTest.java
+++ b/keanu-examples/bayesianMethodsForHackers/src/test/java/examples/ChallengerDisasterTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 public class ChallengerDisasterTest {
 
@@ -22,7 +23,7 @@ public class ChallengerDisasterTest {
         System.out.println("mapBeta " + posteriors.mapBeta);
 
         // assert
-        assertThat(posteriors.mapBeta).isBetween(0.1, 0.4);
-        assertThat(posteriors.mapAlpha).isBetween(-25.0, -5.0);
+        assertThat(posteriors.mapBeta).isCloseTo(0.25, within(0.15));
+        assertThat(posteriors.mapAlpha).isCloseTo(-15d, within(5d));
     }
 }

--- a/keanu-examples/bayesianMethodsForHackers/src/test/java/examples/TextMessagingTest.java
+++ b/keanu-examples/bayesianMethodsForHackers/src/test/java/examples/TextMessagingTest.java
@@ -21,12 +21,12 @@ public class TextMessagingTest {
         TextMessaging.TextMessagingResults output = TextMessaging.run();
 
         System.out.println("Switch Point Mode " + output.switchPointMode);
-        System.out.println("Early Rate Mode " + output.earlyRateMode);
-        System.out.println("Late Rate Mode " + output.lateRateMode);
+        System.out.println("Early Rate Mean " + output.earlyRateMean);
+        System.out.println("Late Rate Mean " + output.lateRateMean);
 
         // assert
         assertThat(output.switchPointMode).isCloseTo(43, within(2));
-        assertThat(output.earlyRateMode).isCloseTo(17, within(2d));
-        assertThat(output.lateRateMode).isCloseTo(23, within(2d));
+        assertThat(output.earlyRateMean).isCloseTo(18, within(2d));
+        assertThat(output.lateRateMean).isCloseTo(23, within(2d));
     }
 }

--- a/keanu-examples/bayesianMethodsForHackers/src/test/java/examples/TextMessagingTest.java
+++ b/keanu-examples/bayesianMethodsForHackers/src/test/java/examples/TextMessagingTest.java
@@ -1,10 +1,12 @@
 package examples;
 
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.assertj.core.data.Offset;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 public class TextMessagingTest {
 
@@ -18,7 +20,13 @@ public class TextMessagingTest {
         // act
         TextMessaging.TextMessagingResults output = TextMessaging.run();
 
+        System.out.println("Switch Point Mode " + output.switchPointMode);
+        System.out.println("Early Rate Mode " + output.earlyRateMode);
+        System.out.println("Late Rate Mode " + output.lateRateMode);
+
         // assert
-        assertThat(output.switchPointMode).isBetween(41, 46);
+        assertThat(output.switchPointMode).isCloseTo(43, within(2));
+        assertThat(output.earlyRateMode).isCloseTo(17, within(2d));
+        assertThat(output.lateRateMode).isCloseTo(23, within(2d));
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -141,7 +141,7 @@ public abstract class Vertex<T> implements Observable<T> {
      * This marks the vertex's value as being observed and unchangeable.
      * <p>
      * Non-probabilistic vertices of continuous types (integer, double) are prohibited
-     * from being observed due to it's negative impact on inference algorithms. Non-probabilistic
+     * from being observed due to its negative impact on inference algorithms. Non-probabilistic
      * booleans are allowed to be observed as well as user defined types.
      *
      * @param value the value to be observed


### PR DESCRIPTION
The tests in #98 were failing in non-obvious ways. After digging into it and talking to @gordoncaleb, we determined that the proposal distribution for the Metropolis Hastings sampler (which was just the prior) was too wide, and made bad proposals, resulting in bad samples.

As the API for making a new proposal distribution is pretty clunky, this just changes the priors so that the proposal distribution is more appropriate.