### PR TITLE
Fix bug in concat reverse mode autodiff

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -491,6 +491,7 @@ public class Nd4jDoubleTensor implements DoubleTensor {
      * This is identical to log().times(y), except that it changes NaN results to 0.
      * This is important when calculating 0log0, which should return 0
      * See https://arcsecond.wordpress.com/2009/03/19/0log0-0-for-real/ for some mathematical justification
+     *
      * @param y The tensor value to multiply by
      * @return the log of this tensor multiplied by y
      */
@@ -897,6 +898,10 @@ public class Nd4jDoubleTensor implements DoubleTensor {
     public List<DoubleTensor> split(int dimension, int... splitAtIndices) {
 
         int[] shape = getShape();
+        if (dimension < 0) {
+            dimension += shape.length;
+        }
+
         if (dimension < 0 || dimension >= shape.length) {
             throw new IllegalArgumentException("Invalid dimension to split on " + dimension);
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -53,6 +53,12 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TanVert
 
 public abstract class DoubleVertex extends Vertex<DoubleTensor> implements DoubleOperators<DoubleVertex>, Differentiable {
 
+    /**
+     * @param dimension dimension to concat along. Negative dimension indexing is not supported.
+     * @param toConcat  array of things to concat. Must match in all dimensions except for the provided
+     *                  dimension
+     * @return a vertex that represents the concatenation of the toConcat
+     */
     public static DoubleVertex concat(int dimension, DoubleVertex... toConcat) {
         return new ConcatenationVertex(dimension, toConcat);
     }
@@ -185,10 +191,21 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return new ArcTan2Vertex(this, that);
     }
 
+    /**
+     * Sum over all dimensions. This will always result in a scalar.
+     *
+     * @return a vertex representing the summation result
+     */
     public DoubleVertex sum() {
         return new SumVertex(this);
     }
 
+    /**
+     * Sum over specified dimensions.
+     *
+     * @param sumOverDimensions dimensions to sum over. Negative dimension indexing is not supported
+     * @return a vertex representing the summation result
+     */
     public DoubleVertex sum(int... sumOverDimensions) {
         return new SumVertex(this, sumOverDimensions);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -139,7 +139,7 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
             splitPartials.put(operands[i], new PartialDerivatives(new HashMap<>()));
         }
 
-        int wrtDimensionToSliceOn = operands[0].getShape().length + dimension;
+        int wrtDimensionToSliceOn = -operands[0].getShape().length + dimension;
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeOfOutputsWithRespectToSelf.asMap().entrySet()) {
             DoubleTensor partial = entry.getValue();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -28,7 +28,8 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
     /**
      * A vertex that can concatenate any amount of vertices along a given dimension.
      *
-     * @param dimension the dimension to concatenate on. This is the only dimension in which sizes may be different.
+     * @param dimension the dimension to concatenate on. This is the only dimension in which sizes may be different. Negative
+     *                  dimension indexing is not supported.
      * @param operands  the operands vertices to concatenate
      */
     public ConcatenationVertex(int dimension, DoubleVertex... operands) {
@@ -139,11 +140,14 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
             splitPartials.put(operands[i], new PartialDerivatives(new HashMap<>()));
         }
 
-        int wrtDimensionToSliceOn = -operands[0].getShape().length + dimension;
+        int operandsRank = operands[0].getShape().length;
+        int wrtStartsAt = -operandsRank;
+        int wrtSplitOn = wrtStartsAt + dimension;
+
         for (Map.Entry<VertexId, DoubleTensor> entry : derivativeOfOutputsWithRespectToSelf.asMap().entrySet()) {
             DoubleTensor partial = entry.getValue();
 
-            List<DoubleTensor> splitPartial = partial.split(wrtDimensionToSliceOn, splitIndices);
+            List<DoubleTensor> splitPartial = partial.split(wrtSplitOn, splitIndices);
 
             for (int i = 0; i < splitPartial.size(); i++) {
                 splitPartials.get(operands[i]).putWithRespectTo(entry.getKey(), splitPartial.get(i));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
@@ -22,7 +22,7 @@ public class SumVertex extends DoubleUnaryOpVertex {
     private final int[] overDimensions;
 
     /**
-     * Performs a sum across specified dimensions
+     * Performs a sum across specified dimensions. Negative dimension indexing is not supported.
      *
      * @param inputVertex    the vertex to have its values summed
      * @param overDimensions dimensions to sum over

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -566,9 +566,15 @@ public class Nd4jDoubleTensorTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void doesThrowOnNegativeDimensionSplit() {
+    public void doesThrowOnInvalidNegativeDimensionSplit() {
         DoubleTensor A = DoubleTensor.arange(0, 100).reshape(10, 10);
-        A.split(-1, new int[]{1, 5});
+        A.split(-3, new int[]{1, 5});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesThrowOnInvalidDimensionSplit() {
+        DoubleTensor A = DoubleTensor.arange(0, 100).reshape(10, 10);
+        A.split(3, new int[]{1, 5});
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -1,7 +1,10 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static org.junit.Assert.assertEquals;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -9,6 +12,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -167,6 +171,23 @@ public class ConcatenationVertexTest {
 
         assertEquals(concatPartialForward.withRespectTo(a), concatPartialReverse.withRespectTo(a));
         assertEquals(concatPartialForward.withRespectTo(b), concatPartialReverse.withRespectTo(b));
+    }
+
+    @Test
+    public void canConcatenateHighRankAutoDiff() {
+        DoubleVertex a = new UniformVertex(0, 10);
+        a.setValue(DoubleTensor.arange(0, 12).reshape(2, 2, 3));
+
+        DoubleVertex b = new UniformVertex(0, 10);
+        b.setValue(DoubleTensor.arange(0, 8).reshape(2, 2, 2));
+
+        DoubleVertex c = a.times(ConstantVertex.of(DoubleTensor.linspace(0, 1, 12).reshape(2, 2, 3)));
+        DoubleVertex d = b.plus(ConstantVertex.of(DoubleTensor.linspace(1, 2, 8).reshape(2, 2, 2)));
+
+        DoubleVertex concat = new ConcatenationVertex(2, c, d);
+        DoubleVertex sum = concat.sum(1);
+
+        finiteDifferenceMatchesForwardAndReverseModeGradient(Arrays.asList(a,b), sum, 10.0, 1e-10);
     }
 
     @Test


### PR DESCRIPTION
Previously we were splitting on the accidentally correct dimension in our tests. For higher rank tensors this fails.