### PR TITLE
Bug/scalar partials

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/ProposalDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/ProposalDistribution.java
@@ -12,7 +12,7 @@ public interface ProposalDistribution {
         return new PriorProposalDistribution();
     }
 
-    Proposal getProposal(Set<Vertex> vertices, KeanuRandom random);
+    Proposal getProposal(Set<? extends Vertex> vertices, KeanuRandom random);
 
     <T> double logProb(Probabilistic<T> vertex, T ofValue, T givenValue);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/ProposalDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/ProposalDistribution.java
@@ -12,7 +12,7 @@ public interface ProposalDistribution {
         return new PriorProposalDistribution();
     }
 
-    Proposal getProposal(Set<? extends Vertex> vertices, KeanuRandom random);
+    Proposal getProposal(Set<Vertex> vertices, KeanuRandom random);
 
     <T> double logProb(Probabilistic<T> vertex, T ofValue, T givenValue);
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -146,6 +146,10 @@ public class TensorShape {
     }
 
     public static int[] selectDimensions(int from, int to, int[] shape) {
+        if (from > to) {
+            throw new IllegalArgumentException("to dimension must be less than from");
+        }
+
         int[] newShape = new int[to - from + 1];
 
         for (int i = 0; i < (to - from + 1); i++) {

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -145,6 +145,16 @@ public class TensorShape {
         return dims;
     }
 
+    public static int[] selectDimensions(int from, int to, int[] shape) {
+        int[] newShape = new int[to - from + 1];
+
+        for (int i = 0; i < (to - from + 1); i++) {
+            newShape[i] = shape[i + from];
+        }
+
+        return newShape;
+    }
+
     public static int[] slideDimension(int from, int to, int[] shape) {
         List<Integer> shapeList = new ArrayList<>(Ints.asList(shape));
         Integer dimLength = shapeList.remove(from);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
@@ -31,7 +31,7 @@ public class Differentiator {
         alreadyQueued.add(ofVertex);
 
         Map<Vertex, PartialDerivatives> dwrtOf = new HashMap<>();
-        collectPartials(singletonMap(ofVertex, dWrtOfVertex), dwrtOf, ofVertex.getShape().length);
+        collectPartials(singletonMap(ofVertex, dWrtOfVertex), dwrtOf, ofVertex);
 
         Map<VertexId, PartialDerivatives> wrtOf = new HashMap<>();
 
@@ -46,7 +46,7 @@ public class Differentiator {
             if (visiting instanceof Differentiable) {
                 Differentiable visitingDifferentiable = ((Differentiable) visiting);
                 Map<Vertex, PartialDerivatives> partialDerivatives = visitingDifferentiable.reverseModeAutoDifferentiation(dwrtOf.get(visiting));
-                collectPartials(partialDerivatives, dwrtOf, visiting.getShape().length);
+                collectPartials(partialDerivatives, dwrtOf, visiting);
             }
 
             if (!visiting.isProbabilistic()) {
@@ -62,17 +62,20 @@ public class Differentiator {
         return wrtOfToOfWrt(wrtOf).get(ofVertex.getId());
     }
 
-    private static void collectPartials(Map<Vertex, PartialDerivatives> partialDerivatives, Map<Vertex, PartialDerivatives> dwrtOf, int prevRank) {
+    private static void collectPartials(Map<Vertex, PartialDerivatives> partialDerivatives,
+                                        Map<Vertex, PartialDerivatives> dwrtOf,
+                                        Vertex visiting) {
 
         for (Map.Entry<Vertex, PartialDerivatives> v : partialDerivatives.entrySet()) {
 
             Vertex wrtVertex = v.getKey();
             PartialDerivatives partialsOf = v.getValue();
             int[] wrtShape = wrtVertex.getShape();
+            int prevRank = visiting.getShape().length;
 
             PartialDerivatives dwrtV;
             if (TensorShape.isScalar(wrtShape)) {
-                dwrtV = partialsOf.sum(false, TensorShape.dimensionRange(-prevRank, 0));
+                dwrtV = partialsOf.sumOverWrtDimensions(TensorShape.dimensionRange(-prevRank, 0));
             } else {
                 dwrtV = partialsOf;
             }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
@@ -52,8 +52,10 @@ public class DoubleIfVertex extends DoubleVertex implements NonProbabilistic<Dou
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
         BooleanTensor predicateValue = predicate.getValue();
-        partials.put(thn, derivativeOfOutputsWithRespectToSelf.multiplyBy(predicateValue.toDoubleMask(), true));
-        partials.put(els, derivativeOfOutputsWithRespectToSelf.multiplyBy(predicateValue.not().toDoubleMask(), true));
+        partials.put(thn, derivativeOfOutputsWithRespectToSelf
+            .multiplyAlongWrtDimensions(predicateValue.toDoubleMask(), this.getShape()));
+        partials.put(els, derivativeOfOutputsWithRespectToSelf
+            .multiplyAlongWrtDimensions(predicateValue.not().toDoubleMask(), this.getShape()));
         return partials;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DualNumber.java
@@ -191,13 +191,13 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         if (this.partialDerivatives.isEmpty()) {
             thisInfMultiplied = PartialDerivatives.OF_CONSTANT;
         } else {
-            thisInfMultiplied = this.partialDerivatives.multiplyBy(that.value);
+            thisInfMultiplied = this.partialDerivatives.multiplyAlongOfDimensions(that.value, this.getValue().getShape());
         }
 
         if (that.partialDerivatives.isEmpty()) {
             thatInfMultiplied = PartialDerivatives.OF_CONSTANT;
         } else {
-            thatInfMultiplied = that.partialDerivatives.multiplyBy(this.value);
+            thatInfMultiplied = that.partialDerivatives.multiplyAlongOfDimensions(this.value, that.getValue().getShape());
         }
 
         PartialDerivatives newInf = thisInfMultiplied.add(thatInfMultiplied);
@@ -214,13 +214,13 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         if (this.partialDerivatives.isEmpty()) {
             thisInfMultiplied = PartialDerivatives.OF_CONSTANT;
         } else {
-            thisInfMultiplied = this.partialDerivatives.multiplyBy(that.value);
+            thisInfMultiplied = this.partialDerivatives.multiplyAlongOfDimensions(that.value, this.getValue().getShape());
         }
 
         if (that.partialDerivatives.isEmpty()) {
             thatInfMultiplied = PartialDerivatives.OF_CONSTANT;
         } else {
-            thatInfMultiplied = that.partialDerivatives.multiplyBy(this.value);
+            thatInfMultiplied = that.partialDerivatives.multiplyAlongOfDimensions(this.value, that.getValue().getShape());
         }
 
         if (thisInfMultiplied.isEmpty() && thatInfMultiplied.isEmpty()) {
@@ -241,13 +241,15 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         if (this.partialDerivatives.isEmpty()) {
             thisInfBase = PartialDerivatives.OF_CONSTANT;
         } else {
-            thisInfBase = this.partialDerivatives.multiplyBy(that.value.times(this.value.pow(that.value.minus(1))));
+            thisInfBase = this.partialDerivatives
+                .multiplyAlongOfDimensions(that.value.times(this.value.pow(that.value.minus(1))), this.getValue().getShape());
         }
 
         if (that.partialDerivatives.isEmpty()) {
             thisInfExponent = PartialDerivatives.OF_CONSTANT;
         } else {
-            thisInfExponent = that.partialDerivatives.multiplyBy(this.value.log().timesInPlace(newValue));
+            thisInfExponent = that.partialDerivatives
+                .multiplyAlongOfDimensions(this.value.log().timesInPlace(newValue), that.getValue().getShape());
         }
 
         PartialDerivatives newInf = thisInfBase.add(thisInfExponent);
@@ -308,7 +310,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         if (this.partialDerivatives.isEmpty()) {
             return new DualNumber(newValue, PartialDerivatives.OF_CONSTANT);
         } else {
-            return new DualNumber(newValue, this.partialDerivatives.multiplyBy(newValue));
+            return new DualNumber(newValue, this.partialDerivatives.multiplyAlongOfDimensions(newValue, this.getValue().getShape()));
         }
     }
 
@@ -318,7 +320,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
             return new DualNumber(newValue, PartialDerivatives.OF_CONSTANT);
         } else {
             DoubleTensor dSin = value.cos();
-            return new DualNumber(newValue, this.partialDerivatives.multiplyBy(dSin));
+            return new DualNumber(newValue, this.partialDerivatives.multiplyAlongOfDimensions(dSin, this.getValue().getShape()));
         }
     }
 
@@ -328,7 +330,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
             return new DualNumber(newValue, PartialDerivatives.OF_CONSTANT);
         } else {
             DoubleTensor dCos = value.sin().unaryMinusInPlace();
-            return new DualNumber(newValue, this.partialDerivatives.multiplyBy(dCos));
+            return new DualNumber(newValue, this.partialDerivatives.multiplyAlongOfDimensions(dCos, this.getValue().getShape()));
         }
     }
 
@@ -338,7 +340,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
             return new DualNumber(newValue, PartialDerivatives.OF_CONSTANT);
         } else {
             DoubleTensor dTan = value.cos().powInPlace(2).reciprocalInPlace();
-            return new DualNumber(newValue, this.partialDerivatives.multiplyBy(dTan));
+            return new DualNumber(newValue, this.partialDerivatives.multiplyAlongOfDimensions(dTan, this.getValue().getShape()));
         }
     }
 
@@ -349,7 +351,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         } else {
             DoubleTensor dArcSin = (value.unaryMinus().timesInPlace(value).plusInPlace(1))
                 .sqrtInPlace().reciprocalInPlace();
-            return new DualNumber(newValue, this.partialDerivatives.multiplyBy(dArcSin));
+            return new DualNumber(newValue, this.partialDerivatives.multiplyAlongOfDimensions(dArcSin, this.getValue().getShape()));
         }
     }
 
@@ -360,7 +362,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
         } else {
             DoubleTensor dArcCos = value.unaryMinus().timesInPlace(value).plusInPlace(1)
                 .sqrtInPlace().reciprocalInPlace().unaryMinusInPlace();
-            return new DualNumber(newValue, this.partialDerivatives.multiplyBy(dArcCos));
+            return new DualNumber(newValue, this.partialDerivatives.multiplyAlongOfDimensions(dArcCos, this.getValue().getShape()));
         }
     }
 
@@ -370,7 +372,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
             return new DualNumber(newValue, PartialDerivatives.OF_CONSTANT);
         } else {
             DoubleTensor dArcTan = value.pow(2).plusInPlace(1).reciprocalInPlace();
-            return new DualNumber(newValue, this.partialDerivatives.multiplyBy(dArcTan));
+            return new DualNumber(newValue, this.partialDerivatives.multiplyAlongOfDimensions(dArcTan, this.getValue().getShape()));
         }
     }
 
@@ -386,7 +388,7 @@ public class DualNumber implements DoubleOperators<DualNumber> {
     public DualNumber sum() {
         DoubleTensor sumOfAll = DoubleTensor.scalar(value.sum());
         int[] resultDims = TensorShape.dimensionRange(0, value.getRank());
-        return new DualNumber(sumOfAll, this.partialDerivatives.sum(false, resultDims));
+        return new DualNumber(sumOfAll, this.partialDerivatives.sumOverOfDimensions(resultDims));
     }
 
     public DualNumber reshape(int[] proposedShape) {
@@ -395,22 +397,25 @@ public class DualNumber implements DoubleOperators<DualNumber> {
     }
 
     public DualNumber slice(int dimension, int index) {
-        PartialDerivatives slicedPartialDerivatives = this.partialDerivatives.slice(dimension, index);
-        return new DualNumber(value.slice(dimension, index), slicedPartialDerivatives);
+        DoubleTensor newValue = value.slice(dimension, index);
+        boolean needReshape = newValue.getRank() == value.getRank();
+        PartialDerivatives slicedPartialDerivatives = this.partialDerivatives.slice(dimension, index, needReshape);
+        return new DualNumber(newValue, slicedPartialDerivatives);
     }
 
     public DualNumber take(int... index) {
         Map<VertexId, DoubleTensor> dualsAtIndex = new HashMap<>();
+        DoubleTensor newValue = DoubleTensor.scalar(this.value.getValue(index));
 
         for (Map.Entry<VertexId, DoubleTensor> entry : this.partialDerivatives.asMap().entrySet()) {
             DoubleTensor atIndexTensor = takeFromPartial(entry.getValue(), index);
-            int desiredRank = entry.getValue().getShape().length;
+            int desiredRank = atIndexTensor.getShape().length + newValue.getShape().length;
             int[] paddedShape = TensorShape.shapeToDesiredRankByPrependingOnes(atIndexTensor.getShape(), desiredRank);
             atIndexTensor = atIndexTensor.reshape(paddedShape);
             dualsAtIndex.put(entry.getKey(), atIndexTensor);
         }
 
-        return new DualNumber(DoubleTensor.scalar(this.value.getValue(index)), dualsAtIndex);
+        return new DualNumber(newValue, dualsAtIndex);
     }
 
     private DoubleTensor takeFromPartial(DoubleTensor from, int... indices) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -400,6 +400,19 @@ public class PartialDerivatives {
         return new PartialDerivatives(reshapedDerivatives);
     }
 
+    /**
+     * Slice the partials along dimension at a specified index.
+     *
+     * @param dimension dimension to slice along
+     * @param index     index to slice at
+     * @param reshape   Due to the way our tensor implementation works, slicing a rank 2 tensor gives us a rank two back, whereas
+     *                  slicing a higher rank tensor gives you a (rank - 1) tensor back.  This causes problems for rank 2 tensors
+     *                  where the shape of the "of" will go from, say, 3x3 to 3x1 whereas the partial will go from 3x3x3x3 to
+     *                  3x3x3 instead of 3x1x3x3.  This reshape deals with this case.  Only needed for rank two inputs as higher
+     *                  ranks correctly resolve (eg 3x3x3 will have a 3x3x3x3x3x3 and after slicing will be a 3x3 and a partial
+     *                  of 3x3x3x3x3.
+     * @return the sliced partials
+     */
     public PartialDerivatives slice(int dimension, int index, boolean reshape) {
         Map<VertexId, DoubleTensor> slicedDerivatives = new HashMap<>();
 
@@ -408,14 +421,6 @@ public class PartialDerivatives {
             partialDerivativeShape[dimension] = 1;
             DoubleTensor slicedPartialDerivative = partialDerivative.getValue().slice(dimension, index);
 
-            /*
-             * Due to the way our tensor implementation works, slicing a rank 2 tensor gives us a rank two back, whereas
-             * slicing a higher rank tensor gives you a (rank - 1) tensor back.  This causes problems for rank 2 tensors
-             * where the shape of the "of" will go from, say, 3x3 to 3x1 whereas the partial will go from 3x3x3x3 to
-             * 3x3x3 instead of 3x1x3x3.  This reshape deals with this case.  Only needed for rank two inputs as higher
-             * ranks correctly resolve (eg 3x3x3 will have a 3x3x3x3x3x3 and after slicing will be a 3x3 and a partial
-             * of 3x3x3x3x3.
-             */
             if (reshape) {
                 slicedPartialDerivative = slicedPartialDerivative.reshape(partialDerivativeShape);
             }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -104,35 +104,6 @@ public class PartialDerivatives {
         derivativeWithRespectTo.put(id, value);
     }
 
-    /**
-     * This will sum partial derivatives that are represented as tensors over given dimensions.
-     *
-     * @param summingAllOfDimensions If True, this means we're summing all of the Of dimensions.
-     *                               In this case, we drop the summed over dimensions from the shape and replace them
-     *                               with a 1x1 (as the Ofs can't disappear completely)
-     * @param overDimensions         The dimensions to sum over. Dimensions are counted from zero
-     * @return The summed partial derivatives over given dimensions
-     */
-    public PartialDerivatives sum(boolean summingAllOfDimensions, int... overDimensions) {
-        Map<VertexId, DoubleTensor> summed = cloneInfinitesimals(derivativeWithRespectTo);
-
-        for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
-            VertexId k = entry.getKey();
-            DoubleTensor v = entry.getValue();
-            DoubleTensor reshapedV = v.sum(overDimensions);
-            if (summingAllOfDimensions) {
-                int[] newShape = TensorShape.concat(new int[]{1, 1}, reshapedV.getShape());
-                reshapedV = reshapedV.reshape(newShape);
-            } else {
-                reshapedV = reshapedV.reshape(onesToShape(v.getShape(), overDimensions));
-            }
-
-            summed.put(k, reshapedV);
-        }
-
-        return new PartialDerivatives(summed);
-    }
-
     public PartialDerivatives sumOverOfDimensions(int... ofDimensions) {
         Map<VertexId, DoubleTensor> summed = cloneInfinitesimals(derivativeWithRespectTo);
 
@@ -391,7 +362,6 @@ public class PartialDerivatives {
             VertexId k = entry.getKey();
             DoubleTensor partial = entry.getValue();
 
-            //Is this broken too?
             DoubleTensor v = partial.div(increaseRankByAppendingOnesToShape(divisor, partial.getRank()));
             divided.put(k, v);
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -105,27 +106,60 @@ public class PartialDerivatives {
 
     /**
      * This will sum partial derivatives that are represented as tensors over given dimensions.
-     * There is the option to reshape to a lower rank tensor where the summation has caused a
-     * dimension to go to length 1.
      *
-     * @param reshape        Returns the sum and drops the summed over dimensions (now length one)
-     *                       in the shape if true. Returns a same ranked tensor but with a shape
-     *                       that has ones for the dimensions summed over.
-     * @param overDimensions The dimensions to sum over. Dimensions are counted from zero
+     * @param summingAllOfDimensions If True, this means we're summing all of the Of dimensions.
+     *                               In this case, we drop the summed over dimensions from the shape and replace them
+     *                               with a 1x1 (as the Ofs can't disappear completely)
+     * @param overDimensions         The dimensions to sum over. Dimensions are counted from zero
      * @return The summed partial derivatives over given dimensions
      */
-    public PartialDerivatives sum(boolean reshape, int... overDimensions) {
+    public PartialDerivatives sum(boolean summingAllOfDimensions, int... overDimensions) {
         Map<VertexId, DoubleTensor> summed = cloneInfinitesimals(derivativeWithRespectTo);
 
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
             VertexId k = entry.getKey();
             DoubleTensor v = entry.getValue();
             DoubleTensor reshapedV = v.sum(overDimensions);
-            if (reshape) {
-                summed.put(k, reshapedV);
+            if (summingAllOfDimensions) {
+                int[] newShape = TensorShape.concat(new int[]{1, 1}, reshapedV.getShape());
+                reshapedV = reshapedV.reshape(newShape);
             } else {
-                summed.put(k, reshapedV.reshape(onesToShape(v.getShape(), overDimensions)));
+                reshapedV = reshapedV.reshape(onesToShape(v.getShape(), overDimensions));
             }
+
+            summed.put(k, reshapedV);
+        }
+
+        return new PartialDerivatives(summed);
+    }
+
+    public PartialDerivatives sumOverOfDimensions(int... ofDimensions) {
+        Map<VertexId, DoubleTensor> summed = cloneInfinitesimals(derivativeWithRespectTo);
+
+        for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
+            VertexId k = entry.getKey();
+            DoubleTensor v = entry.getValue();
+            DoubleTensor summedV = v.sum(ofDimensions);
+            int[] newShape = TensorShape.concat(Tensor.SCALAR_SHAPE, summedV.getShape());
+            summedV = summedV.reshape(newShape);
+
+            summed.put(k, summedV);
+        }
+
+        return new PartialDerivatives(summed);
+    }
+
+    public PartialDerivatives sumOverWrtDimensions(int... wrtDimensions) {
+        Map<VertexId, DoubleTensor> summed = cloneInfinitesimals(derivativeWithRespectTo);
+
+        for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
+            VertexId k = entry.getKey();
+            DoubleTensor v = entry.getValue();
+            DoubleTensor summedV = v.sum(wrtDimensions);
+            int[] newShape = TensorShape.concat(summedV.getShape(), Tensor.SCALAR_SHAPE);
+            summedV = summedV.reshape(newShape);
+
+            summed.put(k, summedV);
         }
 
         return new PartialDerivatives(summed);
@@ -208,11 +242,7 @@ public class PartialDerivatives {
         return fixedShape;
     }
 
-    public PartialDerivatives multiplyBy(DoubleTensor multiplier) {
-        return multiplyBy(multiplier, false);
-    }
-
-    public PartialDerivatives multiplyBy(DoubleTensor multiplier, boolean alongWrtDimensions) {
+    public PartialDerivatives multiplyAlongOfDimensions(DoubleTensor multiplier, int[] ofShape) {
         Map<VertexId, DoubleTensor> multiplied = new HashMap<>();
 
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
@@ -222,10 +252,8 @@ public class PartialDerivatives {
 
             if (multiplier.isScalar()) {
                 result = partial.times(multiplier.scalar());
-            } else if (alongWrtDimensions) {
-                result = elementWiseMultiplyAlongWrt(partial, multiplier);
             } else {
-                result = elementWiseMultiplyAlongOf(partial, multiplier);
+                result = elementWiseMultiplyAlongOf(partial, multiplier, ofShape);
             }
 
             multiplied.put(k, result);
@@ -234,33 +262,59 @@ public class PartialDerivatives {
         return new PartialDerivatives(multiplied);
     }
 
-    private DoubleTensor elementWiseMultiplyAlongOf(DoubleTensor partial, DoubleTensor multiplier) {
+    public PartialDerivatives multiplyAlongWrtDimensions(DoubleTensor multiplier, int[] wrtShape) {
+        Map<VertexId, DoubleTensor> multiplied = new HashMap<>();
 
-        DoubleTensor multiplierFromLeft = increaseRankByAppendingOnesToShape(multiplier, partial.getRank());
+        for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
+            VertexId k = entry.getKey();
+            DoubleTensor partial = entry.getValue();
+            DoubleTensor result;
 
-        int[] partialOfShape = extractOfShape(partial.getShape(), multiplier.getRank());
-        if (TensorShape.isScalar(partialOfShape)) {
+            if (multiplier.isScalar()) {
+                result = partial.times(multiplier.scalar());
+            } else {
+                result = elementWiseMultiplyAlongWrt(partial, multiplier, wrtShape);
+            }
 
-            int[] partialWrtShape = extractWrtShape(partial.getShape(), multiplier.getRank());
-            int[] resultShape = TensorShape.concat(multiplier.getShape(), partialWrtShape);
-
-            return DoubleTensor.ones(resultShape).times(partial).times(multiplierFromLeft);
+            multiplied.put(k, result);
         }
 
+        return new PartialDerivatives(multiplied);
+    }
+
+    private DoubleTensor elementWiseMultiplyAlongOf(DoubleTensor partial, DoubleTensor multiplier, int[] ofShape) {
+
+        int[] partialOfShape = extractOfShape(partial.getShape(), ofShape.length);
+        if (TensorShape.isScalar(partialOfShape)) {
+
+            int[] partialWrtShape = extractWrtShape(partial.getShape(), ofShape.length);
+            int[] resultShape = TensorShape.concat(multiplier.getShape(), partialWrtShape);
+
+            DoubleTensor multiplierFromLeft = increaseRankByAppendingOnesToShape(multiplier, resultShape.length);
+            DoubleTensor appropriateShapePartial = increaseRankByPrependingOnesToShape(partial, resultShape.length);
+
+            return DoubleTensor.ones(resultShape).times(appropriateShapePartial).times(multiplierFromLeft);
+        }
+
+        DoubleTensor multiplierFromLeft = increaseRankByAppendingOnesToShape(multiplier, partial.getRank());
         return partial.times(multiplierFromLeft);
     }
 
-    private DoubleTensor elementWiseMultiplyAlongWrt(DoubleTensor partial, DoubleTensor multiplier) {
+    private DoubleTensor elementWiseMultiplyAlongWrt(DoubleTensor partial, DoubleTensor multiplier, int[] wrtShape) {
 
-        int[] partialWrtShape = extractWrtShape(partial.getShape(), multiplier.getRank());
+        int[] partialWrtShape = extractWrtShape(partial.getShape(), partial.getRank() - wrtShape.length);
         if (TensorShape.isScalar(partialWrtShape)) {
-
-            int[] partialOfShape = extractOfShape(partial.getShape(), multiplier.getRank());
+            int[] partialOfShape = extractOfShape(partial.getShape(), partial.getRank() - wrtShape.length);
             int[] resultShape = TensorShape.concat(partialOfShape, multiplier.getShape());
-            return DoubleTensor.ones(resultShape).times(partial).times(multiplier);
+
+            DoubleTensor multiplierFromRight = increaseRankByPrependingOnesToShape(multiplier, resultShape.length);
+            DoubleTensor appropriateShapePartial = increaseRankByAppendingOnesToShape(partial, resultShape.length);
+
+            return DoubleTensor.ones(resultShape).times(appropriateShapePartial).times(multiplierFromRight);
         }
 
-        return partial.times(multiplier);
+        DoubleTensor multiplierFromRight = increaseRankByPrependingOnesToShape(multiplier, partial.getRank());
+        return partial.times(multiplierFromRight);
     }
 
     public static PartialDerivatives matrixMultiplyAlongOfDimensions(PartialDerivatives partials, DoubleTensor multiplier, boolean partialIsLeft) {
@@ -336,6 +390,8 @@ public class PartialDerivatives {
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeWithRespectTo.entrySet()) {
             VertexId k = entry.getKey();
             DoubleTensor partial = entry.getValue();
+
+            //Is this broken too?
             DoubleTensor v = partial.div(increaseRankByAppendingOnesToShape(divisor, partial.getRank()));
             divided.put(k, v);
         }
@@ -374,14 +430,25 @@ public class PartialDerivatives {
         return new PartialDerivatives(reshapedDerivatives);
     }
 
-    public PartialDerivatives slice(int dimension, int index) {
+    public PartialDerivatives slice(int dimension, int index, boolean reshape) {
         Map<VertexId, DoubleTensor> slicedDerivatives = new HashMap<>();
 
         for (Map.Entry<VertexId, DoubleTensor> partialDerivative : derivativeWithRespectTo.entrySet()) {
             int[] partialDerivativeShape = partialDerivative.getValue().getShape();
             partialDerivativeShape[dimension] = 1;
             DoubleTensor slicedPartialDerivative = partialDerivative.getValue().slice(dimension, index);
-            slicedPartialDerivative = slicedPartialDerivative.reshape(partialDerivativeShape);
+
+            /*
+             * Due to the way our tensor implementation works, slicing a rank 2 tensor gives us a rank two back, whereas
+             * slicing a higher rank tensor gives you a (rank - 1) tensor back.  This causes problems for rank 2 tensors
+             * where the shape of the "of" will go from, say, 3x3 to 3x1 whereas the partial will go from 3x3x3x3 to
+             * 3x3x3 instead of 3x1x3x3.  This reshape deals with this case.  Only needed for rank two inputs as higher
+             * ranks correctly resolve (eg 3x3x3 will have a 3x3x3x3x3x3 and after slicing will be a 3x3 and a partial
+             * of 3x3x3x3x3.
+             */
+            if (reshape) {
+                slicedPartialDerivative = slicedPartialDerivative.reshape(partialDerivativeShape);
+            }
             slicedDerivatives.put(partialDerivative.getKey(), slicedPartialDerivative);
         }
 
@@ -422,4 +489,9 @@ public class PartialDerivatives {
         );
     }
 
+    private static DoubleTensor increaseRankByPrependingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {
+        return lowRankTensor.reshape(
+            TensorShape.shapeToDesiredRankByPrependingOnes(lowRankTensor.getShape(), desiredRank)
+        );
+    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -104,6 +104,13 @@ public class PartialDerivatives {
         derivativeWithRespectTo.put(id, value);
     }
 
+    /**
+     * This will sum partial derivatives that are represented as tensors over given dimensions.
+     * The dimensions that are summed over will be reshaped to a scalar shape of 1x1.
+     *
+     * @param ofDimensions dimensions to sum over (should be first n dimensions)
+     * @return summed and reshaped partials
+     */
     public PartialDerivatives sumOverOfDimensions(int... ofDimensions) {
         Map<VertexId, DoubleTensor> summed = cloneInfinitesimals(derivativeWithRespectTo);
 
@@ -120,6 +127,13 @@ public class PartialDerivatives {
         return new PartialDerivatives(summed);
     }
 
+    /**
+     * This will sum partial derivatives that are represented as tensors over given dimensions.
+     * The dimensions that are summed over will be reshaped to a scalar shape of 1x1.
+     *
+     * @param wrtDimensions dimensions to sum over (should be last n dimensions)
+     * @return summed and reshaped partials
+     */
     public PartialDerivatives sumOverWrtDimensions(int... wrtDimensions) {
         Map<VertexId, DoubleTensor> summed = cloneInfinitesimals(derivativeWithRespectTo);
 
@@ -444,18 +458,6 @@ public class PartialDerivatives {
 
     private int[] extractOfShape(int[] partialDerivativeShape, int rankOfSource) {
         return Arrays.copyOfRange(partialDerivativeShape, 0, rankOfSource);
-    }
-
-    private static int[] onesToShape(int[] shape, int[] onesDimensions) {
-
-        int[] shapeWithOnes = Arrays.copyOf(shape, shape.length);
-
-        for (int onesDimension : onesDimensions) {
-            int resolvedDimension = onesDimension >= 0 ? onesDimension : shape.length + onesDimension;
-            shapeWithOnes[resolvedDimension] = 1;
-        }
-
-        return shapeWithOnes;
     }
 
     private static DoubleTensor increaseRankByAppendingOnesToShape(DoubleTensor lowRankTensor, int desiredRank) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
@@ -30,8 +30,10 @@ public class ArcTan2Vertex extends DoubleBinaryOpVertex {
     protected DualNumber dualOp(DualNumber x, DualNumber y) {
         DoubleTensor denominator = ((y.getValue().pow(2)).plusInPlace((x.getValue().pow(2))));
 
-        PartialDerivatives thisInfX = x.getPartialDerivatives().multiplyBy((y.getValue().div(denominator)).unaryMinusInPlace());
-        PartialDerivatives thisInfY = y.getPartialDerivatives().multiplyBy(x.getValue().div(denominator));
+        PartialDerivatives thisInfX = x.getPartialDerivatives()
+            .multiplyAlongOfDimensions((y.getValue().div(denominator)).unaryMinusInPlace(), x.getValue().getShape());
+        PartialDerivatives thisInfY = y.getPartialDerivatives()
+            .multiplyAlongOfDimensions(x.getValue().div(denominator), y.getValue().getShape());
         PartialDerivatives newInf = thisInfX.add(thisInfY);
         return new DualNumber(x.getValue().atan2(y.getValue()), newInf);
     }
@@ -46,8 +48,8 @@ public class ArcTan2Vertex extends DoubleBinaryOpVertex {
         DoubleTensor dOutWrtX = yValue.div(denominator).unaryMinusInPlace();
         DoubleTensor dOutWrtY = xValue.div(denominator);
 
-        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtX, true));
-        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtY, true));
+        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(dOutWrtX, this.getShape()));
+        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(dOutWrtY, this.getShape()));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
@@ -32,8 +32,10 @@ public class DivisionVertex extends DoubleBinaryOpVertex {
         DoubleTensor rightValue = right.getValue();
         DoubleTensor dOutWrtLeft = rightValue.reciprocal();
         DoubleTensor dOutWrtRight = leftValue.div(rightValue.pow(2.0)).unaryMinusInPlace();
-        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtLeft, true));
-        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtRight, true));
+        partials.put(left, derivativeOfOutputsWithRespectToSelf
+            .multiplyAlongWrtDimensions(dOutWrtLeft, this.getShape()));
+        partials.put(right, derivativeOfOutputsWithRespectToSelf
+            .multiplyAlongWrtDimensions(dOutWrtRight, this.getShape()));
         return partials;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
@@ -30,8 +30,8 @@ public class MultiplicationVertex extends DoubleBinaryOpVertex {
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
 
-        PartialDerivatives rightPartial = derivativeOfOutputsWithRespectToSelf.multiplyBy(right.getValue(), true);
-        PartialDerivatives leftPartial = derivativeOfOutputsWithRespectToSelf.multiplyBy(left.getValue(), true);
+        PartialDerivatives rightPartial = derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(right.getValue(), this.getShape());
+        PartialDerivatives leftPartial = derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(left.getValue(), this.getShape());
 
         partials.put(left, rightPartial);
         partials.put(right, leftPartial);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
@@ -39,8 +39,8 @@ public class PowerVertex extends DoubleBinaryOpVertex {
         DoubleTensor leftPowRight = getValue();
         DoubleTensor dOutWrtLeft = rightValue.div(leftValue).timesInPlace(leftPowRight);
         DoubleTensor dOutWrtRight = leftPowRight.times(leftValue.log());
-        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtLeft, true));
-        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyBy(dOutWrtRight, true));
+        partials.put(left, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(dOutWrtLeft, this.getShape()));
+        partials.put(right, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(dOutWrtRight, this.getShape()));
         return partials;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
@@ -40,7 +40,7 @@ public class ArcCosVertex extends DoubleUnaryOpVertex {
             .unaryMinusInPlace();
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput, true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(dSelfWrtInput, this.getShape()));
 
         return partials;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
@@ -40,7 +40,7 @@ public class ArcSinVertex extends DoubleUnaryOpVertex {
             .reciprocalInPlace();
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput, true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(dSelfWrtInput, this.getShape()));
 
         return partials;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
@@ -38,7 +38,7 @@ public class ArcTanVertex extends DoubleUnaryOpVertex {
         DoubleTensor dSelfWrtInput = inputValue.pow(2).plusInPlace(1).reciprocalInPlace();
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dSelfWrtInput, true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(dSelfWrtInput, this.getShape()));
 
         return partials;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
@@ -33,7 +33,8 @@ public class CosVertex extends DoubleUnaryOpVertex {
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().sin().unaryMinusInPlace(), true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf
+            .multiplyAlongWrtDimensions(inputVertex.getValue().sin().unaryMinusInPlace(), this.getShape()));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
@@ -33,7 +33,7 @@ public class ExpVertex extends DoubleUnaryOpVertex {
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(getValue(), true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(getValue(), this.getShape()));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
@@ -28,14 +28,16 @@ public class LogGammaVertex extends DoubleUnaryOpVertex {
     @Override
     protected DualNumber dualOp(DualNumber dualNumber) {
         DoubleTensor logGammaOfInput = op(dualNumber.getValue());
-        PartialDerivatives dLogGamma = dualNumber.getPartialDerivatives().multiplyBy(inputVertex.getValue().digamma());
+        PartialDerivatives dLogGamma = dualNumber.getPartialDerivatives()
+            .multiplyAlongOfDimensions(inputVertex.getValue().digamma(), getShape());
         return new DualNumber(logGammaOfInput, dLogGamma);
     }
 
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        PartialDerivatives dOutputsWrtInputVertex = derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().digamma(), true);
+        PartialDerivatives dOutputsWrtInputVertex =
+            derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(inputVertex.getValue().digamma(), getShape());
         partials.put(inputVertex, dOutputsWrtInputVertex);
         return partials;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
@@ -33,7 +33,8 @@ public class LogVertex extends DoubleUnaryOpVertex {
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().reciprocal(), true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf
+            .multiplyAlongWrtDimensions(inputVertex.getValue().reciprocal(), this.getShape()));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertex.java
@@ -1,8 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import java.util.Map;
+
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 public class MatrixInverseVertex extends DoubleUnaryOpVertex {
 
@@ -18,6 +22,11 @@ public class MatrixInverseVertex extends DoubleUnaryOpVertex {
     @Override
     protected DualNumber dualOp(DualNumber dualNumber) {
         return dualNumber.matrixInverse();
+    }
+
+    @Override
+    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
+        
     }
 
     private static int[] checkInputIsSquareMatrix(int[] shape) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertex.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -26,7 +27,17 @@ public class MatrixInverseVertex extends DoubleUnaryOpVertex {
 
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        
+        Map<Vertex, PartialDerivatives> partials = new HashMap<>();
+        DoubleTensor parentValue = getValue();
+        DoubleTensor negativeValue = getValue().unaryMinus();
+
+        PartialDerivatives newPartials =
+            PartialDerivatives.matrixMultiplyAlongWrtDimensions(derivativeOfOutputsWithRespectToSelf, negativeValue, false);
+        newPartials = PartialDerivatives.matrixMultiplyAlongWrtDimensions(newPartials, parentValue, true);
+
+        partials.put(inputVertex, newPartials);
+
+        return partials;
     }
 
     private static int[] checkInputIsSquareMatrix(int[] shape) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertex.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static io.improbable.keanu.tensor.TensorShape.copyLowRankOverHighRankFromTailEnd;
 
 public class ReshapeVertex extends DoubleUnaryOpVertex {
 
@@ -33,7 +32,11 @@ public class ReshapeVertex extends DoubleUnaryOpVertex {
         Map<Vertex, PartialDerivatives> reshapedDerivatives = new HashMap<>();
 
         for (Map.Entry<VertexId, DoubleTensor> partialDerivative : derivativeOfOutputsWithRespectToSelf.asMap().entrySet()) {
-            int[] newPartialShape = copyLowRankOverHighRankFromTailEnd(partialDerivative.getValue().getShape(), inputVertex.getShape());
+            DoubleTensor partial = partialDerivative.getValue();
+            int[] newPartialShape = TensorShape.concat(
+                TensorShape.selectDimensions(0, partial.getRank() - getShape().length - 1, partial.getShape()),
+                inputVertex.getShape()
+            );
             DoubleTensor reshapedPartialDerivative = partialDerivative.getValue().reshape(newPartialShape);
             reshapedDerivatives.put(inputVertex, new PartialDerivatives(partialDerivative.getKey(), reshapedPartialDerivative));
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
@@ -31,7 +31,7 @@ public class SigmoidVertex extends DoubleUnaryOpVertex {
         DoubleTensor x = a.getValue();
         DoubleTensor xExp = x.exp();
         DoubleTensor dxdfx = xExp.divInPlace(xExp.plus(1).powInPlace(2));
-        PartialDerivatives infinitesimal = a.getPartialDerivatives().multiplyBy(dxdfx);
+        PartialDerivatives infinitesimal = a.getPartialDerivatives().multiplyAlongOfDimensions(dxdfx, x.getShape());
         return new DualNumber(x.sigmoid(), infinitesimal);
     }
 
@@ -42,7 +42,7 @@ public class SigmoidVertex extends DoubleUnaryOpVertex {
         DoubleTensor derivativeOfSigmoidWrtInput = sigmoidOfInput.minus(sigmoidOfInput.pow(2));
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(derivativeOfSigmoidWrtInput, true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(derivativeOfSigmoidWrtInput, this.getShape()));
         return partials;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
@@ -33,7 +33,8 @@ public class SinVertex extends DoubleUnaryOpVertex {
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(inputVertex.getValue().cos(), true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf
+            .multiplyAlongWrtDimensions(inputVertex.getValue().cos(), this.getShape()));
         return partials;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SliceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SliceVertex.java
@@ -2,12 +2,11 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
@@ -57,25 +56,26 @@ public class SliceVertex extends DoubleUnaryOpVertex {
     }
 
     private DoubleTensor padSliceWithZerosToMatchOriginalShape(DoubleTensor tensor) {
-        int[] partialShape = tensor.getShape();
-        int[] inputShape = inputVertex.getShape();
-        int length = getShape().length;
-        int dimensionOfWrtToExtend = dimension + length;
-        int lengthInSlicedDimension = inputShape[dimension] - 1;
+        int[] targetShape = TensorShape.concat(getShape(), inputVertex.getShape());
+        int dimensionInWrt = dimension + getShape().length;
+        int indicesBefore = index;
+        int indicesAfter = targetShape[dimensionInWrt] - index - 1;
+        targetShape[dimensionInWrt] = 1;
+        DoubleTensor outputTensor = tensor.reshape(targetShape);
 
-        if (index == 0) {
-            partialShape[dimensionOfWrtToExtend] = lengthInSlicedDimension;
-            return DoubleTensor.concat(dimensionOfWrtToExtend, tensor, DoubleTensor.zeros(partialShape));
-        } else if (index == lengthInSlicedDimension) {
-            partialShape[dimensionOfWrtToExtend] = lengthInSlicedDimension;
-            return DoubleTensor.concat(dimensionOfWrtToExtend, DoubleTensor.zeros(partialShape), tensor);
-        } else {
-            int[] zerosBeforeSlice = Arrays.copyOf(partialShape, partialShape.length);
-            int[] zerosAfterSlice = Arrays.copyOf(partialShape, partialShape.length);
-            zerosBeforeSlice[dimensionOfWrtToExtend] = index;
-            zerosAfterSlice[dimensionOfWrtToExtend] = lengthInSlicedDimension - index;
-            return DoubleTensor.concat(dimensionOfWrtToExtend, DoubleTensor.zeros(zerosBeforeSlice), tensor, DoubleTensor.zeros(zerosAfterSlice));
+        if (indicesBefore != 0) {
+            targetShape[dimensionInWrt] = indicesBefore;
+            DoubleTensor prefixTensor = DoubleTensor.zeros(targetShape).reshape(targetShape);
+            outputTensor = DoubleTensor.concat(dimensionInWrt, prefixTensor, outputTensor);
         }
+
+        if (indicesAfter != 0) {
+            targetShape[dimensionInWrt] = indicesAfter;
+            DoubleTensor postfixTensor = DoubleTensor.zeros(targetShape).reshape(targetShape);
+            outputTensor = DoubleTensor.concat(dimensionInWrt, outputTensor, postfixTensor);
+        }
+
+        return outputTensor;
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
@@ -36,7 +36,7 @@ public class SumVertex extends DoubleUnaryOpVertex {
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
 
         PartialDerivatives derivativesWrtInput = derivativeOfOutputsWithRespectToSelf
-            .multiplyBy(DoubleTensor.ones(inputVertex.getShape()), true);
+            .multiplyAlongWrtDimensions(DoubleTensor.ones(inputVertex.getShape()), this.getShape());
 
         return singletonMap(inputVertex, derivativesWrtInput);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertex.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
@@ -11,8 +12,6 @@ import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
-
-import static io.improbable.keanu.tensor.TensorShape.copyLowRankOverHighRankFromTailEnd;
 
 public class TakeVertex extends DoubleUnaryOpVertex {
 
@@ -46,7 +45,10 @@ public class TakeVertex extends DoubleUnaryOpVertex {
 
         for (Map.Entry<VertexId, DoubleTensor> partialDerivative : derivativeOfOutputsWithRespectToSelf.asMap().entrySet()) {
             DoubleTensor partial = partialDerivative.getValue();
-            int[] newPartialShape = copyLowRankOverHighRankFromTailEnd(partial.getShape(), inputVertex.getShape());
+            int[] newPartialShape = TensorShape.concat(
+                TensorShape.selectDimensions(0, partial.getRank() - getShape().length - 1, partial.getShape()),
+                inputVertex.getShape()
+            );
             DoubleTensor highRankZeros = DoubleTensor.zeros(newPartialShape);
             DoubleTensor partialBroadcastToHighRank = highRankZeros.plus(partial);
             DoubleTensor takeMask = DoubleTensor.zeros(inputVertex.getShape()).setValue(1., index);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
@@ -36,7 +36,7 @@ public class TanVertex extends DoubleUnaryOpVertex {
         DoubleTensor dTandInput = inputVertex.getValue().cos().powInPlace(2).reciprocalInPlace();
 
         Map<Vertex, PartialDerivatives> partials = new HashMap<>();
-        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyBy(dTandInput, true));
+        partials.put(inputVertex, derivativeOfOutputsWithRespectToSelf.multiplyAlongWrtDimensions(dTandInput, this.getShape()));
         return partials;
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorMatchers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorMatchers.java
@@ -63,18 +63,18 @@ public class TensorMatchers {
             @Override
             protected boolean matchesSafely(Tensor<T> item, Description mismatchDescription) {
                 mismatchDescription.appendText("Tensor");
-                Tensor.FlattenedView<T> itemFlattened = item.getFlattenedView();
-                if (itemFlattened.size() != valueMatchers.size()) {
+                T[] itemArray = item.asFlatArray();
+                if (itemArray.length != valueMatchers.size()) {
                     mismatchDescription
                         .appendText(" with different size ")
-                        .appendValue(itemFlattened.size());
+                        .appendValue(itemArray.length);
                     return false;
                 }
                 for (int i = 0; i < valueMatchers.size(); i++) {
-                    if (!valueMatchers.get(i).matches(itemFlattened.getOrScalar(i))) {
+                    if (!valueMatchers.get(i).matches(itemArray[i])) {
                         mismatchDescription
                             .appendText(" with different value ")
-                            .appendValue(itemFlattened.getOrScalar(i))
+                            .appendValue(itemArray[i])
                             .appendText(" at entry ")
                             .appendValue(i);
                         return false;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
@@ -1,9 +1,7 @@
 package io.improbable.keanu.vertices.dbl;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
 import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardModeGradient;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
 
 import org.junit.Test;
 
@@ -121,8 +119,7 @@ public class DifferentiatorTest {
         DoubleVertex F = D.plus(B).exp();
         DoubleVertex H = G.plus(F).sum().times(A).sum().times(C);
 
-        finiteDifferenceMatchesReverseModeGradient(ImmutableList.of(A, B, C), H, 0.001, 1e-3);
-        finiteDifferenceMatchesForwardModeGradient(ImmutableList.of(A, B, C), H, 0.001, 1e-3);
+        finiteDifferenceMatchesGradient(ImmutableList.of(A, B, C), H, 0.001, 1e-3,  true);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
@@ -2,8 +2,12 @@ package io.improbable.keanu.vertices.dbl;
 
 import static org.junit.Assert.assertEquals;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardModeGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
+
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import io.improbable.keanu.tensor.TensorShape;
@@ -103,12 +107,12 @@ public class DifferentiatorTest {
 
         int[] shape = new int[]{2, 2, 2};
         DoubleVertex A = new GaussianVertex(shape, 0, 1);
-        A.setValue(DoubleTensor.linspace(0.1, 2, (int)TensorShape.getLength(shape)).reshape(shape));
+        A.setValue(DoubleTensor.linspace(0.1, 2, (int) TensorShape.getLength(shape)).reshape(shape));
         DoubleVertex B = new GaussianVertex(shape, 0, 1);
-        B.setValue(DoubleTensor.linspace(0.2, 1, (int)TensorShape.getLength(shape)).reshape(shape));
+        B.setValue(DoubleTensor.linspace(0.2, 1, (int) TensorShape.getLength(shape)).reshape(shape));
 
         DoubleVertex C = new GaussianVertex(shape, 0, 1);
-        C.setValue(DoubleTensor.linspace(0.2, 0.8, (int)TensorShape.getLength(shape)).reshape(shape));
+        C.setValue(DoubleTensor.linspace(0.2, 0.8, (int) TensorShape.getLength(shape)).reshape(shape));
 
         DoubleVertex D = A.atan2(B).sigmoid().times(B);
         DoubleVertex J = A.sin().cos().div(D);
@@ -117,20 +121,8 @@ public class DifferentiatorTest {
         DoubleVertex F = D.plus(B).exp();
         DoubleVertex H = G.plus(F).sum().times(A).sum().times(C);
 
-        PartialDerivatives dHReverse = Differentiator.reverseModeAutoDiff(H, ImmutableSet.of(A, B, C));
-        PartialDerivatives dHForward = H.getDualNumber().getPartialDerivatives();
-
-        DoubleTensor dHdAReverse = dHReverse.withRespectTo(A);
-        DoubleTensor dHdBReverse = dHReverse.withRespectTo(B);
-        DoubleTensor dHdCReverse = dHReverse.withRespectTo(C);
-
-        DoubleTensor dHdAForward = dHForward.withRespectTo(A);
-        DoubleTensor dHdBForward = dHForward.withRespectTo(B);
-        DoubleTensor dHdCForward = dHForward.withRespectTo(C);
-
-        assertEquals(dHdAReverse, dHdAForward);
-        assertEquals(dHdBReverse, dHdBForward);
-        assertEquals(dHdCReverse, dHdCForward);
+        finiteDifferenceMatchesReverseModeGradient(ImmutableList.of(A, B, C), H, 0.001, 1e-3);
+        finiteDifferenceMatchesForwardModeGradient(ImmutableList.of(A, B, C), H, 0.001, 1e-3);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
@@ -114,7 +115,8 @@ public class LogProbGradientCalculatorTest {
         double expectedDLogProbWrtA = B.dLogProb(bValue, D).get(D).times(cValue).sum();
         DoubleTensor expectedDLogProbWrtC = B.dLogProb(bValue, D).get(D).times(aValue);
 
-        assertThat(dBLogProbWrtAValue, equalTo(DoubleTensor.scalar(expectedDLogProbWrtA)));
+        assertArrayEquals(new int[]{1, 1, 1, 1}, dBLogProbWrtAValue.getShape());
+        assertThat(dBLogProbWrtAValue.scalar(), equalTo(expectedDLogProbWrtA));
         assertThat(dBLogProbWrtCValue, equalTo(expectedDLogProbWrtC));
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardModeGradient;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfAScalarAndVector;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfAVectorsAndScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfTwoMatricesElementWiseOperator;
@@ -89,7 +88,6 @@ public class AdditionVertexTest {
         DoubleVertex B = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex C = A.plus(B);
 
-        finiteDifferenceMatchesReverseModeGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10);
-        finiteDifferenceMatchesForwardModeGradient(ImmutableList.of(A, B), C, 10.0, 1e-10);
+        finiteDifferenceMatchesGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10, true);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
@@ -1,10 +1,21 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardModeGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfAScalarAndVector;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfAVectorsAndScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfTwoMatricesElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfTwoScalars;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwo2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwoScalarVertexValues;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class AdditionVertexTest {
 
@@ -70,5 +81,15 @@ public class AdditionVertexTest {
             DoubleTensor.eye(4).reshape(1, 4, 1, 4),
             DoubleVertex::plus
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex A = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex B = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
+        DoubleVertex C = A.plus(B);
+
+        finiteDifferenceMatchesReverseModeGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10);
+        finiteDifferenceMatchesForwardModeGradient(ImmutableList.of(A, B), C, 10.0, 1e-10);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -444,7 +444,7 @@ public class ConcatenationVertexTest {
         DoubleVertex inputB = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex inputC = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = new ConcatenationVertex(0, inputA, inputB, inputC);
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, 10.0, 1e-10);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, 10.0, 1e-10, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertexTest.java
@@ -1,10 +1,20 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfAScalarAndVector;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfAVectorsAndScalar;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfTwoMatricesElementWiseOperator;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDualNumberOfTwoScalars;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwo2x2MatrixVertexValues;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwoScalarVertexValues;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.*;
+import com.google.common.collect.ImmutableList;
+
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class DivisionVertexTest {
 
@@ -70,5 +80,14 @@ public class DivisionVertexTest {
             DoubleTensor.create(new double[]{-2.0 / 1.0, -2.0 / 4.0, -2.0 / 9.0, -2.0 / 16.}).diag().reshape(1, 4, 1, 4),
             DoubleVertex::divideBy
         );
+    }
+
+    @Test
+    public void changesMatchGradient() {
+        DoubleVertex A = new UniformVertex(new int[]{2, 2, 2}, 1.0, 10.0);
+        DoubleVertex B = new UniformVertex(new int[]{2, 2, 2}, 100.0, 150.0);
+        DoubleVertex C = A.div(B).times(A);
+
+        finiteDifferenceMatchesGradient(ImmutableList.of(A, B), C, 0.001, 1e-5, true);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -283,7 +283,7 @@ public class MatrixMultiplicationVertexTest {
         final double INCREMENT = 10;
         final double DELTA = 1e-10;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB), outputVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB), outputVertex, INCREMENT, DELTA, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -154,8 +154,8 @@ public class SliceVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex cube = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
-        SliceVertex slice = new SliceVertex(cube, 0, 0);
-        finiteDifferenceMatchesGradient(ImmutableList.of(cube), slice, 10.0, 1e-10);
+        SliceVertex slice = new SliceVertex(cube, 2, 0);
+        finiteDifferenceMatchesGradient(ImmutableList.of(cube), slice, 10.0, 1e-10, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
@@ -62,7 +62,7 @@ public class ArcCosVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -0.25, 0.25);
         DoubleVertex outputVertex = inputVertex.times(3).acos();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
@@ -62,7 +62,7 @@ public class ArcSinVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -0.25, 0.25);
         DoubleVertex outputVertex = inputVertex.times(2.0).asin();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
@@ -62,7 +62,7 @@ public class ArcTanVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -2.0, 2.0);
         DoubleVertex outputVertex = inputVertex.times(2).atan();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
@@ -57,7 +57,7 @@ public class CosVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).cos();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
@@ -57,7 +57,7 @@ public class ExpVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).exp();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
@@ -65,6 +65,6 @@ public class LogGammaVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 1.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).logGamma();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
@@ -57,7 +57,7 @@ public class LogVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 1.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).log();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.ScalarDoubleTensor;
+import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
@@ -58,6 +59,8 @@ public class MatrixInverseVertexTest {
         inverse.lazyEval();
 
         DoubleTensor inverseWrtMatrix = inverse.getDualNumber().getPartialDerivatives().withRespectTo(matrix);
+        DoubleTensor reverseInverseWrtMatrix = Differentiator.reverseModeAutoDiff(inverse, matrix).withRespectTo(matrix);
+
         DoubleTensor expectedInverseWrtMatrix = DoubleTensor.create(new double[]{
             -4.0, 3.0,
             2.0, -1.5,
@@ -71,6 +74,7 @@ public class MatrixInverseVertexTest {
         );
 
         assertEquals(expectedInverseWrtMatrix, inverseWrtMatrix);
+        assertEquals(expectedInverseWrtMatrix, reverseInverseWrtMatrix);
     }
 
     @Test
@@ -87,7 +91,10 @@ public class MatrixInverseVertexTest {
 
             DoubleTensor changeInMultipliedWrtInput =
                 multiplied.getDualNumber().getPartialDerivatives().withRespectTo(inputVertex);
-            assertEquals(changeInMultipliedWrtInput.sum(), 0.0, 1e-10);
+            DoubleTensor reverseOutputWrtInput =
+                Differentiator.reverseModeAutoDiff(multiplied, inputVertex).withRespectTo(inputVertex);
+            assertEquals(changeInMultipliedWrtInput.pow(2.0).sum(), 0.0, 1e-10);
+            assertEquals(reverseOutputWrtInput.pow(2.0).sum(), 0.0, 1e-10);
         }
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
@@ -107,7 +107,8 @@ public class MatrixInverseVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{3, 3}, 1.0, 25.0);
         DoubleVertex invertVertex = inputVertex.matrixInverse();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), invertVertex, 0.001, 1e-6);
+        finiteDifferenceMatchesGradient(
+            ImmutableList.of(inputVertex), invertVertex, 0.001, 1e-5, false);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
@@ -108,7 +108,7 @@ public class MatrixInverseVertexTest {
         DoubleVertex invertVertex = inputVertex.matrixInverse();
 
         finiteDifferenceMatchesGradient(
-            ImmutableList.of(inputVertex), invertVertex, 0.001, 1e-5, false);
+            ImmutableList.of(inputVertex), invertVertex, 0.001, 1e-5, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
@@ -104,21 +104,21 @@ public class ReshapeVertexTest {
 
     @Test
     public void partialCorrectlyFlowsThroughTwoReshapes() {
-        DoubleVertex A = new UniformVertex(0, 10);
-        A.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+        DoubleVertex A = new UniformVertex(new int[]{2, 2, 2, 2}, 0, 10);
+        A.setValue(A.sample());
 
-        DoubleVertex B = new UniformVertex(0, 10);
-        B.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+        DoubleVertex B = new UniformVertex(new int[]{2, 2, 2, 2}, 0, 10);
+        B.setValue(B.sample());
 
         DoubleVertex C = A.plus(B);
 
-        DoubleVertex D = C.reshape(4, 1);
-        DoubleVertex E = D.reshape(1, 4);
+        DoubleVertex D = C.reshape(4, 2, 2);
+        DoubleVertex E = D.reshape(4, 4);
 
         PartialDerivatives forward = E.getDualNumber().getPartialDerivatives();
         PartialDerivatives backward = Differentiator.reverseModeAutoDiff(E, ImmutableSet.of(A, B));
 
-        Assert.assertArrayEquals(new int[]{1, 4, 2, 2}, forward.withRespectTo(A).getShape());
+        Assert.assertArrayEquals(new int[]{4, 4, 2, 2, 2, 2}, forward.withRespectTo(A).getShape());
         Assert.assertArrayEquals(forward.withRespectTo(A).asFlatDoubleArray(), backward.withRespectTo(A).asFlatDoubleArray(), 1e-6);
     }
 
@@ -127,7 +127,7 @@ public class ReshapeVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{4, 4}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(1.5).reshape(2, 2, 2, 2);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
@@ -71,7 +71,7 @@ public class SigmoidVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).sigmoid();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-6);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-6, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
@@ -57,7 +57,7 @@ public class SinVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).sin();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
@@ -1,11 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Ignore;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardModeGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
+
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -30,15 +31,15 @@ public class SumVertexTest {
 
     @Test
     public void doesSumSimpleAutoDiff() {
-        DoubleVertex a = new UniformVertex(new int[]{1, 5}, 0, 10);
-        a.setValue(new double[]{1, 2, 3, 4, 5});
+        DoubleVertex a = new UniformVertex(new int[]{2, 2, 2}, 0, 10);
+        a.setValue(a.sample());
 
         DoubleVertex b = a.sum();
 
         DoubleTensor dbdaForward = b.getDualNumber().getPartialDerivatives().withRespectTo(a);
         DoubleTensor dbdaReverse = Differentiator.reverseModeAutoDiff(b, a).withRespectTo(a);
 
-        DoubleTensor expectedDbDa = DoubleTensor.create(new double[]{1, 1, 1, 1, 1}, 1, 1, 1, 5);
+        DoubleTensor expectedDbDa = DoubleTensor.ones(new int[]{1, 1, 2, 2, 2});
 
         assertThat(dbdaForward, equalTo(expectedDbDa));
         assertThat(dbdaReverse, equalTo(expectedDbDa));
@@ -128,12 +129,13 @@ public class SumVertexTest {
     }
 
     @Test
-    @Ignore("Test Currently fails due to tensor shape differences")
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.times(3).sum();
+        inputVertex.setValue(DoubleTensor.arange(0, 8).reshape(2, 2, 2));
+        DoubleVertex outputVertex = inputVertex.sum().times(inputVertex);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10);
+        finiteDifferenceMatchesReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 1e-6, 1e-10);
+        finiteDifferenceMatchesForwardModeGradient(ImmutableList.of(inputVertex), outputVertex, 1e-6, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
@@ -1,11 +1,9 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardModeGradient;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
 
 import org.junit.Test;
 
@@ -134,8 +132,7 @@ public class SumVertexTest {
         inputVertex.setValue(DoubleTensor.arange(0, 8).reshape(2, 2, 2));
         DoubleVertex outputVertex = inputVertex.sum().times(inputVertex);
 
-        finiteDifferenceMatchesReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 1e-6, 1e-10);
-        finiteDifferenceMatchesForwardModeGradient(ImmutableList.of(inputVertex), outputVertex, 1e-6, 1e-10);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 1e-6, 1e-10, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -30,21 +30,21 @@ public class TakeVertexTest {
         DoubleTensor takePartial = take.getDualNumber().getPartialDerivatives().withRespectTo(m);
         DoubleTensor takePartialReverse = Differentiator.reverseModeAutoDiff(take, m, alpha).withRespectTo(m);
 
-        Assert.assertEquals(N.getValue(0, 0), take.getValue().scalar(), 1e-6);
-        Assert.assertArrayEquals(new int[]{1, 1, 1, 4}, takePartial.getShape());
-        Assert.assertArrayEquals(new double[]{10, 0, 0, 0}, takePartial.asFlatDoubleArray(), 1e-6);
-        Assert.assertArrayEquals(takePartial.getShape(), takePartialReverse.getShape());
-        Assert.assertArrayEquals(takePartial.asFlatDoubleArray(), takePartialReverse.asFlatDoubleArray(), 1e-6);
+        assertEquals(N.getValue(0, 0), take.getValue().scalar(), 1e-6);
+        assertArrayEquals(new int[]{1, 1, 1, 4}, takePartial.getShape());
+        assertArrayEquals(new double[]{10, 0, 0, 0}, takePartial.asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(takePartial.getShape(), takePartialReverse.getShape());
+        assertArrayEquals(takePartial.asFlatDoubleArray(), takePartialReverse.asFlatDoubleArray(), 1e-6);
 
         TakeVertex take2 = new TakeVertex(N, 0, 1);
         DoubleTensor takePartial2 = take2.getDualNumber().getPartialDerivatives().withRespectTo(m);
         DoubleTensor takePartial2Reverse = Differentiator.reverseModeAutoDiff(take2, m, alpha).withRespectTo(m);
 
-        Assert.assertEquals(N.getValue(0, 1), take2.getValue().scalar(), 1e-6);
-        Assert.assertArrayEquals(new int[]{1, 1, 1, 4}, takePartial2.getShape());
-        Assert.assertArrayEquals(new double[]{0, 15, 0, 0}, takePartial2.asFlatDoubleArray(), 1e-6);
-        Assert.assertArrayEquals(takePartial2.getShape(), takePartial2Reverse.getShape());
-        Assert.assertArrayEquals(takePartial2.asFlatDoubleArray(), takePartial2Reverse.asFlatDoubleArray(), 1e-6);
+        assertEquals(N.getValue(0, 1), take2.getValue().scalar(), 1e-6);
+        assertArrayEquals(new int[]{1, 1, 1, 4}, takePartial2.getShape());
+        assertArrayEquals(new double[]{0, 15, 0, 0}, takePartial2.asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(takePartial2.getShape(), takePartial2Reverse.getShape());
+        assertArrayEquals(takePartial2.asFlatDoubleArray(), takePartial2Reverse.asFlatDoubleArray(), 1e-6);
     }
 
 
@@ -63,20 +63,20 @@ public class TakeVertexTest {
         DoubleTensor takePartial = take.getDualNumber().getPartialDerivatives().withRespectTo(m);
         DoubleTensor takePartialReverse = Differentiator.reverseModeAutoDiff(take, m, alpha).withRespectTo(m);
 
-        Assert.assertArrayEquals(new int[]{1, 1, 2, 2}, takePartial.getShape());
-        Assert.assertArrayEquals(new double[]{10, 20, 0, 0}, takePartial.asFlatDoubleArray(), 1e-6);
-        Assert.assertArrayEquals(takePartial.getShape(), takePartialReverse.getShape());
-        Assert.assertArrayEquals(takePartial.asFlatDoubleArray(), takePartialReverse.asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(new int[]{1, 1, 2, 2}, takePartial.getShape());
+        assertArrayEquals(new double[]{10, 20, 0, 0}, takePartial.asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(takePartial.getShape(), takePartialReverse.getShape());
+        assertArrayEquals(takePartial.asFlatDoubleArray(), takePartialReverse.asFlatDoubleArray(), 1e-6);
 
         TakeVertex take2 = new TakeVertex(N, 0, 1);
 
         DoubleTensor takePartial2 = take2.getDualNumber().getPartialDerivatives().withRespectTo(m);
         DoubleTensor takePartial2Reverse = Differentiator.reverseModeAutoDiff(take2, m, alpha).withRespectTo(m);
 
-        Assert.assertArrayEquals(new int[]{1, 1, 2, 2}, takePartial2.getShape());
-        Assert.assertArrayEquals(new double[]{15, 25, 0, 0}, takePartial2.asFlatDoubleArray(), 1e-6);
-        Assert.assertArrayEquals(takePartial.getShape(), takePartial2Reverse.getShape());
-        Assert.assertArrayEquals(takePartial2.asFlatDoubleArray(), takePartial2Reverse.asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(new int[]{1, 1, 2, 2}, takePartial2.getShape());
+        assertArrayEquals(new double[]{15, 25, 0, 0}, takePartial2.asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(takePartial.getShape(), takePartial2Reverse.getShape());
+        assertArrayEquals(takePartial2.asFlatDoubleArray(), takePartial2Reverse.asFlatDoubleArray(), 1e-6);
     }
 
     @Test
@@ -110,23 +110,23 @@ public class TakeVertexTest {
         DoubleTensor takeDual = take.getDualNumber().getPartialDerivatives().withRespectTo(alpha);
         DoubleTensor takeDualReverse = Differentiator.reverseModeAutoDiff(take, m, alpha).withRespectTo(alpha);
 
-        Assert.assertArrayEquals(new int[]{1, 1, 2, 2}, takeDual.getShape());
-        Assert.assertArrayEquals(new double[]{56, 92, 103, 174}, takeDual.asFlatDoubleArray(), 1e-6);
-        Assert.assertArrayEquals(takeDual.getShape(), takeDualReverse.getShape());
-        Assert.assertArrayEquals(takeDual.asFlatDoubleArray(), takeDualReverse.asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(new int[]{1, 1, 2, 2}, takeDual.getShape());
+        assertArrayEquals(new double[]{56, 92, 103, 174}, takeDual.asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(takeDual.getShape(), takeDualReverse.getShape());
+        assertArrayEquals(takeDual.asFlatDoubleArray(), takeDualReverse.asFlatDoubleArray(), 1e-6);
     }
 
     @Test
     public void shapeOfPartialCorrectlyPassesThroughTake() {
         DoubleVertex A = new UniformVertex(0, 10);
-        A.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+        A.setValue(DoubleTensor.arange(1, 28).reshape(3, 3, 3));
 
         DoubleVertex B = new UniformVertex(0, 10);
-        B.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+        B.setValue(DoubleTensor.arange(1, 28).reshape(3, 3, 3));
 
         DoubleVertex C = A.times(B);
 
-        DoubleVertex D = C.take(0, 1);
+        DoubleVertex D = C.take(0, 1, 2);
 
         DoubleVertex E = new UniformVertex(0, 10);
         E.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 1, 4));
@@ -136,18 +136,19 @@ public class TakeVertexTest {
         PartialDerivatives forward = F.getDualNumber().getPartialDerivatives();
         PartialDerivatives reverse = Differentiator.reverseModeAutoDiff(F, A, B);
 
-        Assert.assertArrayEquals(new int[]{1, 4, 2, 2}, forward.withRespectTo(A).getShape());
-        Assert.assertArrayEquals(forward.withRespectTo(A).getShape(), reverse.withRespectTo(A).getShape());
-        Assert.assertArrayEquals(forward.withRespectTo(A).asFlatDoubleArray(), reverse.withRespectTo(A).asFlatDoubleArray(), 1e-6);
+        assertArrayEquals(new int[]{1, 4, 3, 3, 3}, forward.withRespectTo(A).getShape());
+        assertArrayEquals(forward.withRespectTo(A).getShape(), reverse.withRespectTo(A).getShape());
+        assertArrayEquals(forward.withRespectTo(A).asFlatDoubleArray(), reverse.withRespectTo(A).asFlatDoubleArray(), 1e-6);
     }
 
     @Test
-    @Ignore("Currently fails due to partial derivative issues")
     public void changesMatchGradient() {
-        DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.times(3).take(0, 0 , 0);
+        DoubleVertex inputA = new UniformVertex(new int[]{3, 3, 3}, -10.0, 10.0);
+        DoubleVertex inputB = new UniformVertex(new int[]{3, 3, 3}, -10.0, 10.0);
+        DoubleVertex inputC = new UniformVertex(new int[]{2, 2}, -10.0, 10.0);
+        DoubleVertex outputVertex = inputA.times(10.0).times(inputB).take(0, 1, 2).plus(inputC);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB), outputVertex, 10.0, 1e-10, true);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
@@ -62,7 +62,7 @@ public class TanVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -1.0, 1.0);
         DoubleVertex outputVertex = inputVertex.div(3).tan();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.0001, 1e-6);
+        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.0001, 1e-6, true);
     }
 
 }


### PR DESCRIPTION
Fix a number of bugs in forward and reverse mode autodiff for rank > 2 tensors.

Remaining problems:
 - Operations that perform tensor broadcast won't produce the correct partials in reverse mode. (collectPartials needs to deal with this case correctly).