### PR TITLE
Add ability to create categorical vertex of Dirichlet vertex

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
@@ -40,16 +40,7 @@ public class CategoricalVertex<T> extends Vertex<T> implements Probabilistic<T> 
     }
 
     public static CategoricalVertex<Integer> of(DirichletVertex vertex) {
-        final long categoriesCountLong = TensorShape.getLength(vertex.getShape());
-
-        // This should never happen in practice, but the number of categories must be an int
-        // as they get stored in a Collection, which can only have the size of an int.
-        if (categoriesCountLong > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException("Number of categories cannot exceed size of an integer");
-        }
-
-        // We cast to an int so we can expose a more predictable key type (Integer)
-        final int categoriesCount = (int) categoriesCountLong;
+        final int categoriesCount = Math.toIntExact(TensorShape.getLength(vertex.getShape()));
         final IntStream categories = IntStream.range(0, categoriesCount);
         final List<Integer> categoriesList = categories.boxed().collect(Collectors.toList());
         return CategoricalVertex.of(vertex, categoriesList);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.generic.probabilistic.discrete;
 
 import io.improbable.keanu.distributions.discrete.Categorical;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Probabilistic;
@@ -9,7 +10,6 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TakeVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.DirichletVertex;
-import org.nd4j.linalg.util.ArrayUtil;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -26,7 +26,7 @@ public class CategoricalVertex<T> extends Vertex<T> implements Probabilistic<T> 
     }
 
     public static <T> CategoricalVertex<T> of(DirichletVertex vertex, List<T> categories) {
-        final int length = ArrayUtil.prod(vertex.getShape());
+        final int length = (int) TensorShape.getLength(vertex.getShape());
         if (length != categories.size()) {
             throw new IllegalArgumentException("Categories must have length of vertex's size");
         }
@@ -40,7 +40,7 @@ public class CategoricalVertex<T> extends Vertex<T> implements Probabilistic<T> 
     }
 
     public static CategoricalVertex<Integer> of(DirichletVertex vertex) {
-        final int categoriesCount = ArrayUtil.prod(vertex.getShape());
+        final int categoriesCount = (int) TensorShape.getLength(vertex.getShape());
         final IntStream categories = IntStream.range(0, categoriesCount);
         final List<Integer> categoriesList = categories.boxed().collect(Collectors.toList());
         return CategoricalVertex.of(vertex, categoriesList);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertexTest.java
@@ -1,23 +1,22 @@
 package io.improbable.keanu.vertices.generic.probabilistic.discrete;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.DirichletVertex;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
 
 public class CategoricalVertexTest {
-    private final Logger log = LoggerFactory.getLogger(CategoricalVertexTest.class);
-
     private static double epsilon = 0.01;
     private static int N = 100000;
 
@@ -31,55 +30,96 @@ public class CategoricalVertexTest {
     @Test
     public void fourValuesEquallyWeightedSummingToOne() {
 
-        LinkedHashMap<TestEnum, DoubleVertex> selectableValues = new LinkedHashMap<>();
+        Map<TestEnum, DoubleVertex> selectableValues = new LinkedHashMap<>();
         selectableValues.put(TestEnum.A, ConstantVertex.of(0.25));
         selectableValues.put(TestEnum.B, ConstantVertex.of(0.25));
         selectableValues.put(TestEnum.C, ConstantVertex.of(0.25));
         selectableValues.put(TestEnum.D, ConstantVertex.of(0.25));
 
-        LinkedHashMap<TestEnum, Double> proportions = testSample(selectableValues, random);
+        Map<TestEnum, Double> proportions = testSample(selectableValues, random);
         assertProportionsWithinExpectedRanges(selectableValues, proportions);
     }
 
     @Test
     public void fourValuesNotEquallyWeightedSummingToOne() {
 
-        LinkedHashMap<TestEnum, DoubleVertex> selectableValues = new LinkedHashMap<>();
+        Map<TestEnum, DoubleVertex> selectableValues = new LinkedHashMap<>();
         selectableValues.put(TestEnum.A, ConstantVertex.of(0.1));
         selectableValues.put(TestEnum.B, ConstantVertex.of(0.2));
         selectableValues.put(TestEnum.C, ConstantVertex.of(0.3));
         selectableValues.put(TestEnum.D, ConstantVertex.of(0.4));
 
-        LinkedHashMap<TestEnum, Double> proportions = testSample(selectableValues, random);
+        Map<TestEnum, Double> proportions = testSample(selectableValues, random);
         assertProportionsWithinExpectedRanges(selectableValues, proportions);
     }
 
     @Test
     public void fourValuesEquallyWeightedSummingToFour() {
 
-        LinkedHashMap<TestEnum, DoubleVertex> selectableValues = new LinkedHashMap<>();
+        Map<TestEnum, DoubleVertex> selectableValues = new LinkedHashMap<>();
         selectableValues.put(TestEnum.A, ConstantVertex.of(1.0));
         selectableValues.put(TestEnum.B, ConstantVertex.of(1.0));
         selectableValues.put(TestEnum.C, ConstantVertex.of(1.0));
         selectableValues.put(TestEnum.D, ConstantVertex.of(1.0));
 
-        LinkedHashMap<TestEnum, Double> proportions = testSample(selectableValues, random);
-        LinkedHashMap<TestEnum, DoubleVertex> normalisedSelectableValues = normaliseSelectableValues(selectableValues, 4.0);
+        Map<TestEnum, Double> proportions = testSample(selectableValues, random);
+        Map<TestEnum, DoubleVertex> normalisedSelectableValues = normaliseSelectableValues(selectableValues, 4.0);
         assertProportionsWithinExpectedRanges(normalisedSelectableValues, proportions);
     }
 
     @Test
     public void fourValuesNotEquallyWeightedSummingToFour() {
 
-        LinkedHashMap<TestEnum, DoubleVertex> selectableValues = new LinkedHashMap<>();
+        Map<TestEnum, DoubleVertex> selectableValues = new LinkedHashMap<>();
         selectableValues.put(TestEnum.A, ConstantVertex.of(0.25));
         selectableValues.put(TestEnum.B, ConstantVertex.of(0.75));
         selectableValues.put(TestEnum.C, ConstantVertex.of(1.25));
         selectableValues.put(TestEnum.D, ConstantVertex.of(1.75));
 
-        LinkedHashMap<TestEnum, Double> proportions = testSample(selectableValues, random);
-        LinkedHashMap<TestEnum, DoubleVertex> normalisedSelectableValues = normaliseSelectableValues(selectableValues, 4.0);
+        Map<TestEnum, Double> proportions = testSample(selectableValues, random);
+        Map<TestEnum, DoubleVertex> normalisedSelectableValues = normaliseSelectableValues(selectableValues, 4.0);
         assertProportionsWithinExpectedRanges(normalisedSelectableValues, proportions);
+    }
+
+    @Test
+    public void ofDirichletVertexHasCorrectProportions() {
+        final DoubleTensor concentration = DoubleTensor.create(1, 2, 3, 4);
+        final DirichletVertex dirichletVertex = new DirichletVertex(new ConstantDoubleVertex(concentration));
+        final CategoricalVertex<TestEnum> categoricalVertex = CategoricalVertex.of(dirichletVertex, Arrays.asList(TestEnum.A, TestEnum.B, TestEnum.C, TestEnum.D));
+        final DoubleTensor sample = dirichletVertex.getValue();
+
+        final Map<TestEnum, DoubleVertex> expectedProportions = new LinkedHashMap<>();
+        expectedProportions.put(TestEnum.A, ConstantVertex.of(sample.getValue(0, 0)));
+        expectedProportions.put(TestEnum.B, ConstantVertex.of(sample.getValue(0, 1)));
+        expectedProportions.put(TestEnum.C, ConstantVertex.of(sample.getValue(0, 2)));
+        expectedProportions.put(TestEnum.D, ConstantVertex.of(sample.getValue(0, 3)));
+
+        final Map<TestEnum, Double> proportions = testSampleFromVertex(categoricalVertex, random);
+        assertProportionsWithinExpectedRanges(expectedProportions, proportions);
+    }
+
+    @Test
+    public void ofDirichletVertexUsesIntegerRangeByDefault() {
+        final DoubleTensor concentration = DoubleTensor.create(1, 2, 3, 4, 5);
+        final DirichletVertex dirichletVertex = new DirichletVertex(new ConstantDoubleVertex(concentration));
+        final CategoricalVertex<Integer> categoricalVertex = CategoricalVertex.of(dirichletVertex);
+        final DoubleTensor sample = dirichletVertex.getValue();
+
+        final Map<Integer, DoubleVertex> expectedProportions = new LinkedHashMap<>();
+        expectedProportions.put(0, ConstantVertex.of(sample.getValue(0, 0)));
+        expectedProportions.put(1, ConstantVertex.of(sample.getValue(0, 1)));
+        expectedProportions.put(2, ConstantVertex.of(sample.getValue(0, 2)));
+        expectedProportions.put(3, ConstantVertex.of(sample.getValue(0, 3)));
+        expectedProportions.put(4, ConstantVertex.of(sample.getValue(0, 4)));
+
+        final Map<Integer, Double> proportions = testSampleFromVertex(categoricalVertex, random);
+        assertProportionsWithinExpectedRanges(expectedProportions, proportions);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ofDirichletWrongAmountOfCategoriesFails() {
+        final DirichletVertex dirichletVertex = new DirichletVertex(1, 2, 3, 4, 5);
+        CategoricalVertex.of(dirichletVertex, Arrays.asList(TestEnum.A, TestEnum.B, TestEnum.C, TestEnum.D));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -131,28 +171,25 @@ public class CategoricalVertexTest {
         select.logProb(TestEnum.A);
     }
 
-    private LinkedHashMap<TestEnum, Double> testSample(LinkedHashMap<TestEnum, DoubleVertex> selectableValues,
-                                                       KeanuRandom random) {
+    private <T> Map<T, Double> testSample(Map<T, DoubleVertex> selectableValues,
+                                          KeanuRandom random) {
+        return testSampleFromVertex(new CategoricalVertex<>(selectableValues), random);
+    }
 
-        CategoricalVertex<TestEnum> select = new CategoricalVertex<>(selectableValues);
-
-        LinkedHashMap<TestEnum, Integer> sampleFrequencies = new LinkedHashMap<>();
-        sampleFrequencies.put(TestEnum.A, 0);
-        sampleFrequencies.put(TestEnum.B, 0);
-        sampleFrequencies.put(TestEnum.C, 0);
-        sampleFrequencies.put(TestEnum.D, 0);
+    private <T> Map<T, Double> testSampleFromVertex(CategoricalVertex<T> vertex, KeanuRandom random) {
+        Map<T, Integer> sampleFrequencies = vertex.getSelectableValues().keySet().stream().collect(Collectors.toMap(key -> key, key -> 0));
 
         for (int i = 0; i < N; i++) {
-            TestEnum s = select.sample(random);
+            T s = vertex.sample(random);
             sampleFrequencies.put(s, sampleFrequencies.get(s) + 1);
         }
 
         return calculateProportions(sampleFrequencies, N);
     }
 
-    private LinkedHashMap<TestEnum, Double> calculateProportions(LinkedHashMap<TestEnum, Integer> sampleFrequencies, int n) {
-        LinkedHashMap<TestEnum, Double> proportions = new LinkedHashMap<>();
-        for (Map.Entry<TestEnum, Integer> entry : sampleFrequencies.entrySet()) {
+    private <T> Map<T, Double> calculateProportions(Map<T, Integer> sampleFrequencies, int n) {
+        Map<T, Double> proportions = new LinkedHashMap<>();
+        for (Map.Entry<T, Integer> entry : sampleFrequencies.entrySet()) {
             double proportion = (double) entry.getValue() / n;
             proportions.put(entry.getKey(), proportion);
         }
@@ -160,21 +197,20 @@ public class CategoricalVertexTest {
         return proportions;
     }
 
-    private void assertProportionsWithinExpectedRanges(LinkedHashMap<TestEnum, DoubleVertex> selectableValues,
-                                                       HashMap<TestEnum, Double> proportions) {
+    private <T> void assertProportionsWithinExpectedRanges(Map<T, DoubleVertex> selectableValues,
+                                                           Map<T, Double> proportions) {
 
-        for (Map.Entry<TestEnum, Double> entry : proportions.entrySet()) {
-            log.info(entry.getKey() + ": " + entry.getValue());
+        for (Map.Entry<T, Double> entry : proportions.entrySet()) {
             double p = entry.getValue();
             double expected = selectableValues.get(entry.getKey()).getValue().scalar();
-            assertEquals(p, expected, epsilon);
+            assertEquals(String.format("Sample proportion for category %s is not as expected", entry.getKey()), p, expected, epsilon);
         }
     }
 
-    private LinkedHashMap<TestEnum, DoubleVertex> normaliseSelectableValues(LinkedHashMap<TestEnum, DoubleVertex> selectableValues,
-                                                                            double sum) {
-        LinkedHashMap<TestEnum, DoubleVertex> normalised = new LinkedHashMap<>();
-        for (Map.Entry<TestEnum, DoubleVertex> entry : selectableValues.entrySet()) {
+    private <T> Map<T, DoubleVertex> normaliseSelectableValues(Map<T, DoubleVertex> selectableValues,
+                                                               double sum) {
+        Map<T, DoubleVertex> normalised = new LinkedHashMap<>();
+        for (Map.Entry<T, DoubleVertex> entry : selectableValues.entrySet()) {
             double normalizedProbability = entry.getValue().getValue().scalar() / sum;
             normalised.put(entry.getKey(), ConstantVertex.of(normalizedProbability));
         }


### PR DESCRIPTION
Fixes #185 by adding the ability to create a categorical vertex directly from a Dirichlet vertex. This means that the values of the Dirichlet vertex will become the probabilities for the values of the categorical vertex.

Tests have been added verifying the basic behaviour, that sampling from the resultant categorical vertex matches the probabilities from the input Dirichlet. 

Initial implementation by @johannespetrat, I simply tweaked and added tests