### PR TITLE
Add documentation to optimizers

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
@@ -31,12 +31,33 @@ public interface Optimizer {
      */
     void removeFitnessCalculationHandler(BiConsumer<double[], Double> fitnessCalculationHandler);
 
+    /**
+     * This methods detects the vertices in the Bayesian Network that have been observed, and will use MAP estimation to
+     * optimize the observation probability of these vertices.
+     * This method will modify in place the Bayesian network that was used to create this object.
+     *
+     * @return the natural logarithm of the Maximum a posteriori (MAP)
+     */
     double maxAPosteriori();
 
+    /**
+     * This methods detects the vertices in the Bayesian Network that have been observed, and will use Maximum Likelihood
+     * estimation to optimize the observation probability of these vertices.
+     * This method will modify in place the Bayesian network that was used to create this object.
+     *
+     * @return the natural logarithm of the maximum likelihood (MLE)
+     */
     double maxLikelihood();
 
     BayesianNetwork getBayesianNetwork();
 
+    /**
+     * Creates an {@link Optimizer} which optimizes against the unobserved (latent) variables of the Bayesian network.
+     *
+     * @param network The Bayesian network containing the unobserved variables to be optimized against,
+     *                 and the observed variables to optimize the probability of.
+     * @return an {@link Optimizer}
+     */
     static Optimizer of(BayesianNetwork network) {
         if (network.getDiscreteLatentVertices().isEmpty()) {
             return GradientOptimizer.of(network);
@@ -45,10 +66,24 @@ public interface Optimizer {
         }
     }
 
+    /**
+     * Creates a Bayesian network from the given vertices and uses this to
+     * create an {@link Optimizer} which optimizes against the unobserved (latent) variables.
+     *
+     * @param vertices The vertices to create a Bayesian network from.
+     * @return an {@link Optimizer}
+     */
     static Optimizer of(Collection<? extends Vertex> vertices) {
         return of(new BayesianNetwork(vertices));
     }
 
+    /**
+     * Retrieves the connected graph from the given vertex and uses this to
+     * create an {@link Optimizer} which optimizes against the unobserved (latent) variables.
+     *
+     * @param vertexFromNetwork The vertices to create a Bayesian network from.
+     * @return an {@link Optimizer}
+     */
     static Optimizer ofConnectedGraph(Vertex<?> vertexFromNetwork) {
         return of(vertexFromNetwork.getConnectedGraph());
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
@@ -32,7 +32,7 @@ public interface Optimizer {
     void removeFitnessCalculationHandler(BiConsumer<double[], Double> fitnessCalculationHandler);
 
     /**
-     * This and will use MAP estimation to optimize the values of latent vertices such that the
+     * This will use MAP estimation to optimize the values of latent vertices such that the
      * probability of the whole Bayesian network is maximised.
      * This method will modify in place the Bayesian network that was used to create this object.
      *
@@ -42,7 +42,7 @@ public interface Optimizer {
 
     /**
      * This method will use Maximum Likelihood estimation to optimize the values of latent vertices such that
-     * the probability of the whole Bayesian network is maximised.
+     * the probability of the observed vertices is maximised.
      * This method will modify in place the Bayesian network that was used to create this object.
      *
      * @return the natural logarithm of the maximum likelihood (MLE)

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
@@ -17,7 +17,7 @@ import io.improbable.keanu.vertices.Vertex;
 
 public interface Optimizer {
     /**
-     * Adds a callback to be called whenever the optimizer evaluates the fitness of a point.
+     * Adds a callback to be called whenever the optimizer evaluates the fitness of a point. E.g. for logging.
      * @param fitnessCalculationHandler a function to be called whenever the optimizer evaluates the fitness of a point.
      *                                  The double[] argument to the handler represents the point being evaluated.
      *                                  The Double argument to the handler represents the fitness of that point.
@@ -25,15 +25,15 @@ public interface Optimizer {
     void addFitnessCalculationHandler(BiConsumer<double[], Double> fitnessCalculationHandler);
 
     /**
-     * This attempts to remove a callback function that previously would have been called whenever the optimizer
+     * Removes a callback function that previously would have been called whenever the optimizer
      * evaluated the fitness of a point. If the callback is not registered then this function will do nothing.
      * @param fitnessCalculationHandler the function to be removed from the list of fitness evaluation callbacks
      */
     void removeFitnessCalculationHandler(BiConsumer<double[], Double> fitnessCalculationHandler);
 
     /**
-     * This methods detects the vertices in the Bayesian Network that have been observed, and will use MAP estimation to
-     * optimize the observation probability of these vertices.
+     * This and will use MAP estimation to optimize the values of latent vertices such that the
+     * probability of the whole Bayesian network is maximised.
      * This method will modify in place the Bayesian network that was used to create this object.
      *
      * @return the natural logarithm of the Maximum a posteriori (MAP)
@@ -41,8 +41,8 @@ public interface Optimizer {
     double maxAPosteriori();
 
     /**
-     * This methods detects the vertices in the Bayesian Network that have been observed, and will use Maximum Likelihood
-     * estimation to optimize the observation probability of these vertices.
+     * This method will use Maximum Likelihood estimation to optimize the values of latent vertices such that
+     * the probability of the whole Bayesian network is maximised.
      * This method will modify in place the Bayesian network that was used to create this object.
      *
      * @return the natural logarithm of the maximum likelihood (MLE)
@@ -52,10 +52,10 @@ public interface Optimizer {
     BayesianNetwork getBayesianNetwork();
 
     /**
-     * Creates an {@link Optimizer} which optimizes against the unobserved (latent) variables of the Bayesian network.
+     * Creates an {@link Optimizer} which optimizes the values of latent variables of the Bayesian network to maximise
+     * the overall probability.
      *
-     * @param network The Bayesian network containing the unobserved variables to be optimized against,
-     *                 and the observed variables to optimize the probability of.
+     * @param network The Bayesian network to run optimization on.
      * @return an {@link Optimizer}
      */
     static Optimizer of(BayesianNetwork network) {
@@ -68,7 +68,7 @@ public interface Optimizer {
 
     /**
      * Creates a Bayesian network from the given vertices and uses this to
-     * create an {@link Optimizer} which optimizes against the unobserved (latent) variables.
+     * create an {@link Optimizer} which optimizes the values of latent variables to maximise overall probability.
      *
      * @param vertices The vertices to create a Bayesian network from.
      * @return an {@link Optimizer}
@@ -78,10 +78,10 @@ public interface Optimizer {
     }
 
     /**
-     * Retrieves the connected graph from the given vertex and uses this to
-     * create an {@link Optimizer} which optimizes against the unobserved (latent) variables.
+     * Creates a Bayesian network from the graph connected to the given vertex and uses this to
+     * create an {@link Optimizer} which optimizes the values of latent variables to maximise overall probability.
      *
-     * @param vertexFromNetwork The vertices to create a Bayesian network from.
+     * @param vertexFromNetwork A vertex in the graph to create the Bayesian network from
      * @return an {@link Optimizer}
      */
     static Optimizer ofConnectedGraph(Vertex<?> vertexFromNetwork) {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
@@ -16,9 +16,19 @@ import io.improbable.keanu.util.ProgressBar;
 import io.improbable.keanu.vertices.Vertex;
 
 public interface Optimizer {
-
+    /**
+     * Adds a callback to be called whenever the optimizer evaluates the fitness of a point.
+     * @param fitnessCalculationHandler a function to be called whenever the optimizer evaluates the fitness of a point.
+     *                                  The double[] argument to the handler represents the point being evaluated.
+     *                                  The Double argument to the handler represents the fitness of that point.
+     */
     void addFitnessCalculationHandler(BiConsumer<double[], Double> fitnessCalculationHandler);
 
+    /**
+     * This attempts to remove a callback function that previously would have been called whenever the optimizer
+     * evaluated the fitness of a point. If the callback is not registered then this function will do nothing.
+     * @param fitnessCalculationHandler the function to be removed from the list of fitness evaluation callbacks
+     */
     void removeFitnessCalculationHandler(BiConsumer<double[], Double> fitnessCalculationHandler);
 
     double maxAPosteriori();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/Optimizer.java
@@ -52,8 +52,8 @@ public interface Optimizer {
     BayesianNetwork getBayesianNetwork();
 
     /**
-     * Creates an {@link Optimizer} which optimizes the values of latent variables of the Bayesian network to maximise
-     * the overall probability.
+     * Creates an {@link Optimizer} which provides methods for optimizing the values of latent variables
+     * of the Bayesian network to maximise probability.
      *
      * @param network The Bayesian network to run optimization on.
      * @return an {@link Optimizer}
@@ -68,7 +68,8 @@ public interface Optimizer {
 
     /**
      * Creates a Bayesian network from the given vertices and uses this to
-     * create an {@link Optimizer} which optimizes the values of latent variables to maximise overall probability.
+     * create an {@link Optimizer}. This provides methods for optimizing the values of latent variables
+     * of the Bayesian network to maximise probability.
      *
      * @param vertices The vertices to create a Bayesian network from.
      * @return an {@link Optimizer}
@@ -79,7 +80,8 @@ public interface Optimizer {
 
     /**
      * Creates a Bayesian network from the graph connected to the given vertex and uses this to
-     * create an {@link Optimizer} which optimizes the values of latent variables to maximise overall probability.
+     * create an {@link Optimizer}. This provides methods for optimizing the values of latent variables
+     * of the Bayesian network to maximise probability.
      *
      * @param vertexFromNetwork A vertex in the graph to create the Bayesian network from
      * @return an {@link Optimizer}

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -41,10 +41,10 @@ public class GradientOptimizer implements Optimizer {
         }
     }
     /**
-     * Creates a {@link GradientOptimizer} which optimizes against the unobserved (latent) variables of the Bayesian network.
+     * Creates a {@link GradientOptimizer} which optimizes the values of the latent variables to maximise
+     * the overall probability of the Bayesian network.
      *
-     * @param bayesNet The Bayesian network containing the unobserved variables to be optimized against,
-     *                 and the observed variables to optimize the probability of.
+     * @param bayesNet The Bayesian network to run optimization on.
      * @return a {@link GradientOptimizer}
      */
     public static GradientOptimizer of(BayesianNetwork bayesNet) {
@@ -63,7 +63,8 @@ public class GradientOptimizer implements Optimizer {
 
     /**
      * Creates a Bayesian network from the given vertices and uses this to
-     * create a {@link GradientOptimizer} which optimizes against the unobserved (latent) variables.
+     * create a {@link GradientOptimizer} which optimizes the values of latent variables
+     * to maximise overall probability.
      *
      * @param vertices The vertices to create a Bayesian network from.
      * @return a {@link GradientOptimizer}
@@ -73,8 +74,9 @@ public class GradientOptimizer implements Optimizer {
     }
 
     /**
-     * Retrieves the connected graph from the given vertex and uses this to
-     * create a {@link GradientOptimizer} which optimizes against the unobserved (latent) variables.
+     * Creates a Bayesian network from the graph connected to the given vertex and uses this to
+     * create a {@link GradientOptimizer} which optimizes the values of latent variables
+     * to maximise overall probability.
      *
      * @param vertexFromNetwork The vertices to create a Bayesian network from.
      * @return a {@link GradientOptimizer}
@@ -119,7 +121,7 @@ public class GradientOptimizer implements Optimizer {
     }
 
     /**
-     * This attempts to remove a callback function that previously would have been called whenever the optimizer
+     * Removes a callback function that previously would have been called whenever the optimizer
      * evaluated the gradient at a point. If the callback is not registered then this function will do nothing.
      *
      * @param gradientCalculationHandler the function to be removed from the list of gradient evaluation callbacks

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -78,7 +78,7 @@ public class GradientOptimizer implements Optimizer {
      * create a {@link GradientOptimizer} which optimizes the values of latent variables
      * to maximise overall probability.
      *
-     * @param vertexFromNetwork The vertices to create a Bayesian network from.
+     * @param vertexFromNetwork A vertex in the graph to create the Bayesian network from
      * @return a {@link GradientOptimizer}
      */
     public static GradientOptimizer ofConnectedGraph(Vertex<?> vertexFromNetwork) {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -100,16 +100,31 @@ public class GradientOptimizer implements Optimizer {
     @Builder.Default
     private double absoluteThreshold = 1e-8;
 
+    /**
+     * Specifies what formula to use to update the Beta parameter of the Nonlinear conjugate gradient method optimizer.
+     */
     @Builder.Default
     private UpdateFormula updateFormula = UpdateFormula.POLAK_RIBIERE;
 
     private final List<BiConsumer<double[], double[]>> onGradientCalculations = new ArrayList<>();
     private final List<BiConsumer<double[], Double>> onFitnessCalculations = new ArrayList<>();
 
+    /**
+     * Adds a callback to be called whenever the optimizer evaluates the gradient at a point.
+     * @param gradientCalculationHandler a function to be called whenever the optimizer evaluates the gradient at a point.
+     *                                  The double[] argument to the handler represents the point being evaluated.
+     *                                  The double[] argument to the handler represents the gradient of that point.
+     */
     public void addGradientCalculationHandler(BiConsumer<double[], double[]> gradientCalculationHandler) {
         this.onGradientCalculations.add(gradientCalculationHandler);
     }
 
+    /**
+     * This attempts to remove a callback function that previously would have been called whenever the optimizer
+     * evaluated the gradient at a point. If the callback is not registered then this function will do nothing.
+     *
+     * @param gradientCalculationHandler the function to be removed from the list of gradient evaluation callbacks
+     */
     public void removeGradientCalculationHandler(BiConsumer<double[], double[]> gradientCalculationHandler) {
         this.onGradientCalculations.remove(gradientCalculationHandler);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -41,8 +41,8 @@ public class GradientOptimizer implements Optimizer {
         }
     }
     /**
-     * Creates a {@link GradientOptimizer} which optimizes the values of the latent variables to maximise
-     * the overall probability of the Bayesian network.
+     * Creates a {@link GradientOptimizer} which provides methods for optimizing the values of latent variables
+     * of the Bayesian network to maximise probability.
      *
      * @param bayesNet The Bayesian network to run optimization on.
      * @return a {@link GradientOptimizer}
@@ -63,8 +63,8 @@ public class GradientOptimizer implements Optimizer {
 
     /**
      * Creates a Bayesian network from the given vertices and uses this to
-     * create a {@link GradientOptimizer} which optimizes the values of latent variables
-     * to maximise overall probability.
+     * create a {@link GradientOptimizer}. This provides methods for optimizing the values of latent variables
+     * of the Bayesian network to maximise probability.
      *
      * @param vertices The vertices to create a Bayesian network from.
      * @return a {@link GradientOptimizer}
@@ -75,8 +75,8 @@ public class GradientOptimizer implements Optimizer {
 
     /**
      * Creates a Bayesian network from the graph connected to the given vertex and uses this to
-     * create a {@link GradientOptimizer} which optimizes the values of latent variables
-     * to maximise overall probability.
+     * create a {@link GradientOptimizer}. This provides methods for optimizing the values of latent variables
+     * of the Bayesian network to maximise probability.
      *
      * @param vertexFromNetwork A vertex in the graph to create the Bayesian network from
      * @return a {@link GradientOptimizer}

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer;
 import org.apache.commons.math3.exception.NotStrictlyPositiveException;
 import org.apache.commons.math3.optim.InitialGuess;
 import org.apache.commons.math3.optim.MaxEval;
@@ -40,7 +41,13 @@ public class GradientOptimizer implements Optimizer {
             this.apacheMapping = apacheMapping;
         }
     }
-
+    /**
+     * Creates a {@link GradientOptimizer} which optimizes against the unobserved (latent) variables of the Bayesian network.
+     *
+     * @param bayesNet The Bayesian network containing the unobserved variables to be optimized against,
+     *                 and the observed variables to optimize the probability of.
+     * @return a {@link GradientOptimizer}
+     */
     public static GradientOptimizer of(BayesianNetwork bayesNet) {
         List<Vertex> discreteLatentVertices = bayesNet.getDiscreteLatentVertices();
         boolean containsDiscreteLatents = !discreteLatentVertices.isEmpty();
@@ -55,10 +62,24 @@ public class GradientOptimizer implements Optimizer {
             .build();
     }
 
+    /**
+     * Creates a Bayesian network from the given vertices and uses this to
+     * create a {@link GradientOptimizer} which optimizes against the unobserved (latent) variables.
+     *
+     * @param vertices The vertices to create a Bayesian network from.
+     * @return a {@link GradientOptimizer}
+     */
     public static GradientOptimizer of(Collection<? extends Vertex> vertices) {
         return of(new BayesianNetwork(vertices));
     }
 
+    /**
+     * Retrieves the connected graph from the given vertex and uses this to
+     * create a {@link GradientOptimizer} which optimizes against the unobserved (latent) variables.
+     *
+     * @param vertexFromNetwork The vertices to create a Bayesian network from.
+     * @return a {@link GradientOptimizer}
+     */
     public static GradientOptimizer ofConnectedGraph(Vertex<?> vertexFromNetwork) {
         return of(vertexFromNetwork.getConnectedGraph());
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/gradient/GradientOptimizer.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer;
 import org.apache.commons.math3.exception.NotStrictlyPositiveException;
 import org.apache.commons.math3.optim.InitialGuess;
 import org.apache.commons.math3.optim.MaxEval;

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
@@ -166,25 +166,11 @@ public class NonGradientOptimizer implements Optimizer {
         return (int) (2 * Optimizer.totalNumberOfLatentDimensions(latentVertices) + 1);
     }
 
-    /**
-     * This methods detects the vertices in the Bayesian Network that have been observed, and will use MAP estimation to
-     * optimize the observation probability of these vertices.
-     * This method will modify in place the Bayesian network that was used to create this object.
-     *
-     * @return the natural logarithm of the Maximum a posteriori (MAP)
-     */
     @Override
     public double maxAPosteriori() {
         return optimize(bayesianNetwork.getLatentOrObservedVertices());
     }
 
-    /**
-     * This methods detects the vertices in the Bayesian Network that have been observed, and will use Maximum Likelihood
-     * estimation to optimize the observation probability of these vertices.
-     * This method will modify in place the Bayesian network that was used to create this object.
-     *
-     * @return the natural logarithm of the maximum likelihood (MLE)
-     */
     @Override
     public double maxLikelihood() {
         return optimize(bayesianNetwork.getObservedVertices());

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
@@ -22,6 +22,11 @@ import io.improbable.keanu.vertices.Vertex;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * This class can be used to construct a BOBYQA non-gradient optimizer.
+ * This will use a quadratic approximation of the gradient to perform optimization without derivatives.
+ * @see <a href="http://www.damtp.cam.ac.uk/user/na/NA_papers/NA2009_06.pdf">BOBYQA Optimizer</a>
+ */
 @Builder
 public class NonGradientOptimizer implements Optimizer {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
@@ -30,8 +30,8 @@ import lombok.Getter;
 @Builder
 public class NonGradientOptimizer implements Optimizer {
     /**
-     * Creates a BOBYQA {@link NonGradientOptimizer} which optimizes the values of the latent variables of
-     * the Bayesian network to maximise overall probability.
+     * Creates a BOBYQA {@link NonGradientOptimizer} which provides methods for optimizing the values of latent variables
+     * of the Bayesian network to maximise probability.
      *
      * @param bayesNet The Bayesian network to run optimization on.
      * @return a {@link NonGradientOptimizer}
@@ -44,8 +44,8 @@ public class NonGradientOptimizer implements Optimizer {
 
     /**
      * Creates a Bayesian network from the given vertices and uses this to
-     * create a BOBYQA {@link NonGradientOptimizer} which optimizes the values of latent variables
-     * to maximise overall probability.
+     * create a BOBYQA {@link NonGradientOptimizer}. This provides methods for optimizing the
+     * values of latent variables of the Bayesian network to maximise probability.
      *
      * @param vertices The vertices to create a Bayesian network from.
      * @return a {@link NonGradientOptimizer}
@@ -56,7 +56,8 @@ public class NonGradientOptimizer implements Optimizer {
 
     /**
      * Creates a Bayesian network from the graph connected to the given vertex and uses this to
-     * create a BOBYQA {@link NonGradientOptimizer} which optimizes the values of latent variables to maximise overall probability.
+     * create a BOBYQA {@link NonGradientOptimizer}. This provides methods for optimizing the
+     * values of latent variables of the Bayesian network to maximise probability.
      *
      * @param vertexFromNetwork A vertex in the graph to create the Bayesian network from
      * @return a {@link NonGradientOptimizer}

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
@@ -29,17 +29,37 @@ import lombok.Getter;
  */
 @Builder
 public class NonGradientOptimizer implements Optimizer {
-
+    /**
+     * Creates a BOBYQA {@link NonGradientOptimizer} which optimizes against the unobserved (latent) variables of the Bayesian network.
+     *
+     * @param bayesNet The Bayesian network containing the unobserved variables to be optimized against,
+     *                 and the observed variables to optimize the probability of.
+     * @return a {@link NonGradientOptimizer}
+     */
     public static NonGradientOptimizer of(BayesianNetwork bayesNet) {
         return NonGradientOptimizer.builder()
             .bayesianNetwork(bayesNet)
             .build();
     }
 
+    /**
+     * Creates a Bayesian network from the given vertices and uses this to
+     * create a BOBYQA {@link NonGradientOptimizer} which optimizes against the unobserved (latent) variables.
+     *
+     * @param vertices The vertices to create a Bayesian network from.
+     * @return a {@link NonGradientOptimizer}
+     */
     public static NonGradientOptimizer of(Collection<? extends Vertex> vertices) {
         return of(new BayesianNetwork(vertices));
     }
 
+    /**
+     * Retrieves the connected graph from the given vertex and uses this to
+     * create a BOBYQA {@link NonGradientOptimizer} which optimizes against the unobserved (latent) variables.
+     *
+     * @param vertexFromNetwork The vertices to create a Bayesian network from.
+     * @return a {@link NonGradientOptimizer}
+     */
     public static NonGradientOptimizer ofConnectedGraph(Vertex<?> vertexFromNetwork) {
         return of(vertexFromNetwork.getConnectedGraph());
     }
@@ -96,6 +116,7 @@ public class NonGradientOptimizer implements Optimizer {
         }
     }
 
+
     private double optimize(List<Vertex> outputVertices) {
 
         ProgressBar progressBar = Optimizer.createFitnessProgressBar(this);
@@ -146,6 +167,10 @@ public class NonGradientOptimizer implements Optimizer {
     }
 
     /**
+     * This methods detects the vertices in the Bayesian Network that have been observed, and will use MAP estimation to
+     * optimize the observation probability of these vertices.
+     * This method will modify in place the Bayesian network that was used to create this object.
+     *
      * @return the natural logarithm of the Maximum a posteriori (MAP)
      */
     @Override
@@ -154,6 +179,10 @@ public class NonGradientOptimizer implements Optimizer {
     }
 
     /**
+     * This methods detects the vertices in the Bayesian Network that have been observed, and will use Maximum Likelihood
+     * estimation to optimize the observation probability of these vertices.
+     * This method will modify in place the Bayesian network that was used to create this object.
+     *
      * @return the natural logarithm of the maximum likelihood (MLE)
      */
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
@@ -58,7 +58,7 @@ public class NonGradientOptimizer implements Optimizer {
      * Creates a Bayesian network from the graph connected to the given vertex and uses this to
      * create a BOBYQA {@link NonGradientOptimizer} which optimizes the values of latent variables to maximise overall probability.
      *
-     * @param vertexFromNetwork The vertices to create a Bayesian network from.
+     * @param vertexFromNetwork A vertex in the graph to create the Bayesian network from
      * @return a {@link NonGradientOptimizer}
      */
     public static NonGradientOptimizer ofConnectedGraph(Vertex<?> vertexFromNetwork) {

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/variational/optimizer/nongradient/NonGradientOptimizer.java
@@ -30,10 +30,10 @@ import lombok.Getter;
 @Builder
 public class NonGradientOptimizer implements Optimizer {
     /**
-     * Creates a BOBYQA {@link NonGradientOptimizer} which optimizes against the unobserved (latent) variables of the Bayesian network.
+     * Creates a BOBYQA {@link NonGradientOptimizer} which optimizes the values of the latent variables of
+     * the Bayesian network to maximise overall probability.
      *
-     * @param bayesNet The Bayesian network containing the unobserved variables to be optimized against,
-     *                 and the observed variables to optimize the probability of.
+     * @param bayesNet The Bayesian network to run optimization on.
      * @return a {@link NonGradientOptimizer}
      */
     public static NonGradientOptimizer of(BayesianNetwork bayesNet) {
@@ -44,7 +44,8 @@ public class NonGradientOptimizer implements Optimizer {
 
     /**
      * Creates a Bayesian network from the given vertices and uses this to
-     * create a BOBYQA {@link NonGradientOptimizer} which optimizes against the unobserved (latent) variables.
+     * create a BOBYQA {@link NonGradientOptimizer} which optimizes the values of latent variables
+     * to maximise overall probability.
      *
      * @param vertices The vertices to create a Bayesian network from.
      * @return a {@link NonGradientOptimizer}
@@ -54,8 +55,8 @@ public class NonGradientOptimizer implements Optimizer {
     }
 
     /**
-     * Retrieves the connected graph from the given vertex and uses this to
-     * create a BOBYQA {@link NonGradientOptimizer} which optimizes against the unobserved (latent) variables.
+     * Creates a Bayesian network from the graph connected to the given vertex and uses this to
+     * create a BOBYQA {@link NonGradientOptimizer} which optimizes the values of latent variables to maximise overall probability.
      *
      * @param vertexFromNetwork The vertices to create a Bayesian network from.
      * @return a {@link NonGradientOptimizer}


### PR DESCRIPTION
This PR adds some documentation to detail the underlying methods behind the gradient and non-gradient optimizers. It also adds clarification on how the fitness and gradient evaluation callbacks work and how fitness is evaluated as probability of observed vertices.