### PR TITLE
Add determinant vertex

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
@@ -64,6 +64,16 @@ public class TensorShapeValidation {
         }
     }
 
+    public static void checkShapeIsSquareMatrix(int[] shape) {
+        if (shape.length != 2) {
+            throw new IllegalArgumentException("Input tensor must be a matrix");
+        }
+
+        if (shape[0] != shape[1]) {
+            throw new IllegalArgumentException("Input matrix must be square");
+        }
+    }
+
     private static Set<TensorShape> getNonScalarShapes(int[]... shapes) {
         return Arrays.stream(shapes)
             .map(TensorShape::new)

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -33,6 +33,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ExpVert
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.FloorVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.LogGammaVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.LogVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.MatrixDeterminantVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.MatrixInverseVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ReshapeVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.RoundVertex;
@@ -75,6 +76,17 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
 
     public DoubleVertex matrixInverse() {
         return new MatrixInverseVertex(this);
+    }
+
+    /**
+     * Get a vertex that is the determinant of this vertex.
+     * <p>
+     * Gradient calculations (and thus gradient-based optimisations) will fail if the matrixDeterminant is 0.
+     *
+     * @return a new vertex with the value of the determinant of this vertex
+     */
+    public DoubleVertex matrixDeterminant() {
+        return new MatrixDeterminantVertex(this);
     }
 
     public DoubleVertex divideBy(DoubleVertex that) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -78,13 +78,6 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return new MatrixInverseVertex(this);
     }
 
-    /**
-     * Get a vertex that is the determinant of this vertex.
-     * <p>
-     * Gradient calculations (and thus gradient-based optimisations) will fail if the matrixDeterminant is 0.
-     *
-     * @return a new vertex with the value of the determinant of this vertex
-     */
     public DoubleVertex matrixDeterminant() {
         return new MatrixDeterminantVertex(this);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
@@ -13,16 +13,30 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 /**
  * A vertex that takes on the value of the matrixDeterminant of the value of its input matrix
  * <p>
- * Gradient calculations (and thus gradient-based optimisations) will fail if the matrixDeterminant is 0.
+ * Gradient calculations (and thus gradient-based optimisations) will fail if the determinant is 0.
+ * <p>
+ * Reverse derivatives are implemented according to https://www.cs.ox.ac.uk/files/723/NA-08-01.pdf
+ * <p>
+ * Forward mode differentiation is not implemented due to requiring a tensor trace, which is not yet implemented
  */
 public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
     public MatrixDeterminantVertex(DoubleVertex vertex) {
         super(Tensor.SCALAR_SHAPE, vertex);
+        assertInputValueIsSquareMatrix(vertex.getValue());
     }
 
-    @Override
-    protected DoubleTensor op(DoubleTensor value) {
-        return DoubleTensor.scalar(value.determinant());
+    private static void assertInputValueIsSquareMatrix(DoubleTensor value) {
+        final IllegalArgumentException exception = new IllegalArgumentException("Input tensor must be a square matrix");
+
+        if (value == null) {
+            throw exception;
+        }
+
+        final int[] shape = value.getShape();
+
+        if ((shape.length != 2) || (shape[0] != shape[1])) {
+            throw exception;
+        }
     }
 
     @Override
@@ -30,14 +44,15 @@ public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * Implemented according to https://www.cs.ox.ac.uk/files/723/NA-08-01.pdf
-     *
-     * @param derivativeOfOutputsWithRespectToSelf derivative of outputs with respect to self
-     * @return derivative of outputs with respect to inputs
-     */
+    @Override
+    protected DoubleTensor op(DoubleTensor value) {
+        assertInputValueIsSquareMatrix(value);
+        return DoubleTensor.scalar(value.determinant());
+    }
+
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
+        assertInputValueIsSquareMatrix(inputVertex.getValue());
         DoubleTensor inverseTranspose = inputVertex.getValue().transpose().matrixInverse();
 
         PartialDerivatives derivativeOfOutputsWithRespectToInputs = derivativeOfOutputsWithRespectToSelf

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
@@ -1,0 +1,51 @@
+package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
+
+import java.util.Collections;
+import java.util.Map;
+
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.DualNumber;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+/**
+ * A vertex that takes on the value of the matrixDeterminant of the value of its input matrix
+ * <p>
+ * Gradient calculations (and thus gradient-based optimisations) will fail if the matrixDeterminant is 0.
+ */
+public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
+    public MatrixDeterminantVertex(DoubleVertex vertex) {
+        super(Tensor.SCALAR_SHAPE, vertex);
+    }
+
+    @Override
+    protected DoubleTensor op(DoubleTensor value) {
+        return DoubleTensor.scalar(value.determinant());
+    }
+
+    @Override
+    protected DualNumber dualOp(DualNumber dualNumber) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
+        // As this is the inverse, this will fail if the matrixDeterminant is zero
+        DoubleTensor inverseTranspose = inputVertex.getValue().transpose().matrixInverse();
+
+        // Reverse mode auto diff of matrix matrixDeterminant: https://www.cs.ox.ac.uk/files/723/NA-08-01.pdf
+        // Using variables from the paper
+        // Abar = derivativeOfOutputsWithRespectToInputs (what we want)
+        // A = inputVertex
+        // C = det(inputVertex)
+        // Cbar = derivativeOfOutputsWithRespectToSelf
+        // Abar_i,j = C * Cbar_i,j * inverse(transpose(A))
+        PartialDerivatives derivativeOfOutputsWithRespectToInputs = derivativeOfOutputsWithRespectToSelf
+            .multiplyBy(inputVertex.getValue().determinant())
+            .multiplyAlongWrtDimensions(inverseTranspose, this.inputVertex.getShape());
+
+        return Collections.singletonMap(inputVertex, derivativeOfOutputsWithRespectToInputs);
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
@@ -26,16 +26,12 @@ public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
     }
 
     private static void assertInputValueIsSquareMatrix(DoubleTensor value) {
-        final IllegalArgumentException exception = new IllegalArgumentException("Input tensor must be a square matrix");
-
-        if (value == null) {
-            throw exception;
-        }
-
         final int[] shape = value.getShape();
+        final boolean isMatrix = shape.length == 2;
+        final boolean isSquare = isMatrix && shape[0] == shape[1];
 
-        if ((shape.length != 2) || (shape[0] != shape[1])) {
-            throw exception;
+        if (!isMatrix || !isSquare) {
+            throw new IllegalArgumentException("Input tensor must be a square matrix");
         }
     }
 
@@ -46,13 +42,11 @@ public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
 
     @Override
     protected DoubleTensor op(DoubleTensor value) {
-        assertInputValueIsSquareMatrix(value);
         return DoubleTensor.scalar(value.determinant());
     }
 
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        assertInputValueIsSquareMatrix(inputVertex.getValue());
         DoubleTensor inverseTranspose = inputVertex.getValue().transpose().matrixInverse();
 
         PartialDerivatives derivativeOfOutputsWithRespectToInputs = derivativeOfOutputsWithRespectToSelf

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
@@ -30,18 +30,16 @@ public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Implemented according to https://www.cs.ox.ac.uk/files/723/NA-08-01.pdf
+     *
+     * @param derivativeOfOutputsWithRespectToSelf derivative of outputs with respect to self
+     * @return derivative of outputs with respect to inputs
+     */
     @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        // As this is the inverse, this will fail if the matrixDeterminant is zero
         DoubleTensor inverseTranspose = inputVertex.getValue().transpose().matrixInverse();
 
-        // Reverse mode auto diff of matrix matrixDeterminant: https://www.cs.ox.ac.uk/files/723/NA-08-01.pdf
-        // Using variables from the paper
-        // Abar = derivativeOfOutputsWithRespectToInputs (what we want)
-        // A = inputVertex
-        // C = det(inputVertex)
-        // Cbar = derivativeOfOutputsWithRespectToSelf
-        // Abar_i,j = C * Cbar_i,j * inverse(transpose(A))
         PartialDerivatives derivativeOfOutputsWithRespectToInputs = derivativeOfOutputsWithRespectToSelf
             .multiplyBy(inputVertex.getValue().determinant())
             .multiplyAlongWrtDimensions(inverseTranspose, this.inputVertex.getShape());

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
@@ -22,17 +23,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
     public MatrixDeterminantVertex(DoubleVertex vertex) {
         super(Tensor.SCALAR_SHAPE, vertex);
-        assertInputValueIsSquareMatrix(vertex.getValue());
-    }
-
-    private static void assertInputValueIsSquareMatrix(DoubleTensor value) {
-        final int[] shape = value.getShape();
-        final boolean isMatrix = shape.length == 2;
-        final boolean isSquare = isMatrix && shape[0] == shape[1];
-
-        if (!isMatrix || !isSquare) {
-            throw new IllegalArgumentException("Input tensor must be a square matrix");
-        }
+        TensorShapeValidation.checkShapeIsSquareMatrix(vertex.getShape());
     }
 
     @Override

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorShapeValidationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorShapeValidationTest.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.tensor;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
 
 public class TensorShapeValidationTest {
 
@@ -53,5 +53,20 @@ public class TensorShapeValidationTest {
     @Test
     public void acceptsNonScalarToScalarParentShape() {
         TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar(new int[]{2, 4}, scalar2, scalar1);
+    }
+
+    @Test
+    public void checkSquareMatrixAcceptsSquareMatrices() {
+        TensorShapeValidation.checkShapeIsSquareMatrix(new int[]{3, 3});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkSquareMatrixFailsOnNonMatrices() {
+        TensorShapeValidation.checkShapeIsSquareMatrix(new int[]{3, 3, 3});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkSquareMatrixFailsOnNonSquareMatrices() {
+        TensorShapeValidation.checkShapeIsSquareMatrix(new int[]{3, 2});
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -119,7 +119,7 @@ public class DifferentiatorTest {
         DoubleVertex F = D.plus(B).exp();
         DoubleVertex H = G.plus(F).sum().times(A).sum().times(C);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(A, B, C), H, 0.001, 1e-3,  true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B, C), H, 0.001, 1e-3);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -1,7 +1,8 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators;
 
+import static org.junit.Assert.assertThat;
+
 import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 
@@ -11,31 +12,39 @@ import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
 public class TensorTestOperations {
+    public static void finiteDifferenceMatchesForwardAndReverseModeGradient(List<DoubleVertex> inputVertices,
+                                                                            DoubleVertex outputVertex,
+                                                                            double incrementAmount,
+                                                                            Double delta) {
+        finiteDifferenceMatchesForwardModeGradient(inputVertices, outputVertex, incrementAmount, delta);
+        finiteDifferenceMatchesReverseModeGradient(inputVertices, outputVertex, incrementAmount, delta);
+    }
 
-    public static void finiteDifferenceMatchesGradient(List<DoubleVertex> inputVertices,
-                                                       DoubleVertex outputVertex,
-                                                       final double incrementAmount,
-                                                       final Double delta,
-                                                       final boolean doReverse) {
-        inputVertices.forEach(v -> runGradientTestOnSingleInput(v, outputVertex, incrementAmount, delta, doReverse));
+    public static void finiteDifferenceMatchesForwardModeGradient(List<DoubleVertex> inputVertices,
+                                                                  DoubleVertex outputVertex,
+                                                                  double incrementAmount,
+                                                                  double delta) {
+        inputVertices.forEach(v ->
+            runGradientTestOnSingleInput(v, outputVertex, incrementAmount, delta, true));
+    }
+
+    public static void finiteDifferenceMatchesReverseModeGradient(List<DoubleVertex> inputVertices,
+                                                                  DoubleVertex outputVertex,
+                                                                  double incrementAmount,
+                                                                  double delta) {
+        inputVertices.forEach(v ->
+            runGradientTestOnSingleInput(v, outputVertex, incrementAmount, delta, false));
     }
 
     private static void runGradientTestOnSingleInput(DoubleVertex inputVertex,
                                                      DoubleVertex outputVertex,
-                                                     final double incrementAmount,
-                                                     final Double delta,
-                                                     final boolean doReverse) {
+                                                     double incrementAmount,
+                                                     Double delta,
+                                                     boolean isForwardMode) {
         DoubleTensor initialInput = inputVertex.getValue();
 
         DoubleTensor initialOutput = outputVertex.eval();
-        DoubleTensor outputWrtInputForward =
-            outputVertex.getDualNumber().getPartialDerivatives().withRespectTo(inputVertex);
-
-        if (doReverse) {
-            DoubleTensor outputWrtInputReverse =
-                Differentiator.reverseModeAutoDiff(outputVertex, inputVertex).withRespectTo(inputVertex);
-            assertThat(outputWrtInputForward, allCloseTo(delta, outputWrtInputReverse));
-        }
+        DoubleTensor outputWrtInput = dOutputWrtInput(outputVertex, inputVertex, isForwardMode);
 
         int[] dimensionsToSumOver = getWrtDimensions(inputVertex, outputVertex);
 
@@ -46,9 +55,23 @@ public class TensorTestOperations {
 
             DoubleTensor newOutput = outputVertex.eval();
             DoubleTensor differenceInOutput = newOutput.minus(initialOutput);
-            DoubleTensor differenceUsingGradient = outputWrtInputForward.times(incrementTensor).sum(dimensionsToSumOver);
-            assertThat(differenceUsingGradient, allCloseTo(delta, differenceInOutput));
+            DoubleTensor differenceUsingGradient = outputWrtInput.times(incrementTensor).sum(dimensionsToSumOver);
+            assertThat(gradientAssertMessage(outputVertex, inputVertex, isForwardMode),
+                differenceUsingGradient, allCloseTo(delta, differenceInOutput));
         }
+    }
+
+    private static DoubleTensor dOutputWrtInput(DoubleVertex outputVertex, DoubleVertex inputVertex, boolean isForwardMode) {
+        if (isForwardMode) {
+            return outputVertex.getDualNumber().getPartialDerivatives().withRespectTo(inputVertex);
+        } else {
+            return Differentiator.reverseModeAutoDiff(outputVertex, inputVertex).withRespectTo(inputVertex);
+        }
+    }
+
+    private static String gradientAssertMessage(DoubleVertex outputVertex, DoubleVertex inputVertex, boolean isForwardMode) {
+        String descriptor = isForwardMode ? "Forward" : "Reverse";
+        return String.format("%s derivative of vertex with ID %s with respect to %s should match finite difference", descriptor, outputVertex.getId(), inputVertex.getId());
     }
 
     private static int[] getWrtDimensions(DoubleVertex wrtVertex,

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.*;
 
 import org.junit.Test;
@@ -83,6 +83,6 @@ public class AdditionVertexTest {
         DoubleVertex B = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex C = A.plus(B);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Assert;
@@ -444,7 +444,7 @@ public class ConcatenationVertexTest {
         DoubleVertex inputB = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex inputC = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = new ConcatenationVertex(0, inputA, inputB, inputC);
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, 10.0, 1e-10, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.*;
 
 import org.junit.Test;
@@ -83,6 +83,6 @@ public class DivisionVertexTest {
         DoubleVertex B = new UniformVertex(new int[]{2, 2, 2}, 100.0, 150.0);
         DoubleVertex C = A.div(B).times(A);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(A, B), C, 0.001, 1e-5, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B), C, 0.001, 1e-5);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -283,7 +283,7 @@ public class MatrixMultiplicationVertexTest {
         final double INCREMENT = 10;
         final double DELTA = 1e-10;
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB), outputVertex, INCREMENT, DELTA, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MaxVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MaxVertexTest.java
@@ -7,7 +7,7 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwo2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwoScalarVertexValues;
 
@@ -36,7 +36,7 @@ public class MaxVertexTest {
         B.setValue(DoubleTensor.create(8, 7, 6, 5, 4, 3, 2, 1));
         DoubleVertex C = DoubleVertex.max(A, B);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MinVertexTest.java
@@ -1,25 +1,14 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
 import com.google.common.collect.ImmutableList;
-import io.improbable.keanu.DeterministicRule;
-import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
-import io.improbable.keanu.distributions.continuous.Uniform;
-import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.tensor.bool.BooleanTensor;
+
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.bool.BoolVertex;
-import io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex;
-import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
-import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
-import org.junit.Assert;
-import org.junit.Rule;
+
 import org.junit.Test;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwo2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwoScalarVertexValues;
 import static org.junit.Assert.assertArrayEquals;
@@ -49,7 +38,7 @@ public class MinVertexTest {
         B.setValue(DoubleTensor.create(8, 7, 6, 5, 4, 3, 2, 1));
         DoubleVertex C = DoubleVertex.min(A, B);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -155,7 +155,7 @@ public class SliceVertexTest {
     public void changesMatchGradient() {
         DoubleVertex cube = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         SliceVertex slice = new SliceVertex(cube, 2, 0);
-        finiteDifferenceMatchesGradient(ImmutableList.of(cube), slice, 10.0, 1e-10, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(cube), slice, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -62,7 +62,7 @@ public class ArcCosVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -0.25, 0.25);
         DoubleVertex outputVertex = inputVertex.times(3).acos();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -62,7 +62,7 @@ public class ArcSinVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -0.25, 0.25);
         DoubleVertex outputVertex = inputVertex.times(2.0).asin();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -62,7 +62,7 @@ public class ArcTanVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -2.0, 2.0);
         DoubleVertex outputVertex = inputVertex.times(2).atan();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -57,7 +57,7 @@ public class CosVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).cos();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -57,7 +57,7 @@ public class ExpVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).exp();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
@@ -2,7 +2,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import static org.apache.commons.math3.special.Gamma.digamma;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -65,6 +65,6 @@ public class LogGammaVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 1.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).logGamma();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -57,7 +57,7 @@ public class LogVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, 1.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).log();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
@@ -1,0 +1,73 @@
+package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
+
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
+import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.tensor.TensorMatchers;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.Differentiator;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+
+public class MatrixDeterminantVertexTest {
+    @Test
+    public void calculatesDeterminant() {
+        final DoubleVertex input = new ConstantDoubleVertex(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
+        Assert.assertThat(input.matrixDeterminant().getValue(), TensorMatchers.isScalarWithValue(-2d));
+    }
+
+    @Test
+    public void canDifferentiateWrtScalar() {
+        final int[] shape = new int[]{2, 2};
+        final DoubleVertex input = new UniformVertex(shape, 0, 10);
+        input.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, shape));
+        final DoubleVertex output = input.matrixDeterminant().plus(1);
+        final DoubleTensor expectedDerivative = DoubleTensor.create(new double[]{4, -3, -2, 1}, shape);
+        assertReverseAutoDiffMatches(output, input, expectedDerivative);
+    }
+
+    @Test
+    public void canDifferentiateWrtTensor() {
+        final int[] shape = new int[]{2, 2};
+        final DoubleVertex input = new UniformVertex(shape, 0, 10);
+        input.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, shape));
+        final DoubleVertex output = input.matrixDeterminant().times(input);
+
+        // For calculation of derivative, see
+        // https://www.wolframalpha.com/input/?i=x+%3D+1;+y+%3D+2;+z+%3D+3;+w+%3D+4;+d%2Fdx+(%7B%7Bx,y%7D,%7Bz,w%7D%7D+*+det(%7B%7Bx,y%7D,%7Bz,w%7D%7D))
+        final double[] expectedDerivativeValues = new double[]{2, -3, -2, 1, 8, -8, -4, 2, 12, -9, -8, 3, 16, -12, -8, 2};
+        final DoubleTensor expectedDerivative = DoubleTensor.create(expectedDerivativeValues, 2, 2, 2, 2);
+        assertReverseAutoDiffMatches(output, input, expectedDerivative);
+    }
+
+    @Test
+    public void canOptimiseOutOfTheBoxEvenWithRiskOfSingularMatrices() {
+        // The standard method for calculating the gradient of the determinant fails when the matrixDeterminant is 0.
+        // Regardless, the gradient is defined when the matrixDeterminant is 0.
+        // We run the optimizer many times to create some confidence that we won't run into problems in a real-world
+        // use-case.
+        final int runCount = 100;
+        IntStream.range(0, runCount).forEach(i -> {
+            int[] shape = new int[]{2, 2};
+            DoubleVertex input = new GaussianVertex(shape, Math.random() * 2 - 4, Math.random() * 2 + 0.1);
+            DoubleVertex determinant = input.matrixDeterminant();
+            DoubleVertex output = new GaussianVertex(determinant, 1);
+            output.observe(new double[]{2.0, 2.4});
+            BayesianNetwork net = new BayesianNetwork(output.getConnectedGraph());
+
+            Optimizer.of(net).maxLikelihood();
+            Assert.assertEquals(input.getValue().determinant(), 2.2, 0.1);
+        });
+    }
+
+    private void assertReverseAutoDiffMatches(DoubleVertex output, DoubleVertex input, DoubleTensor expectedDerivative) {
+        final DoubleTensor derivative = Differentiator.reverseModeAutoDiff(output, input).withRespectTo(input);
+        Assert.assertThat(derivative, TensorMatchers.elementwiseEqualTo(expectedDerivative));
+    }
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
@@ -1,10 +1,14 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import static org.hamcrest.Matchers.closeTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
+import static io.improbable.keanu.vertices.VertexMatchers.hasValue;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
 
-import org.apache.commons.math3.exception.MathArithmeticException;
 import org.apache.commons.math3.linear.SingularMatrixException;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,8 +16,8 @@ import com.google.common.collect.ImmutableList;
 
 import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
 import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.tensor.TensorMatchers;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.VertexMatchers;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -24,7 +28,7 @@ public class MatrixDeterminantVertexTest {
     @Test
     public void calculatesDeterminant() {
         final DoubleVertex input = new ConstantDoubleVertex(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
-        Assert.assertThat(input.matrixDeterminant().getValue(), TensorMatchers.isScalarWithValue(-2d));
+        Assert.assertThat(input.matrixDeterminant(), hasValue(isScalarWithValue(-2d)));
     }
 
     @Test
@@ -36,13 +40,13 @@ public class MatrixDeterminantVertexTest {
             7, 8, 9, 20, 10,
             12, 32, 43, -2, 5};
         final DoubleVertex input = new ConstantDoubleVertex(DoubleTensor.create(values, 5, 5));
-        Assert.assertThat(input.matrixDeterminant().getValue(), TensorMatchers.isScalarWithValue(Matchers.closeTo(6120880d, 1e-5)));
+        assertThat(input.matrixDeterminant(), VertexMatchers.hasValue(isScalarWithValue(closeTo(6120880d, 1e-5))));
     }
 
     @Test
     public void calculatesDeterminantOnScalar() {
         final DoubleVertex input = new ConstantDoubleVertex(DoubleTensor.scalar(5));
-        Assert.assertThat(input.matrixDeterminant().getValue(), TensorMatchers.isScalarWithValue(5d));
+        assertThat(input.matrixDeterminant(), hasValue(isScalarWithValue(5d)));
     }
 
     @Test
@@ -82,7 +86,7 @@ public class MatrixDeterminantVertexTest {
     public void differentiationFailsWhenMatrixIsSingular() {
         final int[] shape = new int[]{2, 2};
         final DoubleVertex input = new UniformVertex(shape, 0, 10);
-        input.setValue(DoubleTensor.create(new double[]{0, 0, 0,0}, shape));
+        input.setValue(DoubleTensor.create(new double[]{0, 0, 0, 0}, shape));
         final DoubleVertex output = input.matrixDeterminant();
         Differentiator.reverseModeAutoDiff(output, input);
     }
@@ -106,6 +110,6 @@ public class MatrixDeterminantVertexTest {
         final BayesianNetwork net = new BayesianNetwork(output.getConnectedGraph());
 
         Optimizer.of(net).maxLikelihood();
-        Assert.assertEquals(input.getValue().determinant(), 2.2, 0.1);
+        assertEquals(input.getValue().determinant(), 2.2, 0.1);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
@@ -78,16 +78,6 @@ public class MatrixDeterminantVertexTest {
         input.matrixDeterminant();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void failsIfInputChangesToInvalidForm() {
-        final int[] shape = new int[]{4, 4};
-        final int[] badShape = new int[]{2, 2, 2, 2};
-        final DoubleVertex input = new ConstantDoubleVertex(DoubleTensor.create(1, shape));
-        final DoubleVertex output = input.matrixDeterminant();
-        input.setValue(DoubleTensor.create(1, badShape));
-        output.eval();
-    }
-
     @Test(expected = SingularMatrixException.class)
     public void differentiationFailsWhenMatrixIsSingular() {
         final int[] shape = new int[]{2, 2};

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -114,8 +114,8 @@ public class MatrixInverseVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{3, 3}, 1.0, 25.0);
         DoubleVertex invertVertex = inputVertex.matrixInverse();
 
-        finiteDifferenceMatchesGradient(
-            ImmutableList.of(inputVertex), invertVertex, 0.001, 1e-5, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(
+            ImmutableList.of(inputVertex), invertVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -127,7 +127,7 @@ public class ReshapeVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{4, 4}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(1.5).reshape(2, 2, 2, 2);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -71,7 +71,7 @@ public class SigmoidVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.times(3).sigmoid();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-6, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-6);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -57,7 +57,7 @@ public class SinVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputVertex.div(3).sin();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -132,7 +132,7 @@ public class SumVertexTest {
         inputVertex.setValue(DoubleTensor.arange(0, 8).reshape(2, 2, 2));
         DoubleVertex outputVertex = inputVertex.sum().times(inputVertex);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 1e-6, 1e-10, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 1e-6, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -148,7 +148,7 @@ public class TakeVertexTest {
         DoubleVertex inputC = new UniformVertex(new int[]{2, 2}, -10.0, 10.0);
         DoubleVertex outputVertex = inputA.times(10.0).times(inputB).take(0, 1, 2).plus(inputC);
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputA, inputB), outputVertex, 10.0, 1e-10, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB), outputVertex, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDualNumberOfScalar;
@@ -62,7 +62,7 @@ public class TanVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new int[]{2, 2, 2}, -1.0, 1.0);
         DoubleVertex outputVertex = inputVertex.div(3).tan();
 
-        finiteDifferenceMatchesGradient(ImmutableList.of(inputVertex), outputVertex, 0.0001, 1e-6, true);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.0001, 1e-6);
     }
 
 }


### PR DESCRIPTION
This PR adds support for a determinant vertex. It takes a vertex shaped like a matrix as input, and outputs a scalar determinant.

Reverse auto diff has been implemented on this vertex as well. It's slightly problematic as it involves the inverse of our input matrix, which fails when the determinant is 0 (despite the gradient being well-defined at that point). This seems to be the expected way to perform such a calculation, and none of the literature even addresses this as a problem. @gordoncaleb and I couldn't think of a case where this would be a problem, and I added some random testing to verify this at least in a small case.

Forward differentiation has not been implemented.