### PR TITLE
Add argMax function to tensors

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/NumberTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/NumberTensor.java
@@ -39,9 +39,10 @@ public interface NumberTensor<N extends Number, T extends NumberTensor<N,T>> ext
      * // [[5]]
      * </pre>
      *
-     * @return A scalar tensor with the index of the largest value
+     * @return A scalar tensor with the index of the largest value. If there are multiple largest values, it will be
+     *         the first index.
      */
-    IntegerTensor argMax();
+    int argMax();
 
     /**
      * Find the indices into the tensor of the largest values in a specified axis (dimension), e.g.
@@ -57,7 +58,8 @@ public interface NumberTensor<N extends Number, T extends NumberTensor<N,T>> ext
      *
      * @param axis The axis (dimension) to find the largest values in
      * @return A tensor where each value is the location of the maximum value in the vector at that location in the
-     *         specified dimension in the original tensor
+     *         specified dimension in the original tensor. If there are multiple largest values in this vector, it will
+     *         be the first index.
      * @see <a href="https://www.geeksforgeeks.org/numpy-argmax-python/">An article about argmax over an axis in numpy</a>
      */
     IntegerTensor argMax(int axis);

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/NumberTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/NumberTensor.java
@@ -29,6 +29,39 @@ public interface NumberTensor<N extends Number, T extends NumberTensor<N,T>> ext
     
     T abs();
 
+    /**
+     * Find the index into the flattened array of the tensor of the largest value, e.g.
+     * <pre>
+     * DoubleTensor tensor = DoubleTensor.arange(0, 6).reshape(2, 3);
+     * // [[0., 1., 2.],
+     * //  [3., 4., 5.]]
+     * IntegerTensor max = tensor.argMax();
+     * // [[5]]
+     * </pre>
+     *
+     * @return A scalar tensor with the index of the largest value
+     */
+    IntegerTensor argMax();
+
+    /**
+     * Find the indices into the tensor of the largest values in a specified axis (dimension), e.g.
+     * <pre>
+     * DoubleTensor tensor = DoubleTensor.arange(0, 6).reshape(2, 3);
+     * // [[0., 1., 2.],
+     * //  [3., 4., 5.]]
+     * IntegerTensor maxesFor0 = tensor.argMax(0);
+     * // [[1, 1, 1]]
+     * IntegerTensor maxFor1 = tensor.argMax(1);
+     * // [[2, 2]]
+     * </pre>
+     *
+     * @param axis The axis (dimension) to find the largest values in
+     * @return A tensor where each value is the location of the maximum value in the vector at that location in the
+     *         specified dimension in the original tensor
+     * @see <a href="https://www.geeksforgeeks.org/numpy-argmax-python/">An article about argmax over an axis in numpy</a>
+     */
+    IntegerTensor argMax(int axis);
+
     T getGreaterThanMask(T greaterThanThis);
 
     T getGreaterThanOrEqualToMask(T greaterThanThis);

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -1,10 +1,8 @@
 package io.improbable.keanu.tensor;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
-import com.google.common.primitives.Ints;
+import org.apache.commons.lang3.ArrayUtils;
 
 public class TensorShape {
 
@@ -12,29 +10,6 @@ public class TensorShape {
 
     public TensorShape(int[] shape) {
         this.shape = Arrays.copyOf(shape, shape.length);
-    }
-
-    public int[] getShape() {
-        return Arrays.copyOf(shape, shape.length);
-    }
-
-    public boolean isScalar() {
-        return isScalar(shape);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        TensorShape that = (TensorShape) o;
-
-        return Arrays.equals(shape, that.shape);
-    }
-
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(shape);
     }
 
     /**
@@ -158,7 +133,7 @@ public class TensorShape {
 
         return newShape;
     }
-    
+
     public static int[] shapeDesiredToRankByAppendingOnes(int[] lowRankTensorShape, int desiredRank) {
         return increaseRankByPaddingOnes(lowRankTensorShape, desiredRank, true);
     }
@@ -189,5 +164,38 @@ public class TensorShape {
         return newShape;
     }
 
+    /**
+     * Removes a dimension from a shape
+     *
+     * @param shape     the shape to remove the dimension from
+     * @param dimension the dimension to remove
+     * @return the shape without the given dimension
+     */
+    public static int[] argMaxShape(int[] shape, int dimension) {
+        return ArrayUtils.remove(shape, dimension);
+    }
+
+    public int[] getShape() {
+        return Arrays.copyOf(shape, shape.length);
+    }
+
+    public boolean isScalar() {
+        return isScalar(shape);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TensorShape that = (TensorShape) o;
+
+        return Arrays.equals(shape, that.shape);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(shape);
+    }
 }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -165,13 +165,24 @@ public class TensorShape {
     }
 
     /**
-     * Removes a dimension from a shape
+     * Removes a dimension from a shape, guaranteeing that the resultant shape is at least rank 2. A row vector (1xN) is
+     * returned when removing a dimension would result in lower than rank 2.
      *
-     * @param shape     the shape to remove the dimension from
      * @param dimension the dimension to remove
+     * @param shape     the shape to remove the dimension from
      * @return the shape without the given dimension
      */
-    public static int[] argMaxShape(int[] shape, int dimension) {
+    public static int[] removeDimensionSafe(int dimension, int[] shape) {
+        TensorShapeValidation.checkDimensionExistsInShape(dimension, shape);
+
+        if (shape.length == 1) {
+            return new int[]{1, shape[0]};
+        }
+
+        if (shape.length == 2) {
+            return new int[]{1, dimension == 1 ? shape[0] : shape[1]};
+        }
+
         return ArrayUtils.remove(shape, dimension);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
@@ -51,11 +51,11 @@ public class TensorShapeValidation {
      * Check if the given dimension exists within the shape
      *
      * @param dimension Proposed dimension
-     * @param shape Shape to check
+     * @param shape     Shape to check
      * @throws IllegalArgumentException if the dimension exceeds the rank of the shape
      */
     public static void checkDimensionExistsInShape(int dimension, int[] shape) {
-        if (dimension > shape.length - 1) {
+        if (dimension >= shape.length) {
             throw new IllegalArgumentException(String.format("Dimension %d does not exist in tensor of rank %d", dimension, shape.length));
         }
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
@@ -48,6 +48,19 @@ public class TensorShapeValidation {
     }
 
     /**
+     * Check if the given dimension exists within the shape
+     *
+     * @param dimension Proposed dimension
+     * @param shape Shape to check
+     * @throws IllegalArgumentException if the dimension exceeds the rank of the shape
+     */
+    public static void checkDimensionExistsInShape(int dimension, int[] shape) {
+        if (dimension > shape.length - 1) {
+            throw new IllegalArgumentException(String.format("Dimension %d does not exist in tensor of rank %d", dimension, shape.length));
+        }
+    }
+
+    /**
      * This ensures there is at most a single non-scalar shape.
      *
      * @param shapes the tensors for shape checking

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -47,10 +47,11 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     private INDArray tensor;
 
     public Nd4jDoubleTensor(double[] data, int[] shape) {
-        this.tensor = TypedINDArrayFactory.create(data, shape, BUFFER_TYPE);
+        this(TypedINDArrayFactory.create(data, shape, BUFFER_TYPE));
     }
 
     public Nd4jDoubleTensor(INDArray tensor) {
+        TensorShapeValidation.checkRankIsAtLeastTwo(tensor.shape());
         this.tensor = tensor;
     }
 
@@ -187,15 +188,15 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     }
 
     @Override
-    public IntegerTensor argMax() {
-        return new Nd4jIntegerTensor(tensor.argMax());
+    public int argMax() {
+        return tensor.argMax().getInt(0);
     }
 
     @Override
     public IntegerTensor argMax(int axis) {
         int[] shape = this.getShape();
         TensorShapeValidation.checkDimensionExistsInShape(axis, shape);
-        return new Nd4jIntegerTensor(tensor.argMax(axis)).reshape(TensorShape.argMaxShape(shape, axis));
+        return new Nd4jIntegerTensor(tensor.argMax(axis).reshape(TensorShape.removeDimensionSafe(axis, shape)));
     }
 
     @Override
@@ -890,8 +891,6 @@ public class Nd4jDoubleTensor implements DoubleTensor {
         return new Nd4jDoubleTensor(slice);
     }
 
-    // Comparisons
-
     /**
      * @param dimension      the dimension to slice on
      * @param splitAtIndices the indices that the dimension to slice on should be slice on
@@ -948,6 +947,8 @@ public class Nd4jDoubleTensor implements DoubleTensor {
 
         return splits;
     }
+
+    // Comparisons
 
     @Override
     public BooleanTensor lessThan(double value) {

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -11,6 +11,7 @@ import org.apache.commons.math3.util.FastMath;
 
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
+import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.tensor.validate.TensorValidator;
@@ -365,6 +366,17 @@ public class ScalarDoubleTensor implements DoubleTensor {
     @Override
     public double min() {
         return value;
+    }
+
+    @Override
+    public IntegerTensor argMax() {
+        return IntegerTensor.scalar(0);
+    }
+
+    @Override
+    public IntegerTensor argMax(int axis) {
+        TensorShapeValidation.checkDimensionExistsInShape(axis, this.getShape());
+        return IntegerTensor.create(0).reshape(1);
     }
 
     @Override
@@ -795,41 +807,6 @@ public class ScalarDoubleTensor implements DoubleTensor {
         return new SimpleDoubleFlattenedView(value);
     }
 
-    private static class SimpleDoubleFlattenedView implements FlattenedView<Double> {
-
-        private double value;
-
-        public SimpleDoubleFlattenedView(double value) {
-            this.value = value;
-        }
-
-        @Override
-        public long size() {
-            return 1;
-        }
-
-        @Override
-        public Double get(long index) {
-            if (index != 0) {
-                throw new IndexOutOfBoundsException();
-            }
-            return value;
-        }
-
-        @Override
-        public Double getOrScalar(long index) {
-            return value;
-        }
-
-        @Override
-        public void set(long index, Double value) {
-            if (index != 0) {
-                throw new IndexOutOfBoundsException();
-            }
-            this.value = value;
-        }
-    }
-
     @Override
     public double[] asFlatDoubleArray() {
         return new double[]{value};
@@ -869,5 +846,40 @@ public class ScalarDoubleTensor implements DoubleTensor {
             "data = [" + value + "]" +
             "\nshape = " + Arrays.toString(shape) +
             "\n}";
+    }
+
+    private static class SimpleDoubleFlattenedView implements FlattenedView<Double> {
+
+        private double value;
+
+        public SimpleDoubleFlattenedView(double value) {
+            this.value = value;
+        }
+
+        @Override
+        public long size() {
+            return 1;
+        }
+
+        @Override
+        public Double get(long index) {
+            if (index != 0) {
+                throw new IndexOutOfBoundsException();
+            }
+            return value;
+        }
+
+        @Override
+        public Double getOrScalar(long index) {
+            return value;
+        }
+
+        @Override
+        public void set(long index, Double value) {
+            if (index != 0) {
+                throw new IndexOutOfBoundsException();
+            }
+            this.value = value;
+        }
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -369,14 +369,14 @@ public class ScalarDoubleTensor implements DoubleTensor {
     }
 
     @Override
-    public IntegerTensor argMax() {
-        return IntegerTensor.scalar(0);
+    public int argMax() {
+        return 0;
     }
 
     @Override
     public IntegerTensor argMax(int axis) {
         TensorShapeValidation.checkDimensionExistsInShape(axis, this.getShape());
-        return IntegerTensor.create(0).reshape(1);
+        return IntegerTensor.scalar(0);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -487,15 +487,15 @@ public class Nd4jIntegerTensor implements IntegerTensor {
     }
 
     @Override
-    public IntegerTensor argMax() {
-        return new Nd4jIntegerTensor(tensor.argMax());
+    public int argMax() {
+        return tensor.argMax().getInt(0);
     }
 
     @Override
     public IntegerTensor argMax(int axis) {
         int[] shape = this.getShape();
         TensorShapeValidation.checkDimensionExistsInShape(axis, shape);
-        return new Nd4jIntegerTensor(tensor.argMax(axis)).reshape(TensorShape.argMaxShape(shape, axis));
+        return new Nd4jIntegerTensor(tensor.argMax(axis).reshape(TensorShape.removeDimensionSafe(axis, shape)));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -20,6 +20,7 @@ import org.nd4j.linalg.ops.transforms.Transforms;
 import io.improbable.keanu.tensor.INDArrayExtensions;
 import io.improbable.keanu.tensor.INDArrayShim;
 import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.TypedINDArrayFactory;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
@@ -30,6 +31,16 @@ import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 public class Nd4jIntegerTensor implements IntegerTensor {
 
     private static final DataBuffer.Type BUFFER_TYPE = DataBuffer.Type.DOUBLE;
+    private INDArray tensor;
+
+    public Nd4jIntegerTensor(int[] data, int[] shape) {
+        this(TypedINDArrayFactory.create(data, shape, BUFFER_TYPE));
+    }
+
+    public Nd4jIntegerTensor(INDArray tensor) {
+        TensorShapeValidation.checkRankIsAtLeastTwo(tensor.shape());
+        this.tensor = tensor;
+    }
 
     public static Nd4jIntegerTensor scalar(int scalarValue) {
         return new Nd4jIntegerTensor(TypedINDArrayFactory.scalar(scalarValue, BUFFER_TYPE));
@@ -55,15 +66,11 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         return new Nd4jIntegerTensor(TypedINDArrayFactory.zeros(shape, BUFFER_TYPE));
     }
 
-    private INDArray tensor;
-
-    public Nd4jIntegerTensor(int[] data, int[] shape) {
-        this(TypedINDArrayFactory.create(data, shape, BUFFER_TYPE));
-    }
-
-    public Nd4jIntegerTensor(INDArray tensor) {
-        TensorShapeValidation.checkRankIsAtLeastTwo(tensor.shape());
-        this.tensor = tensor;
+    static INDArray unsafeGetNd4J(IntegerTensor that) {
+        if (that.isScalar()) {
+            return TypedINDArrayFactory.scalar(that.scalar().doubleValue(), BUFFER_TYPE).reshape(that.getShape());
+        }
+        return ((Nd4jIntegerTensor) that).tensor;
     }
 
     @Override
@@ -480,6 +487,18 @@ public class Nd4jIntegerTensor implements IntegerTensor {
     }
 
     @Override
+    public IntegerTensor argMax() {
+        return new Nd4jIntegerTensor(tensor.argMax());
+    }
+
+    @Override
+    public IntegerTensor argMax(int axis) {
+        int[] shape = this.getShape();
+        TensorShapeValidation.checkDimensionExistsInShape(axis, shape);
+        return new Nd4jIntegerTensor(tensor.argMax(axis)).reshape(TensorShape.argMaxShape(shape, axis));
+    }
+
+    @Override
     public BooleanTensor greaterThan(IntegerTensor value) {
 
         INDArray mask;
@@ -617,13 +636,6 @@ public class Nd4jIntegerTensor implements IntegerTensor {
         return tensor.toString();
     }
 
-    static INDArray unsafeGetNd4J(IntegerTensor that) {
-        if (that.isScalar()) {
-            return TypedINDArrayFactory.scalar(that.scalar().doubleValue(), BUFFER_TYPE).reshape(that.getShape());
-        }
-        return ((Nd4jIntegerTensor) that).tensor;
-    }
-
     private BooleanTensor fromMask(INDArray mask, int[] shape) {
         DataBuffer data = mask.data();
         boolean[] boolsFromMask = new boolean[mask.length()];
@@ -632,6 +644,21 @@ public class Nd4jIntegerTensor implements IntegerTensor {
             boolsFromMask[i] = data.getInt(i) != 0;
         }
         return new SimpleBooleanTensor(boolsFromMask, shape);
+    }
+
+    @Override
+    public double[] asFlatDoubleArray() {
+        return tensor.dup().data().asDouble();
+    }
+
+    @Override
+    public int[] asFlatIntegerArray() {
+        return tensor.dup().data().asInt();
+    }
+
+    @Override
+    public Integer[] asFlatArray() {
+        return ArrayUtils.toObject(asFlatIntegerArray());
     }
 
     private static class Nd4jIntegerFlattenedView implements FlattenedView<Integer> {
@@ -666,21 +693,6 @@ public class Nd4jIntegerTensor implements IntegerTensor {
             tensor.data().put(index, value);
         }
 
-    }
-
-    @Override
-    public double[] asFlatDoubleArray() {
-        return tensor.dup().data().asDouble();
-    }
-
-    @Override
-    public int[] asFlatIntegerArray() {
-        return tensor.dup().data().asInt();
-    }
-
-    @Override
-    public Integer[] asFlatArray() {
-        return ArrayUtils.toObject(asFlatIntegerArray());
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensor.java
@@ -7,9 +7,9 @@ import com.google.common.math.IntMath;
 
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
+import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.dbl.ScalarDoubleTensor;
 
 public class ScalarIntegerTensor implements IntegerTensor {
 
@@ -432,6 +432,17 @@ public class ScalarIntegerTensor implements IntegerTensor {
     }
 
     @Override
+    public IntegerTensor argMax() {
+        return IntegerTensor.scalar(0);
+    }
+
+    @Override
+    public IntegerTensor argMax(int axis) {
+        TensorShapeValidation.checkDimensionExistsInShape(axis, this.getShape());
+        return IntegerTensor.create(0).reshape(1);
+    }
+
+    @Override
     public BooleanTensor greaterThan(IntegerTensor that) {
         if (that.isScalar()) {
             return greaterThan(that.scalar());
@@ -472,6 +483,28 @@ public class ScalarIntegerTensor implements IntegerTensor {
         return new SimpleIntegerFlattenedView(value);
     }
 
+    @Override
+    public double[] asFlatDoubleArray() {
+        return new double[]{value};
+    }
+
+    @Override
+    public int[] asFlatIntegerArray() {
+        return new int[]{value};
+    }
+
+    @Override
+    public Integer[] asFlatArray() {
+        return new Integer[]{value};
+    }
+
+    @Override
+    public String toString() {
+        return "ScalarIntegerTensor{" +
+            "value=" + value +
+            '}';
+    }
+
     private static class SimpleIntegerFlattenedView implements FlattenedView<Integer> {
 
         private int value;
@@ -506,28 +539,6 @@ public class ScalarIntegerTensor implements IntegerTensor {
             this.value = value;
         }
 
-    }
-
-    @Override
-    public double[] asFlatDoubleArray() {
-        return new double[]{value};
-    }
-
-    @Override
-    public int[] asFlatIntegerArray() {
-        return new int[]{value};
-    }
-
-    @Override
-    public Integer[] asFlatArray() {
-        return new Integer[]{value};
-    }
-
-    @Override
-    public String toString() {
-        return "ScalarIntegerTensor{" +
-            "value=" + value +
-            '}';
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensor.java
@@ -432,14 +432,14 @@ public class ScalarIntegerTensor implements IntegerTensor {
     }
 
     @Override
-    public IntegerTensor argMax() {
-        return IntegerTensor.scalar(0);
+    public int argMax() {
+        return 0;
     }
 
     @Override
     public IntegerTensor argMax(int axis) {
         TensorShapeValidation.checkDimensionExistsInShape(axis, this.getShape());
-        return IntegerTensor.create(0).reshape(1);
+        return IntegerTensor.scalar(0);
     }
 
     @Override

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorMatchers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorMatchers.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.tensor;
 
+import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -88,6 +89,10 @@ public class TensorMatchers {
                 description.appendText("Tensor with value ").appendValue(valueMatchers);
             }
         };
+    }
+
+    public static <T> Matcher<Tensor<T>> tensorEqualTo(Tensor<T> tensor) {
+        return both(TensorMatchers.elementwiseEqualTo(tensor)).and(hasShape(tensor.getShape()));
     }
 
     public static <T> Matcher<Tensor<T>> allValues(Matcher<T> valueMatcher) {

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -641,28 +641,37 @@ public class Nd4jDoubleTensorTest {
     }
 
     @Test
-    public void canArgFindMaxOfVector() {
-        DoubleTensor tensor = DoubleTensor.create(1, 3, 4, 5, 2);
+    public void canFindArgMaxOfRowVector() {
+        DoubleTensor tensorRow = DoubleTensor.create(1, 3, 4, 5, 2);
 
-        assertThat(tensor.argMax(), isScalarWithValue(3));
-        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.zeros(5).reshape(5)));
-        assertThat(tensor.argMax(1), isScalarWithValue(3));
+        assertEquals(3, tensorRow.argMax());
+        assertThat(tensorRow.argMax(0), tensorEqualTo(IntegerTensor.zeros(5)));
+        assertThat(tensorRow.argMax(1), isScalarWithValue(3));
+    }
+
+    @Test
+    public void canFindArgMaxOfColumnVector() {
+        DoubleTensor tensorCol = DoubleTensor.create(1, 3, 4, 5, 2).reshape(5, 1);
+
+        assertEquals(3, tensorCol.argMax());
+        assertThat(tensorCol.argMax(0), isScalarWithValue(3));
+        assertThat(tensorCol.argMax(1), tensorEqualTo(IntegerTensor.zeros(5)));
     }
 
     @Test
     public void argMaxReturnsIndexOfFirstMax() {
         DoubleTensor tensor = DoubleTensor.create(1, 5, 5, 5, 5);
 
-        assertThat(tensor.argMax(), isScalarWithValue(1));
+        assertEquals(tensor.argMax(), 1);
     }
 
     @Test
     public void canFindArgMaxOfMatrix() {
         DoubleTensor tensor = DoubleTensor.create(1, 2, 4, 3, 3, 1, 3, 1).reshape(2, 4);
 
-        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(1, 0, 0, 0).reshape(4)));
-        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(2, 0).reshape(2)));
-        assertThat(tensor.argMax(), isScalarWithValue(2));
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(1, 0, 0, 0)));
+        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(2, 0)));
+        assertEquals(2, tensor.argMax());
     }
 
     @Test
@@ -673,7 +682,7 @@ public class Nd4jDoubleTensorTest {
         assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(7, new int[]{2, 4, 2, 4})));
         assertThat(tensor.argMax(2), tensorEqualTo(IntegerTensor.create(3, new int[]{2, 8, 2, 4})));
         assertThat(tensor.argMax(3), tensorEqualTo(IntegerTensor.ones(2, 8, 4, 4)));
-        assertThat(tensor.argMax(), isScalarWithValue(511));
+        assertEquals(511, tensor.argMax());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
 import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
-import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
 import static io.improbable.keanu.tensor.TensorMatchers.tensorEqualTo;
 
 import java.util.function.Function;
@@ -181,9 +180,9 @@ public class ScalarDoubleTensorTest {
     public void canArgFindMaxOfScalar() {
         DoubleTensor tensor = DoubleTensor.scalar(1);
 
-        assertThat(tensor.argMax(), isScalarWithValue(0));
-        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(0).reshape(1)));
-        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(0).reshape(1)));
+        assertEquals(0, tensor.argMax());
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.scalar(0)));
+        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.scalar(0)));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
 import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
+import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
+import static io.improbable.keanu.tensor.TensorMatchers.tensorEqualTo;
 
 import java.util.function.Function;
 
@@ -16,6 +18,7 @@ import org.junit.rules.ExpectedException;
 
 import io.improbable.keanu.tensor.TensorValueException;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.tensor.validate.TensorValidator;
 import io.improbable.keanu.tensor.validate.policy.TensorValidationPolicy;
 
@@ -172,5 +175,20 @@ public class ScalarDoubleTensorTest {
         tensor2 = validator.validate(tensor2);
         assertThat(tensor1, equalTo(notZero));
         assertThat(tensor2, equalTo(one));
+    }
+
+    @Test
+    public void canArgFindMaxOfScalar() {
+        DoubleTensor tensor = DoubleTensor.scalar(1);
+
+        assertThat(tensor.argMax(), isScalarWithValue(0));
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(0).reshape(1)));
+        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(0).reshape(1)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void argMaxFailsForAxisTooHigh() {
+        DoubleTensor tensor = DoubleTensor.scalar(1);
+        tensor.argMax(2);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
@@ -549,28 +549,30 @@ public class Nd4jIntegerTensorTest {
     }
 
     @Test
-    public void canFindArgMaxOfVector() {
-        IntegerTensor tensor = IntegerTensor.create(1, 3, 4, 5, 2);
+    public void canFindArgMaxOfRowVector() {
+        IntegerTensor tensorRow = IntegerTensor.create(1, 3, 4, 5, 2);
 
-        assertThat(tensor.argMax(), isScalarWithValue(3));
-        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.zeros(5).reshape(5)));
-        assertThat(tensor.argMax(1), isScalarWithValue(3));
+        assertEquals(3, tensorRow.argMax());
+        assertThat(tensorRow.argMax(0), tensorEqualTo(IntegerTensor.zeros(5)));
+        assertThat(tensorRow.argMax(1), isScalarWithValue(3));
     }
 
     @Test
-    public void argMaxReturnsIndexOfFirstMax() {
-        IntegerTensor tensor = IntegerTensor.create(1, 5, 5, 5, 5);
+    public void canFindArgMaxOfColumnVector() {
+        IntegerTensor tensorCol = IntegerTensor.create(1, 3, 4, 5, 2).reshape(5, 1);
 
-        assertThat(tensor.argMax(), isScalarWithValue(1));
+        assertEquals(3, tensorCol.argMax());
+        assertThat(tensorCol.argMax(0), isScalarWithValue(3));
+        assertThat(tensorCol.argMax(1), tensorEqualTo(IntegerTensor.zeros(5)));
     }
 
     @Test
     public void canFindArgMaxOfMatrix() {
         IntegerTensor tensor = IntegerTensor.create(1, 2, 4, 3, 3, 1, 3, 1).reshape(2, 4);
 
-        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(1, 0, 0, 0).reshape(4)));
-        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(2, 0).reshape(2)));
-        assertThat(tensor.argMax(), isScalarWithValue(2));
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(1, 0, 0, 0)));
+        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(2, 0)));
+        assertEquals(2, tensor.argMax());
     }
 
     @Test
@@ -581,7 +583,7 @@ public class Nd4jIntegerTensorTest {
         assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(7, new int[]{2, 4, 2, 4})));
         assertThat(tensor.argMax(2), tensorEqualTo(IntegerTensor.create(3, new int[]{2, 8, 2, 4})));
         assertThat(tensor.argMax(3), tensorEqualTo(IntegerTensor.ones(2, 8, 4, 4)));
-        assertThat(tensor.argMax(), isScalarWithValue(511));
+        assertEquals(511, tensor.argMax());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
@@ -6,7 +6,11 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
+import static io.improbable.keanu.tensor.TensorMatchers.tensorEqualTo;
+
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -542,6 +546,48 @@ public class Nd4jIntegerTensorTest {
 
         assertArrayEquals(new int[]{1, 2, 1, 4}, min.asFlatIntegerArray());
         assertArrayEquals(new int[]{2, 3, 3, 4}, max.asFlatIntegerArray());
+    }
+
+    @Test
+    public void canFindArgMaxOfVector() {
+        IntegerTensor tensor = IntegerTensor.create(1, 3, 4, 5, 2);
+
+        assertThat(tensor.argMax(), isScalarWithValue(3));
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.zeros(5).reshape(5)));
+        assertThat(tensor.argMax(1), isScalarWithValue(3));
+    }
+
+    @Test
+    public void argMaxReturnsIndexOfFirstMax() {
+        IntegerTensor tensor = IntegerTensor.create(1, 5, 5, 5, 5);
+
+        assertThat(tensor.argMax(), isScalarWithValue(1));
+    }
+
+    @Test
+    public void canFindArgMaxOfMatrix() {
+        IntegerTensor tensor = IntegerTensor.create(1, 2, 4, 3, 3, 1, 3, 1).reshape(2, 4);
+
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(1, 0, 0, 0).reshape(4)));
+        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(2, 0).reshape(2)));
+        assertThat(tensor.argMax(), isScalarWithValue(2));
+    }
+
+    @Test
+    public void canFindArgMaxOfHighRank() {
+        IntegerTensor tensor = IntegerTensor.create(IntStream.range(0, 512).toArray()).reshape(2, 8, 4, 2, 4);
+
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.ones(8, 4, 2, 4)));
+        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(7, new int[]{2, 4, 2, 4})));
+        assertThat(tensor.argMax(2), tensorEqualTo(IntegerTensor.create(3, new int[]{2, 8, 2, 4})));
+        assertThat(tensor.argMax(3), tensorEqualTo(IntegerTensor.ones(2, 8, 4, 4)));
+        assertThat(tensor.argMax(), isScalarWithValue(511));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void argMaxFailsForAxisTooHigh() {
+        IntegerTensor tensor = IntegerTensor.create(1, 2, 4, 3, 3, 1, 3, 1).reshape(2, 4);
+        tensor.argMax(2);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensorTest.java
@@ -1,0 +1,25 @@
+package io.improbable.keanu.tensor.intgr;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
+import static io.improbable.keanu.tensor.TensorMatchers.tensorEqualTo;
+
+import org.junit.Test;
+
+public class ScalarIntegerTensorTest {
+    @Test
+    public void canArgFindMaxOfScalar() {
+        IntegerTensor tensor = IntegerTensor.scalar(1);
+
+        assertThat(tensor.argMax(), isScalarWithValue(0));
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(0).reshape(1)));
+        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(0).reshape(1)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void argMaxFailsForAxisTooHigh() {
+        IntegerTensor tensor = IntegerTensor.scalar(1);
+        tensor.argMax(2);
+    }
+}

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensorTest.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.tensor.intgr;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
-import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
 import static io.improbable.keanu.tensor.TensorMatchers.tensorEqualTo;
 
 import org.junit.Test;
@@ -12,9 +12,9 @@ public class ScalarIntegerTensorTest {
     public void canArgFindMaxOfScalar() {
         IntegerTensor tensor = IntegerTensor.scalar(1);
 
-        assertThat(tensor.argMax(), isScalarWithValue(0));
-        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.create(0).reshape(1)));
-        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.create(0).reshape(1)));
+        assertEquals(0, tensor.argMax());
+        assertThat(tensor.argMax(0), tensorEqualTo(IntegerTensor.scalar(0)));
+        assertThat(tensor.argMax(1), tensorEqualTo(IntegerTensor.scalar(0)));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This PR adds a function to number tensors, `argMax`, that returns the indices of maximum values in a tensor. It's been adopted to follow the semantics of numpy's argmax method, which takes a single `axis` argument as opposed to an array of `dimensions`. It took me a while to grok how this method worked, so I tried to document it to help others a little more.

Shaping is a little strange with these semantics - the returned tensor can be rank 1 if the input was rank 2. Let me know if that's a problem and what we might want to do instead.