### PR TITLE
Add log gamma vertex with forward and reverse autodiff

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -37,6 +37,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.CosVert
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpLambda;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ExpVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.FloorVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.LogGammaVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.LogVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.MatrixInverseVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ReshapeVertex;
@@ -128,6 +129,10 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
 
     public DoubleVertex log() {
         return new LogVertex(this);
+    }
+
+    public DoubleVertex logGamma() {
+        return new LogGammaVertex(this);
     }
 
     public DoubleVertex sigmoid() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
@@ -1,0 +1,34 @@
+package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+public class LogGammaVertex extends DoubleUnaryOpVertex {
+
+    public LogGammaVertex(DoubleVertex inputVertex) {
+        super(inputVertex);
+    }
+
+    @Override
+    protected DoubleTensor op(DoubleTensor value) {
+        return value.logGamma();
+    }
+
+    @Override
+    protected DualNumber dualOp(DualNumber dualNumber) {
+        return new DualNumber(op(dualNumber.getValue()), dualNumber.getPartialDerivatives().multiplyBy(inputVertex.getValue().digamma()));
+    }
+
+    @Override
+    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
+        Map<Vertex, PartialDerivatives> partials = new HashMap<>();
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().digamma(), true));
+        return partials;
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
@@ -22,13 +22,16 @@ public class LogGammaVertex extends DoubleUnaryOpVertex {
 
     @Override
     protected DualNumber dualOp(DualNumber dualNumber) {
-        return new DualNumber(op(dualNumber.getValue()), dualNumber.getPartialDerivatives().multiplyBy(inputVertex.getValue().digamma()));
+        DoubleTensor logGammaOfInput = op(dualNumber.getValue());
+        PartialDerivatives dLogGamma = dualNumber.getPartialDerivatives().multiplyBy(inputVertex.getValue().digamma());
+        return new DualNumber(logGammaOfInput, dLogGamma);
     }
 
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().digamma(), true));
+        PartialDerivatives dOutputsWrtInputVertex = derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().digamma(), true);
+        partials.put(inputVertex, dOutputsWrtInputVertex);
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
@@ -11,6 +11,11 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 public class LogGammaVertex extends DoubleUnaryOpVertex {
 
+    /**
+     * Returns the log of the gamma of the inputVertex
+     *
+     * @param inputVertex the vertex
+     */
     public LogGammaVertex(DoubleVertex inputVertex) {
         super(inputVertex);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -30,7 +30,8 @@ public class TensorTestOperations {
         DoubleTensor initialInput = inputVertex.getValue();
 
         DoubleTensor initialOutput = outputVertex.eval();
-        DoubleTensor outputWrtInput = outputVertex.getDualNumber().getPartialDerivatives().withRespectTo(inputVertex);
+        DoubleTensor outputWrtInputForward = outputVertex.getDualNumber().getPartialDerivatives().withRespectTo(inputVertex);
+
         int[] dimensionsToSumOver = getWrtDimensions(inputVertex, outputVertex);
         DoubleTensor incrementTensor = DoubleTensor.zeros(inputVertex.getShape());
         Tensor.FlattenedView<Double> flatIncrement = incrementTensor.getFlattenedView();
@@ -42,7 +43,7 @@ public class TensorTestOperations {
 
             DoubleTensor newOutput = outputVertex.eval();
             DoubleTensor differenceInOutput = newOutput.minus(initialOutput);
-            DoubleTensor differenceUsingGradient = outputWrtInput.times(incrementTensor).sum(dimensionsToSumOver);
+            DoubleTensor differenceUsingGradient = outputWrtInputForward.times(incrementTensor).sum(dimensionsToSumOver);
             assertThat(differenceUsingGradient, allCloseTo(boxedDelta, differenceInOutput));
         }
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -1,7 +1,8 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators;
 
-import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
 
 import java.util.List;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
@@ -1,0 +1,70 @@
+package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
+
+import static org.apache.commons.math3.special.Gamma.digamma;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
+
+import org.apache.commons.math3.special.Gamma;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.DeterministicRule;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+
+public class LogGammaVertexTest {
+
+    @Rule
+    public DeterministicRule rule = new DeterministicRule();
+
+    @Test
+    public void logGammaScalarVertexValue() {
+        operatesOnScalarVertexValue(
+            5,
+            Gamma.logGamma(5),
+            DoubleVertex::logGamma
+        );
+    }
+
+    @Test
+    public void calculatesDualNumberOScalarLogGamma() {
+        calculatesDualNumberOfScalar(
+            0.5,
+            digamma(0.5),
+            DoubleVertex::logGamma
+        );
+    }
+
+    @Test
+    public void logGammaMatrixVertexValues() {
+        operatesOn2x2MatrixVertexValues(
+            new double[]{0.0, 0.1, 0.2, 0.3},
+            new double[]{Gamma.logGamma(0.0), Gamma.logGamma(0.1), Gamma.logGamma(0.2), Gamma.logGamma(0.3)},
+            DoubleVertex::logGamma
+        );
+    }
+
+    @Test
+    public void calculatesDualNumberOfMatrixElementWiseLogGamma() {
+        calculatesDualNumberOfMatrixElementWiseOperator(
+            new double[]{0.1, 0.2, 0.3, 0.4},
+            toDiagonalArray(new double[]{digamma(0.1), digamma(0.2), digamma(0.3), digamma(0.4)}),
+            DoubleVertex::logGamma
+        );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 1.0, 10.0);
+        DoubleVertex outputVertex = inputVertex.div(3).logGamma();
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
+    }
+}


### PR DESCRIPTION
Log Gamma is a commonly used function in our distribution pdfs. In order to describe the pdf as a graph we need a vertex can be used for the operation.