### PR TITLE
enforce import order that matches IntelliJ default

### DIFF
--- a/codegen/src/test/java/io/improbable/keanu/codegen/python/TemplateProcessorTest.java
+++ b/codegen/src/test/java/io/improbable/keanu/codegen/python/TemplateProcessorTest.java
@@ -1,10 +1,7 @@
 package io.improbable.keanu.codegen.python;
 
 import freemarker.template.Template;
-import static junit.framework.TestCase.assertTrue;
 import lombok.Getter;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -20,6 +17,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
 
 public class TemplateProcessorTest {
 

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -4,6 +4,6 @@ spotless {
 
         indentWithSpaces(4)
         removeUnusedImports()
-        importOrder '', 'java', 'javax', 'static '
+        importOrder '', 'javax', 'java', 'static '
     }
 }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -4,5 +4,6 @@ spotless {
 
         indentWithSpaces(4)
         removeUnusedImports()
+        importOrder '', 'java', 'javax', 'static '
     }
 }

--- a/keanu-docs/code/src/main/java/io/improbable/docs/PlatesExample.java
+++ b/keanu-docs/code/src/main/java/io/improbable/docs/PlatesExample.java
@@ -1,8 +1,5 @@
 package io.improbable.docs;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import io.improbable.keanu.plating.PlateBuilder;
 import io.improbable.keanu.plating.Plates;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -12,6 +9,9 @@ import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class PlatesExample {
 

--- a/keanu-docs/code/src/main/java/io/improbable/docs/WetGrass.java
+++ b/keanu-docs/code/src/main/java/io/improbable/docs/WetGrass.java
@@ -1,8 +1,5 @@
 package io.improbable.docs;
 
-import java.util.Arrays;
-import java.util.stream.Stream;
-
 import io.improbable.keanu.algorithms.mcmc.MetropolisHastings;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.network.NetworkState;
@@ -10,6 +7,9 @@ import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.ConditionalProbabilityTable;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 public class WetGrass {
 

--- a/keanu-docs/code/src/test/java/io/improbable/docs/PlatesExampleTest.java
+++ b/keanu-docs/code/src/test/java/io/improbable/docs/PlatesExampleTest.java
@@ -1,16 +1,15 @@
 package io.improbable.docs;
 
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
-
 import io.improbable.keanu.plating.Plate;
 import io.improbable.keanu.plating.Plates;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexLabel;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 public class PlatesExampleTest {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/NetworkSamples.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/NetworkSamples.java
@@ -1,6 +1,12 @@
 package io.improbable.keanu.algorithms;
 
-import static java.util.stream.Collectors.toMap;
+import io.improbable.keanu.network.NetworkState;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.DoubleVertexSamples;
+import io.improbable.keanu.vertices.intgr.IntegerTensorVertexSamples;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -9,13 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import io.improbable.keanu.network.NetworkState;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.intgr.IntegerTensor;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.DoubleVertexSamples;
-import io.improbable.keanu.vertices.intgr.IntegerTensorVertexSamples;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * An immutable collection of network samples. A network sample is a collection

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/PosteriorSamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/PosteriorSamplingAlgorithm.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.algorithms;
 
-import java.util.List;
-
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.vertices.Vertex;
+
+import java.util.List;
 
 public interface PosteriorSamplingAlgorithm {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/TopologicalSort.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/TopologicalSort.java
@@ -1,5 +1,7 @@
 package io.improbable.keanu.algorithms.graphtraversal;
 
+import io.improbable.keanu.vertices.Vertex;
+
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -8,8 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import io.improbable.keanu.vertices.Vertex;
 
 public class TopologicalSort {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/VertexValuePropagation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/graphtraversal/VertexValuePropagation.java
@@ -1,5 +1,8 @@
 package io.improbable.keanu.algorithms.graphtraversal;
 
+import io.improbable.keanu.vertices.NonProbabilistic;
+import io.improbable.keanu.vertices.Vertex;
+
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
@@ -9,9 +12,6 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.PriorityQueue;
 import java.util.Set;
-
-import io.improbable.keanu.vertices.NonProbabilistic;
-import io.improbable.keanu.vertices.Vertex;
 
 /**
  * This class enables efficient propagation of vertex updates.

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -1,10 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
@@ -17,6 +12,11 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCal
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Hamiltonian Monte Carlo is a method for obtaining samples from a probability

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -1,14 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import static io.improbable.keanu.algorithms.mcmc.proposal.MHStepVariableSelector.SINGLE_VARIABLE_SELECTOR;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.HashMap;
-import java.util.ArrayList;
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
 import io.improbable.keanu.algorithms.mcmc.proposal.MHStepVariableSelector;
@@ -23,6 +14,15 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.algorithms.mcmc.proposal.MHStepVariableSelector.SINGLE_VARIABLE_SELECTOR;
 
 /**
  * Metropolis Hastings is a Markov Chain Monte Carlo method for obtaining samples from a probability distribution

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsStep.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsStep.java
@@ -1,11 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
 import io.improbable.keanu.algorithms.mcmc.proposal.Proposal;
 import io.improbable.keanu.algorithms.mcmc.proposal.ProposalDistribution;
@@ -15,6 +9,12 @@ import io.improbable.keanu.vertices.ProbabilityCalculator;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import lombok.Value;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 class MetropolisHastingsStep {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
@@ -1,10 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
@@ -18,6 +13,11 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCal
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Algorithm 6: "No-U-Turn Sampler with Dual Averaging".
@@ -680,4 +680,3 @@ public class NUTS implements PosteriorSamplingAlgorithm {
     }
 
 }
-

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGenerator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGenerator.java
@@ -1,13 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.util.ProgressBar;
@@ -15,6 +7,14 @@ import io.improbable.keanu.vertices.VertexId;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 @Accessors(fluent = true)
 public class NetworkSamplesGenerator {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import java.util.List;
-import java.util.Map;
-
 import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.vertices.VertexId;
+
+import java.util.List;
+import java.util.Map;
 
 public interface SamplingAlgorithm {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SimulatedAnnealing.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SimulatedAnnealing.java
@@ -1,12 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import static io.improbable.keanu.algorithms.mcmc.proposal.MHStepVariableSelector.SINGLE_VARIABLE_SELECTOR;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import io.improbable.keanu.algorithms.mcmc.proposal.MHStepVariableSelector;
 import io.improbable.keanu.algorithms.mcmc.proposal.ProposalDistribution;
 import io.improbable.keanu.network.BayesianNetwork;
@@ -18,6 +11,13 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.improbable.keanu.algorithms.mcmc.proposal.MHStepVariableSelector.SINGLE_VARIABLE_SELECTOR;
 
 /**
  * Simulated Annealing is a modified version of Metropolis Hastings that causes the MCMC random walk to

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/GaussianProposalDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/GaussianProposalDistribution.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.algorithms.mcmc.proposal;
 
-import java.util.Set;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.Gaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.Set;
 
 public class GaussianProposalDistribution implements ProposalDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/PriorProposalDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/PriorProposalDistribution.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.algorithms.mcmc.proposal;
 
-import java.util.Set;
-
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.Set;
 
 public class PriorProposalDistribution implements ProposalDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/ProposalDistribution.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/proposal/ProposalDistribution.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.algorithms.mcmc.proposal;
 
-import java.util.Set;
-
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.Set;
 
 public interface ProposalDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/particlefiltering/ParticleFilter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/particlefiltering/ParticleFilter.java
@@ -1,6 +1,8 @@
 package io.improbable.keanu.algorithms.particlefiltering;
 
-import static java.lang.Math.exp;
+import io.improbable.keanu.vertices.ProbabilityCalculator;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -9,9 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.improbable.keanu.vertices.ProbabilityCalculator;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import static java.lang.Math.exp;
 
 public class ParticleFilter {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GaussianKDE.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/GaussianKDE.java
@@ -1,11 +1,6 @@
 package io.improbable.keanu.algorithms.variational;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.algorithms.VertexSamples;
 import io.improbable.keanu.algorithms.mcmc.MetropolisHastings;
 import io.improbable.keanu.network.BayesianNetwork;
@@ -13,6 +8,10 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertexSamples;
 import io.improbable.keanu.vertices.dbl.probabilistic.KDEVertex;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class GaussianKDE {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
@@ -1,10 +1,5 @@
 package io.improbable.keanu.algorithms.variational.optimizer;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
-
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer;
@@ -14,6 +9,11 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.util.ProgressBar;
 import io.improbable.keanu.vertices.Vertex;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 
 public interface Optimizer {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradient.java
@@ -1,21 +1,20 @@
 package io.improbable.keanu.algorithms.variational.optimizer.gradient;
 
 
-import static io.improbable.keanu.algorithms.variational.optimizer.Optimizer.setAndCascadePoint;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.ProbabilityCalculator;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
+import org.apache.commons.math3.analysis.MultivariateFunction;
+import org.apache.commons.math3.analysis.MultivariateVectorFunction;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import org.apache.commons.math3.analysis.MultivariateFunction;
-import org.apache.commons.math3.analysis.MultivariateVectorFunction;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.ProbabilityCalculator;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
+import static io.improbable.keanu.algorithms.variational.optimizer.Optimizer.setAndCascadePoint;
 
 
 public class FitnessFunctionWithGradient {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -1,13 +1,12 @@
 package io.improbable.keanu.algorithms.variational.optimizer.gradient;
 
-import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.BiConsumer;
-
+import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
+import io.improbable.keanu.algorithms.variational.optimizer.nongradient.FitnessFunction;
+import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.util.ProgressBar;
+import io.improbable.keanu.vertices.Vertex;
+import lombok.Builder;
+import lombok.Getter;
 import org.apache.commons.math3.exception.NotStrictlyPositiveException;
 import org.apache.commons.math3.optim.InitialGuess;
 import org.apache.commons.math3.optim.MaxEval;
@@ -17,13 +16,13 @@ import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunction;
 import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunctionGradient;
 import org.apache.commons.math3.optim.nonlinear.scalar.gradient.NonLinearConjugateGradientOptimizer;
 
-import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
-import io.improbable.keanu.algorithms.variational.optimizer.nongradient.FitnessFunction;
-import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.util.ProgressBar;
-import io.improbable.keanu.vertices.Vertex;
-import lombok.Builder;
-import lombok.Getter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
 
 @Builder
 public class GradientOptimizer implements Optimizer {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/FitnessFunction.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/FitnessFunction.java
@@ -1,15 +1,14 @@
 package io.improbable.keanu.algorithms.variational.optimizer.nongradient;
 
-import static io.improbable.keanu.algorithms.variational.optimizer.Optimizer.setAndCascadePoint;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.ProbabilityCalculator;
+import io.improbable.keanu.vertices.Vertex;
+import org.apache.commons.math3.analysis.MultivariateFunction;
 
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import org.apache.commons.math3.analysis.MultivariateFunction;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.ProbabilityCalculator;
-import io.improbable.keanu.vertices.Vertex;
+import static io.improbable.keanu.algorithms.variational.optimizer.Optimizer.setAndCascadePoint;
 
 public class FitnessFunction {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
@@ -1,19 +1,5 @@
 package io.improbable.keanu.algorithms.variational.optimizer.nongradient;
 
-import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.BiConsumer;
-
-import org.apache.commons.math3.optim.InitialGuess;
-import org.apache.commons.math3.optim.MaxEval;
-import org.apache.commons.math3.optim.PointValuePair;
-import org.apache.commons.math3.optim.SimpleBounds;
-import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunction;
-import org.apache.commons.math3.optim.nonlinear.scalar.noderiv.BOBYQAOptimizer;
-
 import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -21,6 +7,19 @@ import io.improbable.keanu.util.ProgressBar;
 import io.improbable.keanu.vertices.Vertex;
 import lombok.Builder;
 import lombok.Getter;
+import org.apache.commons.math3.optim.InitialGuess;
+import org.apache.commons.math3.optim.MaxEval;
+import org.apache.commons.math3.optim.PointValuePair;
+import org.apache.commons.math3.optim.SimpleBounds;
+import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunction;
+import org.apache.commons.math3.optim.nonlinear.scalar.noderiv.BOBYQAOptimizer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.apache.commons.math3.optim.nonlinear.scalar.GoalType.MAXIMIZE;
 
 @Builder
 public class NonGradientOptimizer implements Optimizer {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Beta.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.A;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.B;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.A;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.B;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class Beta implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Cauchy.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Cauchy.java
@@ -2,7 +2,6 @@ package io.improbable.keanu.distributions.continuous;
 
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Dirichlet.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.C;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.C;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class Dirichlet implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Exponential.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.LAMBDA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.LAMBDA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class Exponential implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gamma.java
@@ -1,21 +1,19 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static java.lang.Math.exp;
-import static java.lang.Math.log;
-import static java.lang.Math.pow;
-import static java.lang.Math.sqrt;
-
-import static io.improbable.keanu.distributions.hyperparam.Diffs.K;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.THETA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
-import org.nd4j.linalg.util.ArrayUtil;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.nd4j.linalg.util.ArrayUtil;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.K;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.THETA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static java.lang.Math.exp;
+import static java.lang.Math.log;
+import static java.lang.Math.pow;
+import static java.lang.Math.sqrt;
 
 public class Gamma implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Gaussian.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.SIGMA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.SIGMA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class Gaussian implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/InverseGamma.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.A;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.B;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.A;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.B;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class InverseGamma implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Laplace.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.BETA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
-import org.nd4j.linalg.util.ArrayUtil;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.nd4j.linalg.util.ArrayUtil;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.BETA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class Laplace implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/LogNormal.java
@@ -1,14 +1,14 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.continuous.Gaussian.LN_SQRT_2PI;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.SIGMA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.continuous.Gaussian.LN_SQRT_2PI;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.SIGMA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class LogNormal implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Logistic.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class Logistic implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Pareto.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/Pareto.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.L;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.L;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class Pareto implements ContinuousDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/SmoothUniform.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 /**
  * The Smooth Uniform distribution is the usual Uniform distribution with the edges

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/StudentT.java
@@ -1,15 +1,14 @@
 package io.improbable.keanu.distributions.continuous;
 
-import static java.lang.Math.PI;
-import static java.lang.Math.log;
-
-import static io.improbable.keanu.distributions.hyperparam.Diffs.T;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.T;
+import static java.lang.Math.PI;
+import static java.lang.Math.log;
 
 /**
  * Student T Distribution

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Binomial.java
@@ -1,12 +1,11 @@
 package io.improbable.keanu.distributions.discrete;
 
-import org.nd4j.linalg.util.ArrayUtil;
-
 import io.improbable.keanu.distributions.DiscreteDistribution;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.nd4j.linalg.util.ArrayUtil;
 
 public class Binomial implements DiscreteDistribution {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Categorical.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.distributions.discrete;
 
-import java.util.Map;
-
 import io.improbable.keanu.distributions.Distribution;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.Map;
 
 public class Categorical<T> implements Distribution<T> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Multinomial.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Multinomial.java
@@ -1,14 +1,6 @@
 package io.improbable.keanu.distributions.discrete;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.ArrayUtils;
-import org.nd4j.linalg.util.ArrayUtil;
-
 import com.google.common.base.Preconditions;
-
 import io.improbable.keanu.distributions.DiscreteDistribution;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShapeValidation;
@@ -17,6 +9,12 @@ import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.tensor.validate.DebugTensorValidator;
 import io.improbable.keanu.tensor.validate.TensorValidator;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.lang3.ArrayUtils;
+import org.nd4j.linalg.util.ArrayUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class Multinomial implements DiscreteDistribution {

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/discrete/Poisson.java
@@ -1,12 +1,11 @@
 package io.improbable.keanu.distributions.discrete;
 
-import org.nd4j.linalg.util.ArrayUtil;
-
 import io.improbable.keanu.distributions.DiscreteDistribution;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.nd4j.linalg.util.ArrayUtil;
 
 /**
  * Computer Generation of Statistical Distributions

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/hyperparam/Diff.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/hyperparam/Diff.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.distributions.hyperparam;
 
 
-import java.util.Objects;
-
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import org.jetbrains.annotations.NotNull;
 
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import java.util.Objects;
 
 /**
  * A Diff is identified only by its name

--- a/keanu-project/src/main/java/io/improbable/keanu/model/MaximumLikelihoodModelFitter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/model/MaximumLikelihoodModelFitter.java
@@ -26,4 +26,3 @@ public class MaximumLikelihoodModelFitter<INPUT, OUTPUT> implements ModelFitter<
         GradientOptimizer.of(modelGraph.getNet()).maxLikelihood();
     }
 }
-

--- a/keanu-project/src/main/java/io/improbable/keanu/model/regression/LinearRegressionGraph.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/model/regression/LinearRegressionGraph.java
@@ -1,7 +1,5 @@
 package io.improbable.keanu.model.regression;
 
-import java.util.function.Function;
-
 import io.improbable.keanu.model.ModelGraph;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.TensorShape;
@@ -12,6 +10,8 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import lombok.Getter;
 import lombok.Value;
+
+import java.util.function.Function;
 
 public class LinearRegressionGraph<OUTPUT> implements ModelGraph<DoubleTensor, OUTPUT> {
     private final DoubleVertex xVertex;

--- a/keanu-project/src/main/java/io/improbable/keanu/model/regression/RegressionModel.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/model/regression/RegressionModel.java
@@ -1,7 +1,5 @@
 package io.improbable.keanu.model.regression;
 
-import java.util.function.Function;
-
 import io.improbable.keanu.model.Model;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -9,6 +7,8 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+
+import java.util.function.Function;
 
 /**
  * A general linear regression model that can be fitted to input and output training data.

--- a/keanu-project/src/main/java/io/improbable/keanu/model/regression/RegressionWeights.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/model/regression/RegressionWeights.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.model.regression;
 
-import java.util.Arrays;
-
 import lombok.experimental.UtilityClass;
+
+import java.util.Arrays;
 
 @UtilityClass
 class RegressionWeights {

--- a/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/BayesianNetwork.java
@@ -1,15 +1,6 @@
 package io.improbable.keanu.network;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.algorithms.graphtraversal.TopologicalSort;
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -17,6 +8,14 @@ import io.improbable.keanu.vertices.ProbabilityCalculator;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class BayesianNetwork {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/network/LambdaSection.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/LambdaSection.java
@@ -1,5 +1,8 @@
 package io.improbable.keanu.network;
 
+import io.improbable.keanu.vertices.Vertex;
+import lombok.Value;
+
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
@@ -8,9 +11,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import io.improbable.keanu.vertices.Vertex;
-import lombok.Value;
 
 /**
  * A Lambda Section is defined as a given vertex and all the vertices that it affects (downstream) OR

--- a/keanu-project/src/main/java/io/improbable/keanu/network/ModelComposition.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/ModelComposition.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.network;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import io.improbable.keanu.vertices.ProxyVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.VertexLabel;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class ModelComposition {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/network/NetworkState.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/NetworkState.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.network;
 
-import java.util.Set;
-
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
+
+import java.util.Set;
 
 /**
  * Depending on how a NetworkState is being used, it may be significantly more efficient

--- a/keanu-project/src/main/java/io/improbable/keanu/network/SimpleNetworkState.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/SimpleNetworkState.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.network;
 
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
+
+import java.util.Map;
+import java.util.Set;
 
 public class SimpleNetworkState implements NetworkState {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/network/grouping/ContinuousPoint.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/grouping/ContinuousPoint.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.network.grouping;
 
-import java.util.Arrays;
-
 import org.apache.commons.math3.ml.clustering.Clusterable;
+
+import java.util.Arrays;
 
 public class ContinuousPoint implements Clusterable {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/network/grouping/NetworkStateGrouper.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/grouping/NetworkStateGrouper.java
@@ -1,18 +1,18 @@
 package io.improbable.keanu.network.grouping;
 
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
+import io.improbable.keanu.network.NetworkState;
+import io.improbable.keanu.network.SimpleNetworkState;
+import io.improbable.keanu.network.grouping.continuouspointgroupers.ContinuousPointGrouper;
+import io.improbable.keanu.vertices.VertexId;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import io.improbable.keanu.network.NetworkState;
-import io.improbable.keanu.network.SimpleNetworkState;
-import io.improbable.keanu.network.grouping.continuouspointgroupers.ContinuousPointGrouper;
-import io.improbable.keanu.vertices.VertexId;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * This class has the ability to group NetworkStates that are similar. Which NetworkStates

--- a/keanu-project/src/main/java/io/improbable/keanu/plating/Plate.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/plating/Plate.java
@@ -1,17 +1,16 @@
 package io.improbable.keanu.plating;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.ProxyVertex;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexDictionary;
+import io.improbable.keanu.vertices.VertexLabel;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.ProxyVertex;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexDictionary;
-import io.improbable.keanu.vertices.VertexLabel;
 
 public class Plate implements VertexDictionary {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/plating/PlateBuilder.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/plating/PlateBuilder.java
@@ -1,17 +1,16 @@
 package io.improbable.keanu.plating;
 
+import com.google.common.collect.ImmutableMap;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexDictionary;
+import io.improbable.keanu.vertices.VertexLabel;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-
-import com.google.common.collect.ImmutableMap;
-
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexDictionary;
-import io.improbable.keanu.vertices.VertexLabel;
 
 /**
  * PlateBuilder allows plates to be constructed in steps

--- a/keanu-project/src/main/java/io/improbable/keanu/plating/Plates.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/plating/Plates.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.plating;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import org.jetbrains.annotations.NotNull;
 
 public class Plates implements Iterable<Plate> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/plating/loop/Loop.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/plating/loop/Loop.java
@@ -1,12 +1,6 @@
 package io.improbable.keanu.plating.loop;
 
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableMap;
-
 import io.improbable.keanu.plating.Plate;
 import io.improbable.keanu.plating.PlateBuilder;
 import io.improbable.keanu.plating.Plates;
@@ -15,6 +9,10 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexDictionary;
 import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.bool.BoolVertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 /**
  * A Loop object is a convenient wrapper around some Plates.

--- a/keanu-project/src/main/java/io/improbable/keanu/plating/loop/LoopBuilder.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/plating/loop/LoopBuilder.java
@@ -1,13 +1,6 @@
 package io.improbable.keanu.plating.loop;
 
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
 import com.google.common.collect.ImmutableMap;
-
 import io.improbable.keanu.plating.Plate;
 import io.improbable.keanu.plating.PlateBuilder;
 import io.improbable.keanu.plating.Plates;
@@ -20,6 +13,12 @@ import io.improbable.keanu.vertices.bool.nonprobabilistic.BoolProxyVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.DoubleProxyVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class LoopBuilder {
     private final VertexDictionary initialState;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/INDArrayShim.java
@@ -1,15 +1,14 @@
 package io.improbable.keanu.tensor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
+import com.google.common.primitives.Ints;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.api.shape.Shape;
 import org.nd4j.linalg.factory.Broadcast;
 import org.nd4j.linalg.factory.Nd4j;
 
-import com.google.common.primitives.Ints;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This class provides shim methods for the ND4J INDArray class.

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/NumberTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/NumberTensor.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.tensor;
 
-import java.util.function.Function;
-
 import io.improbable.keanu.kotlin.NumberOperators;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
+
+import java.util.function.Function;
 
 public interface NumberTensor<N extends Number, T extends NumberTensor<N,T>> extends Tensor<N>, NumberOperators<T> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/Tensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/Tensor.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.tensor;
 
 
-import java.util.Arrays;
-import java.util.List;
-
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.generic.GenericTensor;
+
+import java.util.Arrays;
+import java.util.List;
 
 public interface Tensor<T> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.tensor;
 
-import java.util.Arrays;
-
 import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Arrays;
 
 public class TensorShape {
 
@@ -210,4 +210,3 @@ public class TensorShape {
     }
 
 }
-

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShapeValidation.java
@@ -1,6 +1,6 @@
 package io.improbable.keanu.tensor;
 
-import static java.util.stream.Collectors.toSet;
+import com.google.common.base.Preconditions;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import com.google.common.base.Preconditions;
+import static java.util.stream.Collectors.toSet;
 
 public class TensorShapeValidation {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.tensor.bool;
 
-import static java.util.Arrays.copyOf;
-
-import static com.google.common.primitives.Ints.checkedCast;
-
-import static io.improbable.keanu.tensor.TensorShape.getFlatIndex;
-
-import java.util.Arrays;
-
-import org.apache.commons.lang3.ArrayUtils;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.TensorShapeValidation;
@@ -17,6 +7,13 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.tensor.generic.GenericTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Arrays;
+
+import static com.google.common.primitives.Ints.checkedCast;
+import static io.improbable.keanu.tensor.TensorShape.getFlatIndex;
+import static java.util.Arrays.copyOf;
 
 public class SimpleBooleanTensor implements BooleanTensor {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.tensor.dbl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
-
 import io.improbable.keanu.kotlin.DoubleOperators;
 import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, DoubleOperators<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -1,16 +1,16 @@
 package io.improbable.keanu.tensor.dbl;
 
-import static java.util.Arrays.copyOf;
-
-import static com.google.common.primitives.Ints.checkedCast;
-
-import static io.improbable.keanu.tensor.TypedINDArrayFactory.valueArrayOf;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.Function;
-
+import io.improbable.keanu.tensor.INDArrayExtensions;
+import io.improbable.keanu.tensor.INDArrayShim;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorShape;
+import io.improbable.keanu.tensor.TensorShapeValidation;
+import io.improbable.keanu.tensor.TypedINDArrayFactory;
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.tensor.bool.SimpleBooleanTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.tensor.intgr.Nd4jIntegerTensor;
+import io.improbable.keanu.tensor.validate.TensorValidator;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.LUDecomposition;
@@ -31,17 +31,14 @@ import org.nd4j.linalg.indexing.conditions.Conditions;
 import org.nd4j.linalg.inverse.InvertMatrix;
 import org.nd4j.linalg.ops.transforms.Transforms;
 
-import io.improbable.keanu.tensor.INDArrayExtensions;
-import io.improbable.keanu.tensor.INDArrayShim;
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.tensor.TensorShape;
-import io.improbable.keanu.tensor.TensorShapeValidation;
-import io.improbable.keanu.tensor.TypedINDArrayFactory;
-import io.improbable.keanu.tensor.bool.BooleanTensor;
-import io.improbable.keanu.tensor.bool.SimpleBooleanTensor;
-import io.improbable.keanu.tensor.intgr.IntegerTensor;
-import io.improbable.keanu.tensor.intgr.Nd4jIntegerTensor;
-import io.improbable.keanu.tensor.validate.TensorValidator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import static com.google.common.primitives.Ints.checkedCast;
+import static io.improbable.keanu.tensor.TypedINDArrayFactory.valueArrayOf;
+import static java.util.Arrays.copyOf;
 
 public class Nd4jDoubleTensor implements DoubleTensor {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -1,20 +1,19 @@
 package io.improbable.keanu.tensor.dbl;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Function;
-
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.math3.special.Gamma;
-import org.apache.commons.math3.util.FastMath;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.tensor.validate.TensorValidator;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.math3.special.Gamma;
+import org.apache.commons.math3.util.FastMath;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
 
 public class ScalarDoubleTensor implements DoubleTensor {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/generic/GenericTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/generic/GenericTensor.java
@@ -1,20 +1,17 @@
 package io.improbable.keanu.tensor.generic;
 
-import static java.util.Arrays.copyOf;
-
-import static com.google.common.primitives.Ints.checkedCast;
-
-import static io.improbable.keanu.tensor.TensorShape.getFlatIndex;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorShape;
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import org.nd4j.linalg.util.ArrayUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.nd4j.linalg.util.ArrayUtil;
-
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.tensor.TensorShape;
-import io.improbable.keanu.tensor.bool.BooleanTensor;
+import static com.google.common.primitives.Ints.checkedCast;
+import static io.improbable.keanu.tensor.TensorShape.getFlatIndex;
+import static java.util.Arrays.copyOf;
 
 public class GenericTensor<T> implements Tensor<T> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
@@ -1,17 +1,15 @@
 package io.improbable.keanu.tensor.intgr;
 
-import java.util.Arrays;
-import java.util.function.Function;
-
-import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.factory.Nd4j;
-
 import com.google.common.primitives.Ints;
-
 import io.improbable.keanu.kotlin.IntegerOperators;
 import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.Arrays;
+import java.util.function.Function;
 
 public interface IntegerTensor extends NumberTensor<Integer, IntegerTensor>, IntegerOperators<IntegerTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -1,12 +1,15 @@
 package io.improbable.keanu.tensor.intgr;
 
-import static java.util.Arrays.copyOf;
-
-import static com.google.common.primitives.Ints.checkedCast;
-
-import java.util.Arrays;
-import java.util.function.Function;
-
+import io.improbable.keanu.tensor.INDArrayExtensions;
+import io.improbable.keanu.tensor.INDArrayShim;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorShape;
+import io.improbable.keanu.tensor.TensorShapeValidation;
+import io.improbable.keanu.tensor.TypedINDArrayFactory;
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.tensor.bool.SimpleBooleanTensor;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import org.apache.commons.lang3.ArrayUtils;
 import org.nd4j.linalg.api.buffer.DataBuffer;
 import org.nd4j.linalg.api.ndarray.INDArray;
@@ -19,16 +22,11 @@ import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.conditions.Conditions;
 import org.nd4j.linalg.ops.transforms.Transforms;
 
-import io.improbable.keanu.tensor.INDArrayExtensions;
-import io.improbable.keanu.tensor.INDArrayShim;
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.tensor.TensorShape;
-import io.improbable.keanu.tensor.TensorShapeValidation;
-import io.improbable.keanu.tensor.TypedINDArrayFactory;
-import io.improbable.keanu.tensor.bool.BooleanTensor;
-import io.improbable.keanu.tensor.bool.SimpleBooleanTensor;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import java.util.Arrays;
+import java.util.function.Function;
+
+import static com.google.common.primitives.Ints.checkedCast;
+import static java.util.Arrays.copyOf;
 
 public class Nd4jIntegerTensor implements IntegerTensor {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensor.java
@@ -1,15 +1,14 @@
 package io.improbable.keanu.tensor.intgr;
 
-import java.util.Arrays;
-import java.util.function.Function;
-
 import com.google.common.math.IntMath;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+
+import java.util.Arrays;
+import java.util.function.Function;
 
 public class ScalarIntegerTensor implements IntegerTensor {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/validate/TensorValidator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/validate/TensorValidator.java
@@ -1,7 +1,5 @@
 package io.improbable.keanu.tensor.validate;
 
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -10,6 +8,8 @@ import io.improbable.keanu.tensor.validate.check.CustomTensorValueChecker;
 import io.improbable.keanu.tensor.validate.check.TensorValueChecker;
 import io.improbable.keanu.tensor.validate.check.TensorValueNotEqualsCheck;
 import io.improbable.keanu.tensor.validate.policy.TensorValidationPolicy;
+
+import java.util.function.Function;
 
 public interface TensorValidator<DATATYPE, TENSOR extends Tensor<DATATYPE>> extends TensorValueChecker<TENSOR> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/validate/check/CustomElementwiseTensorValueChecker.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/validate/check/CustomElementwiseTensorValueChecker.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.tensor.validate.check;
 
-import java.util.function.Function;
-
-import org.nd4j.linalg.util.ArrayUtil;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
+import org.nd4j.linalg.util.ArrayUtil;
+
+import java.util.function.Function;
 
 public class CustomElementwiseTensorValueChecker<DATATYPE, TENSOR extends Tensor<DATATYPE>> implements TensorValueChecker<TENSOR> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/validate/check/CustomTensorValueChecker.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/validate/check/CustomTensorValueChecker.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.tensor.validate.check;
 
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
+
+import java.util.function.Function;
 
 public class CustomTensorValueChecker<TENSOR extends Tensor<?>> implements TensorValueChecker<TENSOR> {
     private final Function<TENSOR, BooleanTensor> checkFunction;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/validate/policy/ThrowValueException.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/validate/policy/ThrowValueException.java
@@ -1,7 +1,7 @@
 package io.improbable.keanu.tensor.validate.policy;
 
-import io.improbable.keanu.tensor.TensorValueException;
 import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorValueException;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 
 public class ThrowValueException<TENSOR extends Tensor<?>> implements TensorValidationPolicy<TENSOR> {

--- a/keanu-project/src/main/java/io/improbable/keanu/util/csv/ColumnWriter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/csv/ColumnWriter.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.util.csv;
 
-import static io.improbable.keanu.util.csv.WriteCsv.findLongestTensor;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.vertices.Vertex;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.vertices.Vertex;
+import static io.improbable.keanu.util.csv.WriteCsv.findLongestTensor;
 
 public class ColumnWriter extends Writer {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/util/csv/RowWriter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/csv/RowWriter.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.util.csv;
 
-import static io.improbable.keanu.util.csv.WriteCsv.findLongestTensor;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.vertices.Vertex;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.vertices.Vertex;
+import static io.improbable.keanu.util.csv.WriteCsv.findLongestTensor;
 
 public class RowWriter extends Writer {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/util/csv/SampleWriter.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/csv/SampleWriter.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.util.csv;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.vertices.Vertex;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SampleWriter extends Writer {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/util/csv/Writer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/csv/Writer.java
@@ -1,5 +1,8 @@
 package io.improbable.keanu.util.csv;
 
+import com.opencsv.CSVWriter;
+import com.opencsv.ICSVWriter;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -7,9 +10,6 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-
-import com.opencsv.CSVWriter;
-import com.opencsv.ICSVWriter;
 
 public abstract class Writer {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Observable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Observable.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.vertices;
 
-import java.util.Optional;
-
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import java.util.Optional;
 
 public interface Observable<T> {
     void observe(T value);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Probabilistic.java
@@ -1,14 +1,13 @@
 package io.improbable.keanu.vertices;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
 
 public interface Probabilistic<T> extends Observable<T> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/SimpleVertexDictionary.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/SimpleVertexDictionary.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.vertices;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.ImmutableMap;
 
 public class SimpleVertexDictionary implements VertexDictionary {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -1,17 +1,16 @@
 package io.improbable.keanu.vertices;
 
+import com.google.common.collect.ImmutableSet;
+import io.improbable.keanu.algorithms.graphtraversal.DiscoverGraph;
+import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
-
-import io.improbable.keanu.algorithms.graphtraversal.DiscoverGraph;
-import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public abstract class Vertex<T> implements Observable<T> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexId.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexId.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.vertices;
 
+import com.google.common.primitives.Ints;
+import lombok.EqualsAndHashCode;
+
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
-
-import com.google.common.primitives.Ints;
-
-import lombok.EqualsAndHashCode;
 
 /**
  * An object representing the ID value of a vertex.  IDs are assigned in such a way that a Lexicographic ordering of

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexLabel.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/VertexLabel.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 public class VertexLabel {
     private static final char NAMESPACE_SEPARATOR = '.';

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
@@ -1,10 +1,6 @@
 package io.improbable.keanu.vertices.bool;
 
-import java.util.Arrays;
-import java.util.List;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.kotlin.BooleanOperators;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
@@ -21,6 +17,9 @@ import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary.BoolRe
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary.BoolSliceVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary.BoolTakeVertex;
 import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary.NotVertex;
+
+import java.util.Arrays;
+import java.util.List;
 
 public abstract class BoolVertex extends Vertex<BooleanTensor> implements BooleanOperators<BoolVertex> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/BoolProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/BoolProxyVertex.java
@@ -1,9 +1,6 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
 import com.google.common.collect.Iterables;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
@@ -11,6 +8,8 @@ import io.improbable.keanu.vertices.ProxyVertex;
 import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class BoolProxyVertex extends BoolVertex implements ProxyVertex<BoolVertex>, NonProbabilistic<BooleanTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/CastBoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/CastBoolVertex.java
@@ -26,4 +26,3 @@ public class CastBoolVertex extends BoolVertex implements NonProbabilistic<Boole
     }
 
 }
-

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/BoolModelResultVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/BoolModelResultVertex.java
@@ -6,9 +6,9 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.model.ModelVertex;
 import io.improbable.keanu.vertices.model.ModelResult;
 import io.improbable.keanu.vertices.model.ModelResultProvider;
+import io.improbable.keanu.vertices.model.ModelVertex;
 
 /**
  * A non-probabilistic boolean vertex whose value is extracted from an upstream model vertex.

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/binary/BoolBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/binary/BoolBinaryOpLambda.java
@@ -19,4 +19,3 @@ public abstract class BoolBinaryOpLambda<A extends Tensor, B extends Tensor> ext
         return boolOp.apply(a, b);
     }
 }
-

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/binary/BoolBinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/binary/BoolBinaryOpVertex.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 
 public abstract class BoolBinaryOpVertex<A extends Tensor, B extends Tensor> extends BoolVertex implements NonProbabilistic<BooleanTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/AndMultipleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/AndMultipleVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic.operators.multiple;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkAllShapesMatch;
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.vertices.Vertex;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import io.improbable.keanu.tensor.bool.BooleanTensor;
-import io.improbable.keanu.vertices.Vertex;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkAllShapesMatch;
 
 public class AndMultipleVertex extends BoolReduceVertex {
     public AndMultipleVertex(Collection<Vertex<BooleanTensor>> input) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertex.java
@@ -1,15 +1,15 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic.operators.multiple;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
-
-import java.lang.reflect.Array;
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.lang.reflect.Array;
+import java.util.function.Function;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
 
 public class BoolConcatenationVertex extends BoolVertex implements NonProbabilistic<BooleanTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolReduceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolReduceVertex.java
@@ -1,5 +1,11 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic.operators.multiple;
 
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.vertices.NonProbabilistic;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.bool.BoolVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -7,12 +13,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-
-import io.improbable.keanu.tensor.bool.BooleanTensor;
-import io.improbable.keanu.vertices.NonProbabilistic;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.bool.BoolVertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class BoolReduceVertex extends BoolVertex implements NonProbabilistic<BooleanTensor> {
     private final List<? extends Vertex<BooleanTensor>> inputs;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/OrMultipleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/OrMultipleVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic.operators.multiple;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkAllShapesMatch;
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.vertices.Vertex;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import io.improbable.keanu.tensor.bool.BooleanTensor;
-import io.improbable.keanu.vertices.Vertex;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkAllShapesMatch;
 
 public class OrMultipleVertex extends BoolReduceVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/unary/BoolSliceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/unary/BoolSliceVertex.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
-
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.vertices.bool.BoolVertex;
+
+import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
 
 public class BoolSliceVertex extends BoolUnaryOpVertex<BooleanTensor> {
     private final int dimension;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
@@ -1,11 +1,5 @@
 package io.improbable.keanu.vertices.bool.probabilistic;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.discrete.Bernoulli;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
@@ -15,6 +9,12 @@ import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class BernoulliVertex extends BoolVertex implements ProbabilisticBoolean {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBoolean.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/ProbabilisticBoolean.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.bool.probabilistic;
 
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
+
+import java.util.Map;
+import java.util.Set;
 
 public interface ProbabilisticBoolean extends Probabilistic<BooleanTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.vertices.dbl;
 
-import java.util.Map;
-
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
 
 public interface Differentiable {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
@@ -1,6 +1,10 @@
 package io.improbable.keanu.vertices.dbl;
 
-import static java.util.Collections.singletonMap;
+import io.improbable.keanu.tensor.TensorShape;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -13,11 +17,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
 
-import io.improbable.keanu.tensor.TensorShape;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import static java.util.Collections.singletonMap;
 
 public class Differentiator {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -1,10 +1,6 @@
 package io.improbable.keanu.vertices.dbl;
 
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.function.Function;
-
 import io.improbable.keanu.kotlin.DoubleOperators;
 import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.Tensor;
@@ -50,6 +46,10 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SliceVe
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TakeVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TanVertex;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
 
 public abstract class DoubleVertex extends Vertex<DoubleTensor> implements DoubleOperators<DoubleVertex>, Differentiable {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/KeanuRandom.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/KeanuRandom.java
@@ -1,14 +1,5 @@
 package io.improbable.keanu.vertices.dbl;
 
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.nd4j.linalg.api.buffer.DataBuffer;
-import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.rng.DefaultRandom;
-import org.nd4j.linalg.api.rng.Random;
-import org.nd4j.linalg.factory.Nd4j;
-
 import io.improbable.keanu.distributions.continuous.Gamma;
 import io.improbable.keanu.distributions.continuous.Laplace;
 import io.improbable.keanu.distributions.discrete.Poisson;
@@ -18,6 +9,14 @@ import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.tensor.dbl.ScalarDoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.tensor.intgr.Nd4jIntegerTensor;
+import org.nd4j.linalg.api.buffer.DataBuffer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.api.rng.DefaultRandom;
+import org.nd4j.linalg.api.rng.Random;
+import org.nd4j.linalg.factory.Nd4j;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class KeanuRandom {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -1,7 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
-import java.util.Map;
-
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -10,6 +8,8 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
 
 public class CastDoubleVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
@@ -1,8 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
-import java.util.Collections;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
@@ -10,6 +7,9 @@ import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Collections;
+import java.util.Map;
 
 public class ConstantDoubleVertex extends DoubleVertex implements Differentiable, NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleCPTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleCPTVertex.java
@@ -1,8 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
-import java.util.List;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
@@ -12,6 +9,9 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.CPTCondition;
+
+import java.util.List;
+import java.util.Map;
 
 public class DoubleCPTVertex extends DoubleVertex implements Differentiable, NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
@@ -1,8 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -11,6 +8,9 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class DoubleIfVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleModelResultVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleModelResultVertex.java
@@ -2,13 +2,13 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.model.ModelVertex;
-import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.model.ModelResult;
 import io.improbable.keanu.vertices.model.ModelResultProvider;
+import io.improbable.keanu.vertices.model.ModelVertex;
 
 /**
  * A non-probabilistic double vertex whose value is extracted from an upstream model vertex.

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleProxyVertex.java
@@ -1,12 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Collections;
-import java.util.Map;
-
 import com.google.common.collect.Iterables;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
@@ -16,6 +10,11 @@ import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class DoubleProxyVertex extends DoubleVertex implements ProxyVertex<DoubleVertex>, NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculator.java
@@ -1,14 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.google.common.base.Preconditions;
-
 import io.improbable.keanu.network.LambdaSection;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
@@ -16,6 +8,13 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class LogProbGradientCalculator {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/PartialDerivatives.java
@@ -1,16 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
-import static java.util.Collections.singletonMap;
+import io.improbable.keanu.tensor.TensorShape;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.improbable.keanu.tensor.TensorShape;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
+import static java.util.Collections.singletonMap;
 
 public class PartialDerivatives {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class AdditionVertex extends DoubleBinaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2Vertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ArcTan2Vertex extends DoubleBinaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DifferenceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DifferenceVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 public class DifferenceVertex extends DoubleBinaryOpVertex {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class DivisionVertex extends DoubleBinaryOpVertex {
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -1,17 +1,17 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-
-import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 
 public class DoubleBinaryOpLambda<A, B> extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
 
@@ -76,5 +76,3 @@ public class DoubleBinaryOpLambda<A, B> extends DoubleVertex implements NonProba
         return reverseModeAutoDiffLambda.apply(derivativeOfOutputsWithRespectToSelf);
     }
 }
-
-

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpVertex.java
@@ -1,16 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 
 public abstract class DoubleBinaryOpVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertex.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MatrixMultiplicationVertex extends DoubleBinaryOpVertex {
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class MultiplicationVertex extends DoubleBinaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class PowerVertex extends DoubleBinaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
-
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
@@ -19,6 +9,16 @@ import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
 
 public class ConcatenationVertex extends DoubleVertex implements Differentiable, NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertex.java
@@ -1,6 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkAllShapesMatch;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.NonProbabilistic;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,13 +19,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.NonProbabilistic;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.dbl.Differentiable;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkAllShapesMatch;
 
 public class ReduceVertex extends DoubleVertex implements Differentiable, NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
 
 public class AbsVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ArcCosVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ArcSinVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ArcTanVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
 
 public class CeilVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class CosVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
@@ -1,8 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.Map;
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
@@ -10,6 +7,9 @@ import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
+import java.util.function.Function;
 
 public class DoubleUnaryOpLambda<IN> extends DoubleVertex implements Differentiable, NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpVertex.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
 
 public abstract class DoubleUnaryOpVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ExpVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
 
 public class FloorVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class LogGammaVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class LogVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
@@ -1,14 +1,14 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.Collections;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A vertex that takes on the value of the matrixDeterminant of the value of its input matrix

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class MatrixInverseVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertex.java
@@ -1,14 +1,14 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ReshapeVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/RoundVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/RoundVertex.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Map;
 
 public class RoundVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class SigmoidVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class SinVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SliceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SliceVertex.java
@@ -1,16 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
 
 public class SliceVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
@@ -1,6 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static java.util.Collections.singletonMap;
+import com.google.common.primitives.Longs;
+import io.improbable.keanu.tensor.TensorShape;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -8,14 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.primitives.Longs;
-
-import io.improbable.keanu.tensor.TensorShape;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import static java.util.Collections.singletonMap;
 
 public class SumVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertex.java
@@ -1,9 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.TensorShapeValidation;
@@ -12,6 +8,10 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TakeVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class TanVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.A;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.B;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.Beta;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
@@ -18,6 +8,16 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.A;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.B;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class BetaVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
@@ -1,16 +1,6 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.L;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Cauchy;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -18,6 +8,16 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.L;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class CauchyVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -1,10 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.ChiSquared;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -13,6 +8,11 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class ChiSquaredVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
@@ -1,12 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.C;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Dirichlet;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -14,6 +7,13 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.C;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
 public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -1,15 +1,6 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.LAMBDA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Exponential;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -17,6 +8,15 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.LAMBDA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class ExponentialVertex extends DoubleVertex implements ProbabilisticDouble {
 
@@ -89,5 +89,3 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
     }
 
 }
-
-

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -1,16 +1,6 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.K;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.THETA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Gamma;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -18,6 +8,16 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.K;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.THETA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class GammaVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.SIGMA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Gaussian;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -18,6 +8,16 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.SIGMA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class GaussianVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.A;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.B;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.InverseGamma;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -17,6 +7,16 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.A;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.B;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class InverseGammaVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
@@ -1,15 +1,15 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class KDEVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.BETA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Laplace;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -17,6 +7,16 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.BETA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class LaplaceVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.SIGMA;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.LogNormal;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -17,6 +7,16 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.SIGMA;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class LogNormalVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Logistic;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -17,6 +7,16 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class LogisticVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -1,14 +1,14 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.MultivariateGaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.Map;
+import java.util.Set;
 
 public class MultivariateGaussianVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.L;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Pareto;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -18,6 +8,16 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.L;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.S;
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class ParetoVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDouble.java
@@ -1,13 +1,13 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.Vertex;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Probabilistic;
-import io.improbable.keanu.vertices.Vertex;
 
 public interface ProbabilisticDouble extends Probabilistic<DoubleTensor> {
     default double logPdf(double value) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -1,15 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static java.util.Collections.singletonMap;
-
-import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.SmoothUniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -17,6 +7,15 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
+import static java.util.Collections.singletonMap;
 
 public class SmoothUniformVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -1,12 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.distributions.hyperparam.Diffs.T;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.StudentT;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.Tensor;
@@ -16,6 +9,13 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.T;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class StudentTVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -1,17 +1,17 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Triangular;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class TriangularVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -1,20 +1,19 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static java.util.Collections.singletonMap;
-
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
+import static java.util.Collections.singletonMap;
 
 public class UniformVertex extends DoubleVertex implements ProbabilisticDouble {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/CPTCondition.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/CPTCondition.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.generic.nonprobabilistic;
 
-import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.vertices.Vertex;
 import lombok.Value;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Value
 public class CPTCondition {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/CPTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/CPTVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.generic.nonprobabilistic;
 
-import java.util.List;
-import java.util.Map;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.List;
+import java.util.Map;
 
 public class CPTVertex<OUT extends Tensor> extends Vertex<OUT> implements NonProbabilistic<OUT> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/ConditionalProbabilityTable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/ConditionalProbabilityTable.java
@@ -1,17 +1,16 @@
 package io.improbable.keanu.vertices.generic.nonprobabilistic;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.DoubleCPTVertex;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ConditionalProbabilityTable {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/binary/BinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/binary/BinaryOpVertex.java
@@ -27,4 +27,3 @@ public abstract class BinaryOpVertex<A, B, C> extends Vertex<C> implements NonPr
 
     protected abstract C op(A a, B b);
 }
-

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/GenericSliceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/GenericSliceVertex.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.vertices.generic.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
 
 public class GenericSliceVertex<T> extends UnaryOpVertex<Tensor<T>, Tensor<T>> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/UnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/UnaryOpVertex.java
@@ -26,4 +26,3 @@ public abstract class UnaryOpVertex<IN, OUT> extends Vertex<OUT> implements NonP
 
     protected abstract OUT op(IN a);
 }
-

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/IntegerProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/IntegerProxyVertex.java
@@ -1,9 +1,6 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
 import com.google.common.collect.Iterables;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
@@ -11,6 +8,8 @@ import io.improbable.keanu.vertices.ProxyVertex;
 import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class IntegerProxyVertex extends IntegerVertex implements ProxyVertex<IntegerVertex>, NonProbabilistic<IntegerTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/IntegerModelResultVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/IntegerModelResultVertex.java
@@ -5,10 +5,10 @@ import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexLabel;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.model.ModelVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.model.ModelResult;
 import io.improbable.keanu.vertices.model.ModelResultProvider;
+import io.improbable.keanu.vertices.model.ModelVertex;
 
 /**
  * A non-probabilistic integer vertex whose value is extracted from an upstream model vertex.

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/binary/IntegerBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/binary/IntegerBinaryOpLambda.java
@@ -1,14 +1,14 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-
-import java.util.function.BiFunction;
-
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import java.util.function.BiFunction;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 
 
 public class IntegerBinaryOpLambda<A, B> extends IntegerVertex implements NonProbabilistic<IntegerTensor> {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/binary/IntegerBinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/binary/IntegerBinaryOpVertex.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary;
 
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 
 public abstract class IntegerBinaryOpVertex extends IntegerVertex implements NonProbabilistic<IntegerTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertex.java
@@ -1,15 +1,15 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.multiple;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
-
-import java.lang.reflect.Array;
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import java.lang.reflect.Array;
+import java.util.function.Function;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkShapesCanBeConcatenated;
 
 public class IntegerConcatenationVertex extends IntegerVertex implements NonProbabilistic<IntegerTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/unary/IntegerSliceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/unary/IntegerSliceVertex.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
-
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
 
 public class IntegerSliceVertex extends IntegerUnaryOpVertex {
     private final int dimension;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/unary/IntegerUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/unary/IntegerUnaryOpLambda.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary;
 
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import java.util.function.Function;
 
 public class IntegerUnaryOpLambda<IN> extends IntegerVertex implements NonProbabilistic<IntegerTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
@@ -1,12 +1,5 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.discrete.Binomial;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
@@ -15,6 +8,13 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class BinomialVertex extends IntegerVertex implements ProbabilisticInteger {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertex.java
@@ -1,12 +1,5 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.commons.lang3.ArrayUtils;
-
 import io.improbable.keanu.distributions.discrete.Multinomial;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
@@ -15,6 +8,12 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class MultinomialVertex extends IntegerVertex implements ProbabilisticInteger {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -1,12 +1,6 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.discrete.Poisson;
 import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.Tensor;
@@ -18,6 +12,12 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.CastDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class PoissonVertex extends IntegerVertex implements ProbabilisticInteger {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/ProbabilisticInteger.java
@@ -1,12 +1,12 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
+
+import java.util.Map;
+import java.util.Set;
 
 public interface ProbabilisticInteger extends Probabilistic<IntegerTensor> {
     default double logPmf(int value) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -1,12 +1,6 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
-import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
-
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.distributions.discrete.UniformInt;
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -15,6 +9,12 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
+import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
 public class UniformIntVertex extends IntegerVertex implements ProbabilisticInteger {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/DeterministicRule.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/DeterministicRule.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu;
 
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-
-import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 public class DeterministicRule implements TestRule {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/NetworkSamplesTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/NetworkSamplesTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.algorithms;
 
-import static org.junit.Assert.assertTrue;
+import io.improbable.keanu.vertices.VertexId;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import io.improbable.keanu.vertices.VertexId;
+import static org.junit.Assert.assertTrue;
 
 public class NetworkSamplesTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/graphtraversal/DiscoverGraphTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/graphtraversal/DiscoverGraphTest.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.algorithms.graphtraversal;
 
+import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
-import io.improbable.keanu.vertices.ConstantVertex;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
@@ -1,14 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import static junit.framework.TestCase.assertTrue;
-
-import org.junit.Rule;
-import org.junit.Test;
-
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.network.BayesianNetwork;
@@ -16,6 +7,13 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class HamiltonianTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastingsTest.java
@@ -1,17 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Rule;
-import org.junit.Test;
-
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.mcmc.proposal.GaussianProposalDistribution;
@@ -23,6 +11,17 @@ import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class MetropolisHastingsTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NUTSTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NUTSTest.java
@@ -1,20 +1,18 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import static junit.framework.TestCase.assertTrue;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class NUTSTest {
 
@@ -116,4 +114,3 @@ public class NUTSTest {
         assertFalse(posteriorSamples.get(A).asList().isEmpty());
     }
 }
-

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGeneratorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NetworkSamplesGeneratorTest.java
@@ -1,10 +1,13 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import io.improbable.keanu.algorithms.NetworkSamples;
+import io.improbable.keanu.network.NetworkState;
+import io.improbable.keanu.network.SimpleNetworkState;
+import io.improbable.keanu.util.ProgressBar;
+import io.improbable.keanu.vertices.VertexId;
+import lombok.Value;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
@@ -13,15 +16,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import io.improbable.keanu.algorithms.NetworkSamples;
-import io.improbable.keanu.network.NetworkState;
-import io.improbable.keanu.network.SimpleNetworkState;
-import io.improbable.keanu.util.ProgressBar;
-import io.improbable.keanu.vertices.VertexId;
-import lombok.Value;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 public class NetworkSamplesGeneratorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/proposal/GaussianProposalDistributionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/proposal/GaussianProposalDistributionTest.java
@@ -1,19 +1,18 @@
 package io.improbable.keanu.algorithms.mcmc.proposal;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.when;
-
+import io.improbable.keanu.distributions.continuous.Gaussian;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import io.improbable.keanu.distributions.continuous.Gaussian;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GaussianProposalDistributionTest {

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/particlefiltering/LatentIncrementSortTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/particlefiltering/LatentIncrementSortTest.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.algorithms.particlefiltering;
 
+import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
-import io.improbable.keanu.vertices.ConstantVertex;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/KDEApproximationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/KDEApproximationTest.java
@@ -1,14 +1,5 @@
 package io.improbable.keanu.algorithms.variational;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.Rule;
-import org.junit.Test;
-
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.mcmc.MetropolisHastings;
 import io.improbable.keanu.distributions.continuous.Gaussian;
@@ -21,6 +12,14 @@ import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.KDEVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class KDEApproximationTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/KLDivergenceTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/KLDivergenceTest.java
@@ -11,15 +11,9 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDouble;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
@@ -27,6 +21,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KLDivergenceTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/OptimizerTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/OptimizerTest.java
@@ -1,22 +1,21 @@
 package io.improbable.keanu.algorithms.variational.optimizer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
+import io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer;
+import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import org.junit.Test;
-
-import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
-import io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer;
-import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class OptimizerTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradientTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/FitnessFunctionWithGradientTest.java
@@ -1,17 +1,16 @@
 package io.improbable.keanu.algorithms.variational.optimizer.gradient;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class FitnessFunctionWithGradientTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizerTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizerTest.java
@@ -1,13 +1,12 @@
 package io.improbable.keanu.algorithms.variational.optimizer.gradient;
 
-import static org.junit.Assert.assertTrue;
+import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import io.improbable.keanu.vertices.intgr.probabilistic.PoissonVertex;
+import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
-
-import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
-import io.improbable.keanu.vertices.intgr.probabilistic.PoissonVertex;
+import static org.junit.Assert.assertTrue;
 
 public class GradientOptimizerTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/distributions/gradient/LogNormal.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/distributions/gradient/LogNormal.java
@@ -25,4 +25,3 @@ public class LogNormal {
         }
     }
 }
-

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/foodpoisoning/FoodPoisoningTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/foodpoisoning/FoodPoisoningTest.java
@@ -1,14 +1,6 @@
 package io.improbable.keanu.e2e.foodpoisoning;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
-import java.util.function.Consumer;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.mcmc.MetropolisHastings;
 import io.improbable.keanu.network.BayesianNetwork;
@@ -21,6 +13,13 @@ import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class FoodPoisoningTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/lorenz/LorenzTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/lorenz/LorenzTest.java
@@ -1,16 +1,5 @@
 package io.improbable.keanu.e2e.lorenz;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -18,6 +7,16 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
 
 public class LorenzTest {
     private final Logger log = LoggerFactory.getLogger(LorenzTest.class);

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/DiabetesLinearRegression.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/DiabetesLinearRegression.java
@@ -1,24 +1,23 @@
 package io.improbable.keanu.e2e.regression;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.greaterThan;
-
-import java.util.List;
-
-import io.improbable.keanu.model.regression.RegressionRegularization;
-import io.improbable.keanu.util.CsvDataResource;
-import org.junit.Rule;
-import org.junit.Test;
-
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.model.ModelScoring;
 import io.improbable.keanu.model.regression.RegressionModel;
+import io.improbable.keanu.model.regression.RegressionRegularization;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.util.CsvDataResource;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 /**
  * This data set was taken from https://www4.stat.ncsu.edu/~boos/var.select/diabetes.html

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearLassoRegressionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearLassoRegressionTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.e2e.regression;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.lessThan;
-
-import static io.improbable.keanu.e2e.regression.LinearRegressionTestUtils.assertWeightsAndInterceptMatchTestData;
-import static io.improbable.keanu.e2e.regression.LinearRegressionTestUtils.generateThreeFeatureDataWithOneUncorrelatedFeature;
-
+import io.improbable.keanu.DeterministicRule;
+import io.improbable.keanu.model.regression.RegressionModel;
 import io.improbable.keanu.model.regression.RegressionRegularization;
 import org.junit.Rule;
 import org.junit.Test;
 
-import io.improbable.keanu.DeterministicRule;
-import io.improbable.keanu.model.regression.RegressionModel;
+import static io.improbable.keanu.e2e.regression.LinearRegressionTestUtils.assertWeightsAndInterceptMatchTestData;
+import static io.improbable.keanu.e2e.regression.LinearRegressionTestUtils.generateThreeFeatureDataWithOneUncorrelatedFeature;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.lessThan;
 
 public class LinearLassoRegressionTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearModelScoreTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearModelScoreTest.java
@@ -1,19 +1,18 @@
 package io.improbable.keanu.e2e.regression;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
-
-import org.junit.Rule;
-import org.junit.Test;
-
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.model.ModelScoring;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 
 public class LinearModelScoreTest {
     @Rule

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegressionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegressionTest.java
@@ -1,10 +1,5 @@
 package io.improbable.keanu.e2e.regression;
 
-import static io.improbable.keanu.e2e.regression.LinearRegressionTestUtils.assertWeightsAndInterceptMatchTestData;
-
-import org.junit.Rule;
-import org.junit.Test;
-
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
@@ -14,6 +9,10 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static io.improbable.keanu.e2e.regression.LinearRegressionTestUtils.assertWeightsAndInterceptMatchTestData;
 
 public class LinearRegressionTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegressionTestUtils.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRegressionTestUtils.java
@@ -1,12 +1,5 @@
 package io.improbable.keanu.e2e.regression;
 
-import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
-import static io.improbable.keanu.tensor.TensorMatchers.lessThanOrEqualTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
@@ -15,6 +8,13 @@ import io.improbable.keanu.vertices.dbl.probabilistic.LaplaceVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import lombok.Value;
 import lombok.experimental.UtilityClass;
+
+import java.util.function.Function;
+
+import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
+import static io.improbable.keanu.tensor.TensorMatchers.lessThanOrEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 
 @UtilityClass
 class LinearRegressionTestUtils {

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRidgeRegressionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LinearRidgeRegressionTest.java
@@ -1,16 +1,14 @@
 package io.improbable.keanu.e2e.regression;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThan;
-
-import static io.improbable.keanu.e2e.regression.LinearRegressionTestUtils.assertWeightsAndInterceptMatchTestData;
-
+import io.improbable.keanu.DeterministicRule;
+import io.improbable.keanu.model.regression.RegressionModel;
 import io.improbable.keanu.model.regression.RegressionRegularization;
 import org.junit.Rule;
 import org.junit.Test;
 
-import io.improbable.keanu.DeterministicRule;
-import io.improbable.keanu.model.regression.RegressionModel;
+import static io.improbable.keanu.e2e.regression.LinearRegressionTestUtils.assertWeightsAndInterceptMatchTestData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
 
 public class LinearRidgeRegressionTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LogisticModelScoreTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LogisticModelScoreTest.java
@@ -2,9 +2,8 @@ package io.improbable.keanu.e2e.regression;
 
 
 import io.improbable.keanu.model.ModelScoring;
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.bool.BooleanTensor;
+import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LogisticRegressionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/regression/LogisticRegressionTest.java
@@ -1,18 +1,8 @@
 package io.improbable.keanu.e2e.regression;
 
-import static io.improbable.keanu.tensor.TensorMatchers.lessThanOrEqualTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
-
+import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.model.ModelScoring;
 import io.improbable.keanu.model.regression.RegressionModel;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
-import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
@@ -21,6 +11,14 @@ import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
+import static io.improbable.keanu.tensor.TensorMatchers.lessThanOrEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class LogisticRegressionTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/e2e/rocket/RocketTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/e2e/rocket/RocketTest.java
@@ -1,14 +1,5 @@
 package io.improbable.keanu.e2e.rocket;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-import java.util.stream.Stream;
-
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.improbable.keanu.algorithms.mcmc.MetropolisHastings;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.network.NetworkState;
@@ -17,6 +8,14 @@ import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.ConditionalProbabilityTable;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
 
 public class RocketTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/BayesianNetworkTest.java
@@ -1,19 +1,18 @@
 package io.improbable.keanu.network;
 
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexLabel;
+import io.improbable.keanu.vertices.bool.BoolVertex;
+import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
+import org.junit.Before;
+import org.junit.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexLabel;
-import io.improbable.keanu.vertices.bool.BoolVertex;
-import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 
 public class BayesianNetworkTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/network/ModelCompositionTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/ModelCompositionTest.java
@@ -1,22 +1,8 @@
 package io.improbable.keanu.network;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
@@ -27,6 +13,18 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.DoubleProxyVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.ParetoVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ModelCompositionTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/network/NetworkStateGrouperTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/network/NetworkStateGrouperTest.java
@@ -1,6 +1,10 @@
 package io.improbable.keanu.network;
 
-import static org.junit.Assert.assertTrue;
+import io.improbable.keanu.network.grouping.NetworkStateGrouper;
+import io.improbable.keanu.network.grouping.continuouspointgroupers.DBSCANContinuousPointGrouper;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -8,12 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-
-import io.improbable.keanu.network.grouping.NetworkStateGrouper;
-import io.improbable.keanu.network.grouping.continuouspointgroupers.DBSCANContinuousPointGrouper;
-import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import static org.junit.Assert.assertTrue;
 
 public class NetworkStateGrouperTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/plating/LoopTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/plating/LoopTest.java
@@ -1,18 +1,6 @@
 package io.improbable.keanu.plating;
 
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.plating.loop.Loop;
 import io.improbable.keanu.plating.loop.LoopConstructionException;
@@ -25,6 +13,17 @@ import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.DoubleProxyVertex;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class LoopTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/plating/PlateBuilderTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/plating/PlateBuilderTest.java
@@ -1,33 +1,9 @@
 package io.improbable.keanu.plating;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import static io.improbable.keanu.vertices.VertexLabelMatchers.hasUnqualifiedName;
-import static io.improbable.keanu.vertices.VertexMatchers.hasLabel;
-import static io.improbable.keanu.vertices.VertexMatchers.hasNoLabel;
-import static io.improbable.keanu.vertices.VertexMatchers.hasParents;
-
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
@@ -46,6 +22,27 @@ import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.probabilistic.PoissonVertex;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.improbable.keanu.vertices.VertexLabelMatchers.hasUnqualifiedName;
+import static io.improbable.keanu.vertices.VertexMatchers.hasLabel;
+import static io.improbable.keanu.vertices.VertexMatchers.hasNoLabel;
+import static io.improbable.keanu.vertices.VertexMatchers.hasParents;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class PlateBuilderTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/plating/PlateTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/plating/PlateTest.java
@@ -1,13 +1,11 @@
 package io.improbable.keanu.plating;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.when;
-
-import java.util.Collection;
-
+import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexLabel;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.BoolProxyVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.DoubleProxyVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.IntegerProxyVertex;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,12 +14,13 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import io.improbable.keanu.vertices.ConstantVertex;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexLabel;
-import io.improbable.keanu.vertices.bool.nonprobabilistic.BoolProxyVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.DoubleProxyVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.IntegerProxyVertex;
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PlateTest {

--- a/keanu-project/src/test/java/io/improbable/keanu/plating/PlatesTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/plating/PlatesTest.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.plating;
 
+import org.junit.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
-
-import org.junit.Test;
 
 public class PlatesTest {
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorMatchers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorMatchers.java
@@ -1,16 +1,16 @@
 package io.improbable.keanu.tensor;
 
-import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
 
 
 public class TensorMatchers {

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorShapeValidationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorShapeValidationTest.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.tensor;
 
-import static org.junit.Assert.assertArrayEquals;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
 
 public class TensorShapeValidationTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorValidationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/TensorValidationTest.java
@@ -1,15 +1,14 @@
 package io.improbable.keanu.tensor;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
-import java.util.function.Function;
-
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.validate.TensorValidator;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 public class TensorValidationTest {
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensorTest.java
@@ -1,24 +1,22 @@
 package io.improbable.keanu.tensor.bool;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-
-import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
-import static junit.framework.TestCase.assertTrue;
-
-import java.util.Arrays;
-
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.generic.GenericTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.generic.GenericTensor;
-import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import java.util.Arrays;
+
+import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
 
 public class SimpleBooleanTensorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jBroadcastTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jBroadcastTensorTest.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.tensor.dbl;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
 
 import static io.improbable.keanu.tensor.dbl.Nd4jTensorTestHelpers.assertDivideInPlaceOperationEquals;
 import static io.improbable.keanu.tensor.dbl.Nd4jTensorTestHelpers.assertDivideOperationEquals;
@@ -10,9 +11,7 @@ import static io.improbable.keanu.tensor.dbl.Nd4jTensorTestHelpers.assertPlusInP
 import static io.improbable.keanu.tensor.dbl.Nd4jTensorTestHelpers.assertPlusOperationEquals;
 import static io.improbable.keanu.tensor.dbl.Nd4jTensorTestHelpers.assertTimesInPlaceOperationEquals;
 import static io.improbable.keanu.tensor.dbl.Nd4jTensorTestHelpers.assertTimesOperationEquals;
-
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 public class Nd4jBroadcastTensorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensorTest.java
@@ -1,25 +1,5 @@
 package io.improbable.keanu.tensor.dbl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
-import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
-import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
-import static junit.framework.TestCase.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.TensorValueException;
@@ -27,6 +7,24 @@ import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.tensor.validate.TensorValidator;
 import io.improbable.keanu.tensor.validate.policy.TensorValidationPolicy;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
+import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
+import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class Nd4jDoubleTensorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
@@ -1,25 +1,23 @@
 package io.improbable.keanu.tensor.dbl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
-import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
-
-import java.util.function.Function;
-
+import io.improbable.keanu.tensor.TensorValueException;
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.tensor.validate.TensorValidator;
+import io.improbable.keanu.tensor.validate.policy.TensorValidationPolicy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import io.improbable.keanu.tensor.TensorValueException;
-import io.improbable.keanu.tensor.bool.BooleanTensor;
-import io.improbable.keanu.tensor.intgr.IntegerTensor;
-import io.improbable.keanu.tensor.validate.TensorValidator;
-import io.improbable.keanu.tensor.validate.policy.TensorValidationPolicy;
+import java.util.function.Function;
+
+import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
+import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 
 public class ScalarDoubleTensorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/generic/GenericTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/generic/GenericTensorTest.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.tensor.generic;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
 
 import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
-
-import org.junit.Test;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 public class GenericTensorTest {
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensorTest.java
@@ -1,25 +1,23 @@
 package io.improbable.keanu.tensor.intgr;
 
+import io.improbable.keanu.tensor.bool.BooleanTensor;
+import io.improbable.keanu.tensor.validate.TensorValidator;
+import io.improbable.keanu.tensor.validate.policy.TensorValidationPolicy;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
+import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
+import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-
-import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
-import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
-import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
-
-import java.util.Arrays;
-import java.util.stream.IntStream;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import io.improbable.keanu.tensor.bool.BooleanTensor;
-import io.improbable.keanu.tensor.validate.TensorValidator;
-import io.improbable.keanu.tensor.validate.policy.TensorValidationPolicy;
 
 public class Nd4jIntegerTensorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/intgr/ScalarIntegerTensorTest.java
@@ -1,12 +1,11 @@
 package io.improbable.keanu.tensor.intgr;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
 import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
-
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class ScalarIntegerTensorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/validate/DebugTensorValidatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/validate/DebugTensorValidatorTest.java
@@ -1,13 +1,12 @@
 package io.improbable.keanu.tensor.validate;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import org.junit.After;
 import org.junit.Test;
 
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class DebugTensorValidatorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/ProgressBarTest.java
@@ -1,5 +1,19 @@
 package io.improbable.keanu.util;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -12,20 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 public class ProgressBarTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/util/csv/WriteCsvTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/csv/WriteCsvTest.java
@@ -1,6 +1,15 @@
 package io.improbable.keanu.util.csv;
 
-import static org.junit.Assert.assertTrue;
+import io.improbable.keanu.algorithms.NetworkSamples;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,17 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import io.improbable.keanu.algorithms.NetworkSamples;
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.intgr.IntegerTensor;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
+import static org.junit.Assert.assertTrue;
 
 public class WriteCsvTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/bycolumn/CsvReaderByColumnTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/bycolumn/CsvReaderByColumnTest.java
@@ -1,17 +1,16 @@
 package io.improbable.keanu.util.csv.pojo.bycolumn;
 
-import static org.apache.commons.lang3.ArrayUtils.toPrimitive;
-import static org.junit.Assert.assertArrayEquals;
-
-import java.util.Arrays;
-
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.util.csv.ReadCsv;
 import io.improbable.keanu.util.csv.pojo.CsvProperty;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.apache.commons.lang3.ArrayUtils.toPrimitive;
+import static org.junit.Assert.assertArrayEquals;
 
 public class CsvReaderByColumnTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/byrow/ObjectParserWithPublicFieldTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/byrow/ObjectParserWithPublicFieldTest.java
@@ -1,17 +1,15 @@
 package io.improbable.keanu.util.csv.pojo.byrow;
 
-import static java.util.stream.Collectors.toList;
-
-import static org.junit.Assert.assertEquals;
+import io.improbable.keanu.util.csv.pojo.CsvProperty;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import io.improbable.keanu.util.csv.pojo.CsvProperty;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
 
 public class ObjectParserWithPublicFieldTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/byrow/ObjectParserWithSetterMethodTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/csv/pojo/byrow/ObjectParserWithSetterMethodTest.java
@@ -1,17 +1,15 @@
 package io.improbable.keanu.util.csv.pojo.byrow;
 
-import static java.util.stream.Collectors.toList;
-
-import static org.junit.Assert.assertEquals;
+import io.improbable.keanu.util.csv.pojo.CsvProperty;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import io.improbable.keanu.util.csv.pojo.CsvProperty;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
 
 public class ObjectParserWithSetterMethodTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/AutoDiffPropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/AutoDiffPropagationTest.java
@@ -1,12 +1,11 @@
 package io.improbable.keanu.vertices;
 
-import static org.junit.Assert.assertEquals;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import static org.junit.Assert.assertEquals;
 
 public class AutoDiffPropagationTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/EvalPropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/EvalPropagationTest.java
@@ -1,21 +1,19 @@
 package io.improbable.keanu.vertices;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.TestGraphGenerator.addLinks;
-
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static io.improbable.keanu.vertices.TestGraphGenerator.addLinks;
+import static org.junit.Assert.assertEquals;
 
 public class EvalPropagationTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/ObservableTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/ObservableTest.java
@@ -1,10 +1,5 @@
 package io.improbable.keanu.vertices;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
@@ -14,6 +9,10 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.probabilistic.UniformIntVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ObservableTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/SimpleVertexDictionaryTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/SimpleVertexDictionaryTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.Mockito.mock;
-
-import java.util.Map;
-
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
 
 public class SimpleVertexDictionaryTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DoubleBinaryOpVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpVertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 public class TestGraphGenerator {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/VertexLabelMatchers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/VertexLabelMatchers.java
@@ -1,10 +1,10 @@
 package io.improbable.keanu.vertices;
 
-import static org.hamcrest.Matchers.equalTo;
-
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class VertexLabelMatchers {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/VertexLabelTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/VertexLabelTest.java
@@ -1,15 +1,14 @@
 package io.improbable.keanu.vertices;
 
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static io.improbable.keanu.vertices.VertexLabelMatchers.hasUnqualifiedName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-
-import static io.improbable.keanu.vertices.VertexLabelMatchers.hasUnqualifiedName;
-
-import java.util.Optional;
-
-import org.junit.Test;
 
 public class VertexLabelTest {
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/VertexMatchers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/VertexMatchers.java
@@ -1,19 +1,18 @@
 package io.improbable.keanu.vertices;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import io.improbable.keanu.tensor.Tensor;
+import io.improbable.keanu.tensor.TensorMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-
-import io.improbable.keanu.tensor.Tensor;
-import io.improbable.keanu.tensor.TensorMatchers;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 public class VertexMatchers {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/EqualsVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/EqualsVertexTest.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic;
 
 import io.improbable.keanu.tensor.generic.GenericTensor;
-import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.EqualsVertex;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.EqualsVertex;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/GreaterThanOrEqualVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/GreaterThanOrEqualVertexTest.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.bool.BoolVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class GreaterThanOrEqualVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/GreaterThanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/GreaterThanVertexTest.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.bool.BoolVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class GreaterThanVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/LessThanOrEqualVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/LessThanOrEqualVertexTest.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.bool.BoolVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class LessThanOrEqualVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/LessThanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/LessThanVertexTest.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.bool.BoolVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class LessThanVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NotEqualsVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/nonprobabilistic/NotEqualsVertexTest.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic;
 
 import io.improbable.keanu.tensor.generic.GenericTensor;
-import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.NotEqualsVertex;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.NotEqualsVertex;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertexTest.java
@@ -1,17 +1,6 @@
 package io.improbable.keanu.vertices.bool.probabilistic;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.testGradientAcrossMultipleHyperParameterValues;
-
-import java.util.Map;
-
-import org.junit.Rule;
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.network.BayesianNetwork;
@@ -22,6 +11,14 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.testGradientAcrossMultipleHyperParameterValues;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class BernoulliVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
@@ -1,13 +1,7 @@
 package io.improbable.keanu.vertices.dbl;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -16,6 +10,10 @@ import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static org.junit.Assert.assertEquals;
 
 public class DifferentiatorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleCPTVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleCPTVertexTest.java
@@ -1,9 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
@@ -12,6 +8,9 @@ import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.ConditionalProbabilityTable;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class DoubleCPTVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
@@ -1,8 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
@@ -15,6 +12,8 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class DoubleIfVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffTensorTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertArrayEquals;
-
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 
 public class AutoDiffTensorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class AutoDiffTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DiffTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/DiffTest.java
@@ -1,17 +1,15 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
-import static org.junit.Assert.assertTrue;
-
-import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
-
-import java.util.NoSuchElementException;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.hyperparam.Diff;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+import static io.improbable.keanu.distributions.hyperparam.Diffs.MU;
+import static org.junit.Assert.assertTrue;
 
 public class DiffTest {
     Diffs diffs;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
@@ -1,16 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.Gaussian;
 import io.improbable.keanu.distributions.hyperparam.Diffs;
@@ -19,6 +9,14 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class LogProbGradientCalculatorTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -1,15 +1,14 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators;
 
-import static org.junit.Assert.assertThat;
-
-import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
-
-import java.util.List;
-
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+
+import java.util.List;
+
+import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
+import static org.junit.Assert.assertThat;
 
 public class TensorTestOperations {
     public static void finiteDifferenceMatchesForwardAndReverseModeGradient(List<DoubleVertex> inputVertices,

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
@@ -1,15 +1,13 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.*;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.*;
 
 public class AdditionVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2VertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ArcTan2VertexTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfAScalarAndVector;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfAVectorAndScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfTwoMatricesElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfTwoScalars;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwo2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwoScalarVertexValues;
-
-import org.junit.Test;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
 public class ArcTan2VertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/BinaryOperationTestHelpers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/BinaryOperationTestHelpers.java
@@ -1,18 +1,17 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import java.util.function.BiFunction;
-
 import com.google.common.collect.ImmutableSet;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+
+import java.util.function.BiFunction;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class BinaryOperationTestHelpers {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -1,16 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-
-import java.util.Arrays;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.Differentiator;
@@ -19,6 +9,13 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static org.junit.Assert.assertEquals;
 
 public class ConcatenationVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertexTest.java
@@ -1,15 +1,13 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.*;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.*;
 
 public class DivisionVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambdaTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambdaTest.java
@@ -1,12 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static org.junit.Assert.assertArrayEquals;
-
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
 
 public class DoubleBinaryOpLambdaTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -1,21 +1,19 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-import java.util.HashSet;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static org.junit.Assert.assertEquals;
 
 public class MatrixMultiplicationVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MaxVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MaxVertexTest.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MinVertexTest.java
@@ -1,11 +1,9 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
-
 import org.junit.Test;
 
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MultiplicationVertexTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfAScalarAndVector;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfAVectorAndScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfTwoMatricesElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfTwoScalars;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwo2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwoScalarVertexValues;
-
-import org.junit.Test;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
 public class MultiplicationVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/PowerVertexTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfAScalarAndVector;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfAVectorAndScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfTwoMatricesElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.calculatesDerivativeOfTwoScalars;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwo2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.operatesOnTwoScalarVertexValues;
-
-import org.junit.Test;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
 public class PowerVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -1,14 +1,7 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
@@ -16,6 +9,11 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SliceVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 
 public class SliceVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertexTest.java
@@ -1,17 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.LinkedList;
-import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class ReduceVertexTest {
     int minValue = -8;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class ArcCosVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class ArcSinVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class ArcTanVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class CosVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambdaTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambdaTest.java
@@ -1,12 +1,11 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static org.junit.Assert.assertArrayEquals;
-
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
 
 public class DoubleUnaryOpLambdaTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class ExpVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
@@ -1,6 +1,12 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static org.apache.commons.math3.special.Gamma.digamma;
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.DeterministicRule;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.apache.commons.math3.special.Gamma;
+import org.junit.Rule;
+import org.junit.Test;
 
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
@@ -8,16 +14,7 @@ import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.apache.commons.math3.special.Gamma;
-import org.junit.Rule;
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.DeterministicRule;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import static org.apache.commons.math3.special.Gamma.digamma;
 
 public class LogGammaVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class LogVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
@@ -1,19 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static org.hamcrest.Matchers.closeTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-
-import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
-import static io.improbable.keanu.vertices.VertexMatchers.hasValue;
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
-
-import org.apache.commons.math3.linear.SingularMatrixException;
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.algorithms.variational.optimizer.Optimizer;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -23,6 +10,16 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.apache.commons.math3.linear.SingularMatrixException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.improbable.keanu.tensor.TensorMatchers.isScalarWithValue;
+import static io.improbable.keanu.vertices.VertexMatchers.hasValue;
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesReverseModeGradient;
+import static org.hamcrest.Matchers.closeTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class MatrixDeterminantVertexTest {
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.ScalarDoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static org.junit.Assert.assertEquals;
 
 public class MatrixInverseVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 
 public class ReshapeVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
@@ -1,20 +1,18 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.apache.commons.math3.analysis.function.Sigmoid;
+import org.junit.Before;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.apache.commons.math3.analysis.function.Sigmoid;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class SigmoidVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class SinVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
@@ -1,22 +1,19 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class SumVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TakeVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
@@ -1,18 +1,16 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+import org.junit.Test;
+
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.BinaryOperationTestHelpers.toDiagonalArray;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfMatrixElementWiseOperator;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.calculatesDerivativeOfScalar;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOn2x2MatrixVertexValues;
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.UnaryOperationTestHelpers.operatesOnScalarVertexValue;
-
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class TanVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/UnaryOperationTestHelpers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/UnaryOperationTestHelpers.java
@@ -1,10 +1,5 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import java.util.function.Function;
-
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -14,6 +9,11 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class UnaryOperationTestHelpers {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.BetaDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Beta;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -20,6 +7,17 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.BetaDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class BetaVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.CauchyDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Cauchy;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -20,6 +7,17 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.CauchyDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class CauchyVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertexTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Arrays;
-
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 public class ChiSquaredVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertexTest.java
@@ -1,25 +1,23 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.sampleMethodMatchesLogProbMethodMultiVariate;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.commons.math3.util.Pair;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.util.Pair;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import umontreal.ssj.probdistmulti.DirichletDist;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.sampleMethodMatchesLogProbMethodMultiVariate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.junit.Assert.assertEquals;
 
 public class DirichletVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertexTest.java
@@ -1,19 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.ExponentialDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.continuous.Exponential;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -21,6 +7,18 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.ExponentialDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ExponentialVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.GammaDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Gamma;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -20,6 +7,17 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.GammaDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class GammaVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.NormalDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Gaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -20,6 +7,17 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class GaussianVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.CauchyDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Cauchy;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -20,6 +7,17 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.CauchyDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class HalfCauchyVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.NormalDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Gaussian;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -20,6 +7,17 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class HalfGaussianVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertexTest.java
@@ -1,17 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.InverseGamma;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -19,6 +7,16 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class InverseGammaVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.LaplaceDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Laplace;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -20,6 +7,17 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.LaplaceDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class LaplaceVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.LogNormalDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.LogNormal;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -20,6 +7,17 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.LogNormalDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class LogNormalVertexTest {
     private static final double DELTA = 0.0001;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertexTest.java
@@ -1,17 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.math3.distribution.LogisticDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Logistic;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -19,6 +7,16 @@ import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.apache.commons.math3.distribution.LogisticDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class LogisticVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianTest.java
@@ -11,7 +11,6 @@ import org.apache.commons.math3.distribution.NormalDistribution;
 import org.junit.Before;
 import org.junit.Test;
 
-
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.sampleMethodMatchesLogProbMethodMultiVariate;
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.sampleUnivariateMethodMatchesLogProbMethod;
 import static org.junit.Assert.assertEquals;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertexTest.java
@@ -1,18 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
-import org.apache.commons.math3.distribution.ParetoDistribution;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.distributions.gradient.Pareto;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
@@ -21,6 +8,17 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import org.apache.commons.math3.distribution.ParetoDistribution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.moveAlongDistributionAndTestGradientOnARangeOfHyperParameterValues;
+import static org.junit.Assert.assertEquals;
 
 public class ParetoVertexTest {
 
@@ -231,4 +229,3 @@ public class ParetoVertexTest {
         );
     }
 }
-

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -1,14 +1,16 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toMap;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import com.google.common.collect.ImmutableList;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import io.improbable.keanu.vertices.Probabilistic;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.apache.commons.math3.util.Pair;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,19 +20,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
-import org.apache.commons.math3.util.Pair;
-
-import com.google.common.collect.ImmutableList;
-
-import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
-import io.improbable.keanu.vertices.Probabilistic;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.VertexId;
-import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ProbabilisticDoubleTensorContract {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertexTest.java
@@ -1,15 +1,14 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class SmoothUniformVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertexTest.java
@@ -1,11 +1,6 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import static java.lang.Math.pow;
-
-import static junit.framework.TestCase.assertEquals;
-
-import java.util.List;
-
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.distribution.TDistribution;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Assert;
@@ -14,7 +9,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import java.util.List;
+
+import static java.lang.Math.pow;
+import static junit.framework.TestCase.assertEquals;
 
 public class StudentTVertexTest {
     private static final double DELTA = 0.0001;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertexTest.java
@@ -4,10 +4,6 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,6 +12,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class UniformVertexTest {
     private int N = 100000;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/generic/nonprobabilistic/IfVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/generic/nonprobabilistic/IfVertexTest.java
@@ -1,19 +1,17 @@
 package io.improbable.keanu.vertices.generic.nonprobabilistic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import static io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex.FALSE;
-import static io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex.TRUE;
-import static junit.framework.TestCase.assertFalse;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.bool.BoolVertexTest;
 import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex.FALSE;
+import static io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex.TRUE;
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class IfVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/IntegerVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/IntegerVertexTest.java
@@ -1,21 +1,20 @@
 package io.improbable.keanu.vertices.intgr;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.function.Function;
-
-import io.improbable.keanu.vertices.intgr.probabilistic.UniformIntVertex;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.tensor.intgr.Nd4jIntegerTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.intgr.probabilistic.BinomialVertex;
 import io.improbable.keanu.vertices.intgr.probabilistic.PoissonVertex;
+import io.improbable.keanu.vertices.intgr.probabilistic.UniformIntVertex;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class IntegerVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertexTest.java
@@ -1,11 +1,10 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
-import static org.junit.Assert.assertEquals;
-
+import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.junit.Test;
 
-import io.improbable.keanu.tensor.intgr.IntegerTensor;
+import static org.junit.Assert.assertEquals;
 
 public class BinomialVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertexTest.java
@@ -1,28 +1,7 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
-import static io.improbable.keanu.tensor.TensorMatchers.allValues;
-import static io.improbable.keanu.tensor.TensorMatchers.hasShape;
-import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
-
-import java.util.Map;
-
-import org.junit.Test;
-import org.nd4j.linalg.exception.ND4JIllegalStateException;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import io.improbable.keanu.distributions.DiscreteDistribution;
 import io.improbable.keanu.distributions.discrete.Binomial;
 import io.improbable.keanu.distributions.discrete.Multinomial;
@@ -36,6 +15,24 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.Conc
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.ReshapeVertex;
 import io.improbable.keanu.vertices.generic.probabilistic.discrete.CategoricalVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+import org.junit.Test;
+import org.nd4j.linalg.exception.ND4JIllegalStateException;
+
+import java.util.Map;
+
+import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
+import static io.improbable.keanu.tensor.TensorMatchers.allValues;
+import static io.improbable.keanu.tensor.TensorMatchers.hasShape;
+import static io.improbable.keanu.tensor.TensorMatchers.hasValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MultinomialVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertexTest.java
@@ -1,16 +1,15 @@
 package io.improbable.keanu.vertices.intgr.probabilistic;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.closeTo;
-import static org.junit.Assert.assertEquals;
-
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.junit.Assert.assertEquals;
 
 public class PoissonVertexTest {
     private final Logger log = LoggerFactory.getLogger(PoissonVertexTest.class);


### PR DESCRIPTION
A simple one-liner that enforces an import order.

I've decided that it was a bad idea to propose we move away from the IntelliJ default, so please revert your config... sorry :-|