### PR TITLE
Remove tensors that are used as place holders for shape

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/Tensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/Tensor.java
@@ -34,10 +34,6 @@ public interface Tensor<T> {
         return new GenericTensor<>(value);
     }
 
-    static <T> Tensor<T> placeHolder(long[] shape) {
-        return new GenericTensor<>(shape);
-    }
-
     long[] SCALAR_SHAPE = new long[]{1, 1};
     long[] SCALAR_STRIDE = new long[]{1};
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/BooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/BooleanTensor.java
@@ -23,10 +23,6 @@ public interface BooleanTensor extends Tensor<Boolean>, BooleanOperators<Boolean
         return new SimpleBooleanTensor(scalarValue);
     }
 
-    static BooleanTensor placeHolder(long[] shape) {
-        return new SimpleBooleanTensor(shape);
-    }
-
     static BooleanTensor trues(long... shape) {
         return new SimpleBooleanTensor(true, shape);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -92,10 +92,6 @@ public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, Double
         return new ScalarDoubleTensor(scalarValue);
     }
 
-    static DoubleTensor placeHolder(long[] shape) {
-        return new ScalarDoubleTensor(shape);
-    }
-
     static DoubleTensor concat(int dimension, DoubleTensor... toConcat) {
         INDArray[] concatAsINDArray = new INDArray[toConcat.length];
         for (int i = 0; i < toConcat.length; i++) {

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/generic/GenericTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/generic/GenericTensor.java
@@ -35,15 +35,6 @@ public class GenericTensor<T> implements Tensor<T> {
         this.stride = Tensor.SCALAR_STRIDE;
     }
 
-    /**
-     * @param shape placeholder shape
-     */
-    public GenericTensor(long[] shape) {
-        this.data = null;
-        this.shape = Arrays.copyOf(shape, shape.length);
-        this.stride = TensorShape.getRowFirstStride(shape);
-    }
-
     public GenericTensor(long[] shape, T value) {
         this(fillArray(shape, value), shape);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
@@ -75,10 +75,6 @@ public interface IntegerTensor extends NumberTensor<Integer, IntegerTensor>, Int
         return new ScalarIntegerTensor(scalarValue);
     }
 
-    static IntegerTensor placeHolder(long[] shape) {
-        return new ScalarIntegerTensor(shape);
-    }
-
     static IntegerTensor concat(int dimension, IntegerTensor... toConcat) {
         INDArray[] concatAsINDArray = new INDArray[toConcat.length];
         for (int i = 0; i < toConcat.length; i++) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/Vertex.java
@@ -18,17 +18,25 @@ public abstract class Vertex<T> implements Observable<T> {
     private Set<Vertex> children = Collections.emptySet();
     private Set<Vertex> parents = Collections.emptySet();
     private T value;
+    private long[] initialShape;
     private final Observable<T> observation;
     private VertexLabel label = null;
 
     public Vertex() {
+        this.initialShape = Tensor.SCALAR_SHAPE;
+        this.observation = Observable.observableTypeFor(this.getClass());
+    }
+
+    public Vertex(long[] initialShape) {
+        this.initialShape = initialShape;
         this.observation = Observable.observableTypeFor(this.getClass());
     }
 
     /**
      * Set a label for this vertex.  This allows easy retrieval of this vertex using nothing but a label name.
+     *
      * @param label The label to apply to this vertex.  Uniqueness is only enforced on instantiation of a Bayes Net
-     * @param <V> vertex type
+     * @param <V>   vertex type
      * @return this
      */
     public <V extends Vertex<T>> V setLabel(VertexLabel label) {
@@ -127,7 +135,7 @@ public abstract class Vertex<T> implements Observable<T> {
         if (value instanceof Tensor) {
             return ((Tensor) value).getShape();
         } else {
-            return Tensor.SCALAR_SHAPE;
+            return initialShape;
         }
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/BoolVertex.java
@@ -23,6 +23,10 @@ import java.util.List;
 
 public abstract class BoolVertex extends Vertex<BooleanTensor> implements BooleanOperators<BoolVertex> {
 
+    public BoolVertex(long[] initialShape) {
+        super(initialShape);
+    }
+
     @SafeVarargs
     public final BoolVertex or(Vertex<BooleanTensor>... those) {
         if (those.length == 0) return this;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/BoolProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/BoolProxyVertex.java
@@ -24,7 +24,7 @@ public class BoolProxyVertex extends BoolVertex implements ProxyVertex<BoolVerte
     }
 
     public BoolProxyVertex(long[] shape, VertexLabel label) {
-        this.setValue(BooleanTensor.placeHolder(shape));
+        super(shape);
         this.setLabel(label);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/BooleanIfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/BooleanIfVertex.java
@@ -16,11 +16,11 @@ public class BooleanIfVertex extends BoolVertex implements NonProbabilistic<Bool
                            Vertex<? extends BooleanTensor> predicate,
                            Vertex<? extends BooleanTensor> thn,
                            Vertex<? extends BooleanTensor> els) {
+        super(shape);
         this.predicate = predicate;
         this.thn = thn;
         this.els = els;
         setParents(predicate, thn, els);
-        setValue(BooleanTensor.placeHolder(shape));
     }
 
     protected BooleanTensor op(BooleanTensor predicate, BooleanTensor thn, BooleanTensor els) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/CastBoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/CastBoolVertex.java
@@ -11,6 +11,7 @@ public class CastBoolVertex extends BoolVertex implements NonProbabilistic<Boole
     private final Vertex<? extends BooleanTensor> inputVertex;
 
     public CastBoolVertex(Vertex<? extends BooleanTensor> inputVertex) {
+        super(inputVertex.getShape());
         this.inputVertex = inputVertex;
         setParents(inputVertex);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/ConstantBoolVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/ConstantBoolVertex.java
@@ -13,6 +13,7 @@ public class ConstantBoolVertex extends BoolVertex implements NonProbabilistic<B
 
     @ExportVertexToPythonBindings
     public ConstantBoolVertex(BooleanTensor constant) {
+        super(constant.getShape());
         setValue(constant);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/BoolModelResultVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/BoolModelResultVertex.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.bool.nonprobabilistic.operators;
 
+import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
@@ -18,6 +19,7 @@ public class BoolModelResultVertex extends BoolVertex implements ModelResultProv
     private final ModelResult<BooleanTensor> delegate;
 
     public BoolModelResultVertex(ModelVertex model, VertexLabel label) {
+        super(Tensor.SCALAR_SHAPE);
         delegate = new ModelResult<>(model, label);
         setParents((Vertex) model);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/NumericalEqualsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/NumericalEqualsVertex.java
@@ -20,6 +20,7 @@ public class NumericalEqualsVertex extends BoolVertex implements NonProbabilisti
     public NumericalEqualsVertex(Vertex<? extends NumberTensor> a,
                                  Vertex<? extends NumberTensor> b,
                                  Vertex<? extends NumberTensor> epsilon) {
+        super(a.getShape());
         this.a = a;
         this.b = b;
         this.epsilon = epsilon;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/binary/BoolBinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/binary/BoolBinaryOpVertex.java
@@ -19,10 +19,10 @@ public abstract class BoolBinaryOpVertex<A extends Tensor, B extends Tensor> ext
     }
 
     public BoolBinaryOpVertex(long[] shape, Vertex<A> a, Vertex<B> b) {
+        super(shape);
         this.a = a;
         this.b = b;
         setParents(a, b);
-        setValue(BooleanTensor.placeHolder(shape));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolConcatenationVertex.java
@@ -23,28 +23,27 @@ public class BoolConcatenationVertex extends BoolVertex implements NonProbabilis
      * @param input     the input vertices to concatenate
      */
     public BoolConcatenationVertex(int dimension, BoolVertex... input) {
+        super(checkShapesCanBeConcatenated(dimension, extractFromInputs(long[].class, Vertex::getShape, input)));
         this.dimension = dimension;
         this.input = input;
         setParents(input);
-        long[][] shapes = extractFromInputs(long[].class, Vertex::getShape);
-        setValue(BooleanTensor.placeHolder(checkShapesCanBeConcatenated(dimension, shapes)));
     }
 
     @Override
     public BooleanTensor calculate() {
-        return op(extractFromInputs(BooleanTensor.class, Vertex::getValue));
+        return op(extractFromInputs(BooleanTensor.class, Vertex::getValue, input));
     }
 
     @Override
     public BooleanTensor sample(KeanuRandom random) {
-        return op(extractFromInputs(BooleanTensor.class, Vertex::sample));
+        return op(extractFromInputs(BooleanTensor.class, Vertex::sample, input));
     }
 
     protected BooleanTensor op(BooleanTensor... inputs) {
         return BooleanTensor.concat(dimension, inputs);
     }
 
-    private <T> T[] extractFromInputs(Class<T> clazz, Function<Vertex<BooleanTensor>, T> func) {
+    private static <T> T[] extractFromInputs(Class<T> clazz, Function<Vertex<BooleanTensor>, T> func, BoolVertex[] input) {
         T[] extract = (T[]) Array.newInstance(clazz, input.length);
         for (int i = 0; i < input.length; i++) {
             extract[i] = func.apply(input[i]);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolReduceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/multiple/BoolReduceVertex.java
@@ -20,6 +20,7 @@ public class BoolReduceVertex extends BoolVertex implements NonProbabilistic<Boo
 
     public BoolReduceVertex(long[] shape, Collection<Vertex<BooleanTensor>> input,
                             BiFunction<BooleanTensor, BooleanTensor, BooleanTensor> reduceFunction) {
+        super(shape);
         if (input.size() < 2) {
             throw new IllegalArgumentException("BoolReduceVertex should have at least two input vertices, called with " + input.size());
         }
@@ -27,7 +28,6 @@ public class BoolReduceVertex extends BoolVertex implements NonProbabilistic<Boo
         this.inputs = new ArrayList<>(input);
         this.reduceFunction = reduceFunction;
         setParents(inputs);
-        setValue(BooleanTensor.placeHolder(shape));
     }
 
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/unary/BoolUnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/nonprobabilistic/operators/unary/BoolUnaryOpVertex.java
@@ -16,9 +16,9 @@ public abstract class BoolUnaryOpVertex<T extends Tensor> extends BoolVertex imp
     }
 
     public BoolUnaryOpVertex(long[] shape, Vertex<T> a) {
+        super(shape);
         this.a = a;
         setParents(a);
-        setValue(BooleanTensor.placeHolder(shape));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/bool/probabilistic/BernoulliVertex.java
@@ -29,10 +29,10 @@ public class BernoulliVertex extends BoolVertex implements ProbabilisticBoolean 
      * @param probTrue the probability the bernoulli returns true
      */
     public BernoulliVertex(long[] shape, Vertex<DoubleTensor> probTrue) {
+        super(shape);
         checkTensorsMatchNonScalarShapeOrAreScalar(shape, probTrue.getShape());
         this.probTrue = probTrue;
         setParents(probTrue);
-        setValue(BooleanTensor.placeHolder(shape));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -53,6 +53,10 @@ import java.util.function.Function;
 
 public abstract class DoubleVertex extends Vertex<DoubleTensor> implements DoubleOperators<DoubleVertex>, Differentiable {
 
+    public DoubleVertex(long[] initialShape) {
+        super(initialShape);
+    }
+
     /**
      * @param dimension dimension to concat along. Negative dimension indexing is not supported.
      * @param toConcat  array of things to concat. Must match in all dimensions except for the provided

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -17,6 +17,7 @@ public class CastDoubleVertex extends DoubleVertex implements NonProbabilistic<D
 
     @ExportVertexToPythonBindings
     public CastDoubleVertex(Vertex<? extends NumberTensor> inputVertex) {
+        super(inputVertex.getShape());
         this.inputVertex = inputVertex;
         setParents(inputVertex);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
@@ -16,6 +16,7 @@ public class ConstantDoubleVertex extends DoubleVertex implements Differentiable
 
     @ExportVertexToPythonBindings
     public ConstantDoubleVertex(DoubleTensor constant) {
+        super(constant.getShape());
         setValue(constant);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleCPTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleCPTVertex.java
@@ -22,6 +22,7 @@ public class DoubleCPTVertex extends DoubleVertex implements Differentiable, Non
     public DoubleCPTVertex(List<Vertex<? extends Tensor<Boolean>>> inputs,
                            Map<CPTCondition, DoubleVertex> conditions,
                            DoubleVertex defaultResult) {
+        super(defaultResult.getShape());
         this.inputs = inputs;
         this.conditions = conditions;
         this.defaultResult = defaultResult;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
@@ -23,11 +23,11 @@ public class DoubleIfVertex extends DoubleVertex implements NonProbabilistic<Dou
                           Vertex<? extends BooleanTensor> predicate,
                           Vertex<? extends DoubleTensor> thn,
                           Vertex<? extends DoubleTensor> els) {
+        super(shape);
         this.predicate = predicate;
         this.thn = thn;
         this.els = els;
         setParents(predicate, thn, els);
-        setValue(DoubleTensor.placeHolder(shape));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleModelResultVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleModelResultVertex.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.dbl.nonprobabilistic;
 
+import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
@@ -18,6 +19,7 @@ public class DoubleModelResultVertex extends DoubleVertex implements ModelResult
     private final ModelResult<DoubleTensor> delegate;
 
     public DoubleModelResultVertex(ModelVertex model, VertexLabel label) {
+        super(Tensor.SCALAR_SHAPE);
         this.delegate = new ModelResult<>(model, label);
         setParents((Vertex) model);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleProxyVertex.java
@@ -29,7 +29,7 @@ public class DoubleProxyVertex extends DoubleVertex implements ProxyVertex<Doubl
     }
 
     public DoubleProxyVertex(long[] shape, VertexLabel label) {
-        this.setValue(DoubleTensor.placeHolder(shape));
+        super(shape);
         this.setLabel(label);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -27,13 +27,13 @@ public class DoubleBinaryOpLambda<A, B> extends DoubleVertex implements NonProba
                                 BiFunction<A, B, DoubleTensor> op,
                                 Function<Map<Vertex, PartialDerivatives>, PartialDerivatives> forwardModeAutoDiffLambda,
                                 Function<PartialDerivatives, Map<Vertex, PartialDerivatives>> reverseModeAutoDiffLambda) {
+        super(shape);
         this.left = left;
         this.right = right;
         this.op = op;
         this.forwardModeAutoDiffLambda = forwardModeAutoDiffLambda;
         this.reverseModeAutoDiffLambda = reverseModeAutoDiffLambda;
         setParents(left, right);
-        setValue(DoubleTensor.placeHolder(shape));
     }
 
     public DoubleBinaryOpLambda(long[] shape, Vertex<A> left, Vertex<B> right, BiFunction<A, B, DoubleTensor> op) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpVertex.java
@@ -37,10 +37,10 @@ public abstract class DoubleBinaryOpVertex extends DoubleVertex implements NonPr
      * @param right a vertex
      */
     public DoubleBinaryOpVertex(long[] shape, DoubleVertex left, DoubleVertex right) {
+        super(shape);
         this.left = left;
         this.right = right;
         setParents(left, right);
-        setValue(DoubleTensor.placeHolder(shape));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertex.java
@@ -33,11 +33,10 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
      * @param operands  the operands vertices to concatenate
      */
     public ConcatenationVertex(int dimension, DoubleVertex... operands) {
+        super(checkShapesCanBeConcatenated(dimension, extractFromInputs(long[].class, Vertex::getShape, operands)));
         this.dimension = dimension;
         this.operands = operands;
         setParents(operands);
-        long[][] shapes = extractFromInputs(long[].class, Vertex::getShape);
-        setValue(DoubleTensor.placeHolder(checkShapesCanBeConcatenated(dimension, shapes)));
     }
 
     @Override
@@ -160,19 +159,19 @@ public class ConcatenationVertex extends DoubleVertex implements Differentiable,
 
     @Override
     public DoubleTensor sample(KeanuRandom random) {
-        return op(extractFromInputs(DoubleTensor.class, Vertex::sample));
+        return op(extractFromInputs(DoubleTensor.class, Vertex::sample, operands));
     }
 
     @Override
     public DoubleTensor calculate() {
-        return op(extractFromInputs(DoubleTensor.class, Vertex::getValue));
+        return op(extractFromInputs(DoubleTensor.class, Vertex::getValue, operands));
     }
 
     protected DoubleTensor op(DoubleTensor... inputs) {
         return DoubleTensor.concat(dimension, inputs);
     }
 
-    private <T> T[] extractFromInputs(Class<T> clazz, Function<Vertex<DoubleTensor>, T> func) {
+    private static <T> T[] extractFromInputs(Class<T> clazz, Function<Vertex<DoubleTensor>, T> func, DoubleVertex[] operands) {
         T[] extract = (T[]) Array.newInstance(clazz, operands.length);
         for (int i = 0; i < operands.length; i++) {
             extract[i] = func.apply(operands[i]);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ReduceVertex.java
@@ -32,6 +32,7 @@ public class ReduceVertex extends DoubleVertex implements Differentiable, NonPro
                         BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> reduceFunction,
                         Supplier<PartialDerivatives> forwardModeAutoDiffLambda,
                         Function<PartialDerivatives, Map<Vertex, PartialDerivatives>> reverseModeAutoDiffLambda) {
+        super(shape);
         if (inputs.size() < 2) {
             throw new IllegalArgumentException("ReduceVertex should have at least two input vertices, called with " + inputs.size());
         }
@@ -41,7 +42,6 @@ public class ReduceVertex extends DoubleVertex implements Differentiable, NonPro
         this.forwardModeAutoDiffLambda = forwardModeAutoDiffLambda;
         this.reverseModeAutoDiffLambda = reverseModeAutoDiffLambda;
         setParents(inputs);
-        setValue(DoubleTensor.placeHolder(shape));
     }
 
     public ReduceVertex(long[] shape, BiFunction<DoubleTensor, DoubleTensor, DoubleTensor> reduceFunction,
@@ -60,7 +60,7 @@ public class ReduceVertex extends DoubleVertex implements Differentiable, NonPro
      * Reduce vertex that assumes shape as inputs
      *
      * @param reduceFunction            reduce function
-     * @param forwardModeAutoDiffLambda        auto diff supplier
+     * @param forwardModeAutoDiffLambda auto diff supplier
      * @param reverseModeAutoDiffLambda function for returning diff
      * @param input                     input vertices to reduce
      */

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpLambda.java
@@ -22,12 +22,12 @@ public class DoubleUnaryOpLambda<IN> extends DoubleVertex implements Differentia
                                Function<IN, DoubleTensor> op,
                                Function<Map<Vertex, PartialDerivatives>, PartialDerivatives> forwardModeAutoDiffLambda,
                                Function<PartialDerivatives, Map<Vertex, PartialDerivatives>> reverseModeAutoDiffLambda) {
+        super(shape);
         this.inputVertex = inputVertex;
         this.op = op;
         this.forwardModeAutoDiffLambda = forwardModeAutoDiffLambda;
         this.reverseModeAutoDiffLambda = reverseModeAutoDiffLambda;
         setParents(inputVertex);
-        setValue(DoubleTensor.placeHolder(shape));
     }
 
     public DoubleUnaryOpLambda(long[] shape, Vertex<IN> inputVertex, Function<IN, DoubleTensor> op) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpVertex.java
@@ -29,9 +29,9 @@ public abstract class DoubleUnaryOpVertex extends DoubleVertex implements NonPro
      * @param inputVertex the input vertex
      */
     public DoubleUnaryOpVertex(long[] shape, DoubleVertex inputVertex) {
+        super(shape);
         this.inputVertex = inputVertex;
         setParents(inputVertex);
-        setValue(DoubleTensor.placeHolder(shape));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -34,13 +34,12 @@ public class BetaVertex extends DoubleVertex implements ProbabilisticDouble {
      * @param beta        the beta of the Beta with either the same tensorShape as specified for this vertex or a scalar
      */
     public BetaVertex(long[] tensorShape, DoubleVertex alpha, DoubleVertex beta) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, alpha.getShape(), beta.getShape());
 
         this.alpha = alpha;
         this.beta = beta;
         setParents(alpha, beta);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     ContinuousDistribution distribution() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
@@ -34,13 +34,12 @@ public class CauchyVertex extends DoubleVertex implements ProbabilisticDouble {
      * @param scale       the scale of the Cauchy with either the same tensorShape as specified for this vertex or a scalar
      */
     public CauchyVertex(long[] tensorShape, DoubleVertex location, DoubleVertex scale) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, location.getShape(), scale.getShape());
 
         this.location = location;
         this.scale = scale;
         setParents(location, scale);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     @ExportVertexToPythonBindings

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -27,11 +27,11 @@ public class ChiSquaredVertex extends DoubleVertex implements ProbabilisticDoubl
      * @param k           the number of degrees of freedom
      */
     public ChiSquaredVertex(long[] tensorShape, IntegerVertex k) {
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, k.getShape());
 
         this.k = k;
         setParents(k);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     public ChiSquaredVertex(long[] tensorShape, int k) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
@@ -26,12 +26,12 @@ public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble
      * @param concentration the concentration values of the dirichlet
      */
     public DirichletVertex(long[] tensorShape, DoubleVertex concentration) {
+        super(tensorShape);
         this.concentration = concentration;
         if (concentration.getValue().getLength() < 2) {
             throw new IllegalArgumentException("Dirichlet must be comprised of more than one concentration parameter");
         }
         setParents(concentration);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -34,12 +34,11 @@ public class ExponentialVertex extends DoubleVertex implements ProbabilisticDoub
      *                    vertex or scalar.
      */
     public ExponentialVertex(long[] tensorShape, DoubleVertex lambda) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, lambda.getShape());
 
         this.lambda = lambda;
         setParents(lambda);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -34,13 +34,12 @@ public class GammaVertex extends DoubleVertex implements ProbabilisticDouble {
      * @param k           the k (shape) of the Gamma with either the same shape as specified for this vertex
      */
     public GammaVertex(long[] tensorShape, DoubleVertex theta, DoubleVertex k) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, theta.getShape(), k.getShape());
 
         this.theta = theta;
         this.k = k;
         setParents(theta, k);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -35,13 +35,12 @@ public class GaussianVertex extends DoubleVertex implements ProbabilisticDouble 
      * @param sigma       the sigma of the Gaussian with either the same tensorShape as specified for this vertex or a scalar
      */
     public GaussianVertex(long[] tensorShape, DoubleVertex mu, DoubleVertex sigma) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, mu.getShape(), sigma.getShape());
 
         this.mu = mu;
         this.sigma = sigma;
         setParents(mu, sigma);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     @ExportVertexToPythonBindings

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -33,13 +33,12 @@ public class InverseGammaVertex extends DoubleVertex implements ProbabilisticDou
      * @param beta        the beta of the Inverse Gamma with either the same shape as specified for this vertex or alpha scalar
      */
     public InverseGammaVertex(long[] tensorShape, DoubleVertex alpha, DoubleVertex beta) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, alpha.getShape(), beta.getShape());
 
         this.alpha = alpha;
         this.beta = beta;
         setParents(alpha, beta);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
 import io.improbable.keanu.distributions.continuous.Uniform;
+import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
@@ -17,6 +18,7 @@ public class KDEVertex extends DoubleVertex implements ProbabilisticDouble {
     private DoubleTensor samples;
 
     public KDEVertex(DoubleTensor samples, double bandwidth) {
+        super(Tensor.SCALAR_SHAPE);
         if (samples.getLength() == 0) {
             throw new IllegalStateException("The provided tensor of samples is empty!");
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -33,13 +33,12 @@ public class LaplaceVertex extends DoubleVertex implements ProbabilisticDouble {
      * @param beta        the beta of the Laplace with either the same shape as specified for this vertex or a scalar
      */
     public LaplaceVertex(long[] tensorShape, DoubleVertex mu, DoubleVertex beta) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, mu.getShape(), beta.getShape());
 
         this.mu = mu;
         this.beta = beta;
         setParents(mu, beta);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     public LaplaceVertex(long[] shape, DoubleVertex mu, double beta) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -33,13 +33,12 @@ public class LogNormalVertex extends DoubleVertex implements ProbabilisticDouble
      * @param sigma       the sigma of the Logistic with either the same shape as specified for this vertex or mu scalar
      */
     public LogNormalVertex(long[] tensorShape, DoubleVertex mu, DoubleVertex sigma) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, mu.getShape(), sigma.getShape());
 
         this.mu = mu;
         this.sigma = sigma;
         setParents(mu, sigma);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     public LogNormalVertex(long[] tensorShape, DoubleVertex mu, double sigma) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -33,13 +33,12 @@ public class LogisticVertex extends DoubleVertex implements ProbabilisticDouble 
      * @param s           the s (scale) of the Logistic with either the same shape as specified for this vertex or mu scalar
      */
     public LogisticVertex(long[] tensorShape, DoubleVertex mu, DoubleVertex s) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, mu.getShape(), s.getShape());
 
         this.mu = mu;
         this.s = s;
         setParents(mu, s);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     public LogisticVertex(DoubleVertex mu, DoubleVertex s) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -24,13 +24,12 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Probabil
      * @param covariance the covariance matrix of the Multivariate Gaussian
      */
     public MultivariateGaussianVertex(long[] shape, DoubleVertex mu, DoubleVertex covariance) {
-
+        super(shape);
         checkValidMultivariateShape(mu.getShape(), covariance.getShape());
 
         this.mu = mu;
         this.covariance = covariance;
         setParents(mu, covariance);
-        setValue(DoubleTensor.placeHolder(shape));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
@@ -34,12 +34,12 @@ public class ParetoVertex extends DoubleVertex implements ProbabilisticDouble {
      * @param scale       the scale value(s) of the Pareto.  Must either be the same shape as tensorShape or a scalar
      */
     public ParetoVertex(long[] tensorShape, DoubleVertex location, DoubleVertex scale) {
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, location.getShape(), scale.getShape());
 
         this.scale = scale;
         this.location = location;
         setParents(location, scale);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     public ParetoVertex(DoubleVertex location, DoubleVertex scale) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -36,13 +36,13 @@ public class SmoothUniformVertex extends DoubleVertex implements ProbabilisticDo
      * @param edgeSharpness the edge sharpness of the Smooth Uniform
      */
     public SmoothUniformVertex(long[] tensorShape, DoubleVertex xMin, DoubleVertex xMax, double edgeSharpness) {
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, xMin.getShape(), xMax.getShape());
 
         this.xMin = xMin;
         this.xMax = xMax;
         this.edgeSharpness = edgeSharpness;
         setParents(xMin, xMax);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -30,10 +30,10 @@ public class StudentTVertex extends DoubleVertex implements ProbabilisticDouble 
      * @param v           Degrees of Freedom
      */
     public StudentTVertex(long[] tensorShape, IntegerVertex v) {
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, v.getShape());
         this.v = v;
         setParents(v);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     public StudentTVertex(long[] tensorShape, int v) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -30,14 +30,13 @@ public class TriangularVertex extends DoubleVertex implements ProbabilisticDoubl
      * @param c           the center of the Triangular with either the same shape as specified for this vertex or a scalar
      */
     public TriangularVertex(long[] tensorShape, DoubleVertex xMin, DoubleVertex xMax, DoubleVertex c) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, xMin.getShape(), xMax.getShape(), c.getShape());
 
         this.xMin = xMin;
         this.xMax = xMax;
         this.c = c;
         setParents(xMin, xMax, c);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     public TriangularVertex(long[] tensorShape, DoubleVertex xMin, DoubleVertex xMax, double c) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -31,13 +31,12 @@ public class UniformVertex extends DoubleVertex implements ProbabilisticDouble {
      * @param xMax        the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
      */
     public UniformVertex(long[] tensorShape, DoubleVertex xMin, DoubleVertex xMax) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, xMin.getShape(), xMax.getShape());
 
         this.xMin = xMin;
         this.xMax = xMax;
         setParents(xMin, xMax);
-        setValue(DoubleTensor.placeHolder(tensorShape));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/IfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/IfVertex.java
@@ -16,11 +16,11 @@ public class IfVertex<T> extends Vertex<Tensor<T>> implements NonProbabilistic<T
                     Vertex<? extends BooleanTensor> predicate,
                     Vertex<? extends Tensor<T>> thn,
                     Vertex<? extends Tensor<T>> els) {
+        super(shape);
         this.predicate = predicate;
         this.thn = thn;
         this.els = els;
         setParents(predicate, thn, els);
-        setValue(Tensor.placeHolder(shape));
     }
 
     private Tensor<T> op(BooleanTensor predicate, Tensor<T> thn, Tensor<T> els) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/GenericSliceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/GenericSliceVertex.java
@@ -19,10 +19,9 @@ public class GenericSliceVertex<T> extends UnaryOpVertex<Tensor<T>, Tensor<T>> {
      * @param index       the index of extraction
      */
     public GenericSliceVertex(Vertex<Tensor<T>> inputVertex, int dimension, int index) {
-        super(inputVertex);
+        super(shapeSlice(dimension, inputVertex.getShape()), inputVertex);
         this.dimension = dimension;
         this.index = index;
-        setValue(Tensor.placeHolder(shapeSlice(dimension, inputVertex.getShape())));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/GenericTakeVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/GenericTakeVertex.java
@@ -5,7 +5,7 @@ import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
-public class GenericTakeVertex<T> extends UnaryOpVertex<Tensor<T>,Tensor<T>> {
+public class GenericTakeVertex<T> extends UnaryOpVertex<Tensor<T>, Tensor<T>> {
 
     private final long[] index;
 
@@ -16,10 +16,9 @@ public class GenericTakeVertex<T> extends UnaryOpVertex<Tensor<T>,Tensor<T>> {
      * @param index       the index of extraction
      */
     public GenericTakeVertex(Vertex<Tensor<T>> inputVertex, long... index) {
-        super(inputVertex);
+        super(Tensor.SCALAR_SHAPE, inputVertex);
         TensorShapeValidation.checkIndexIsValid(inputVertex.getShape(), index);
         this.index = index;
-        setValue(Tensor.placeHolder(Tensor.SCALAR_SHAPE));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/UnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/UnaryOpLambda.java
@@ -8,8 +8,8 @@ public class UnaryOpLambda<IN, OUT> extends UnaryOpVertex<IN, OUT> {
 
     private Function<IN, OUT> op;
 
-    public UnaryOpLambda(Vertex<IN> inputVertex, Function<IN, OUT> op) {
-        super(inputVertex);
+    public UnaryOpLambda(long[] shape, Vertex<IN> inputVertex, Function<IN, OUT> op) {
+        super(shape, inputVertex);
         this.op = op;
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/UnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/UnaryOpVertex.java
@@ -9,7 +9,8 @@ public abstract class UnaryOpVertex<IN, OUT> extends Vertex<OUT> implements NonP
 
     protected final Vertex<IN> inputVertex;
 
-    public UnaryOpVertex(Vertex<IN> inputVertex) {
+    public UnaryOpVertex(long[] shape, Vertex<IN> inputVertex) {
+        super(shape);
         this.inputVertex = inputVertex;
         setParents(inputVertex);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/IntegerVertex.java
@@ -6,16 +6,36 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.bool.BoolVertex;
-import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.*;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.EqualsVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.GreaterThanOrEqualVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.GreaterThanVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.LessThanOrEqualVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.LessThanVertex;
+import io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.NotEqualsVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.CastIntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.*;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerAdditionVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerDifferenceVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerDivisionVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerMaxVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerMinVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerMultiplicationVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerPowerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.multiple.IntegerConcatenationVertex;
-import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.*;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerAbsVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerReshapeVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerSliceVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerSumVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerTakeVertex;
+import io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.unary.IntegerUnaryOpLambda;
 
 import java.util.function.Function;
 
 public abstract class IntegerVertex extends Vertex<IntegerTensor> implements IntegerOperators<IntegerVertex> {
+
+    public IntegerVertex(long[] shape) {
+        super(shape);
+    }
 
     public static IntegerVertex concat(int dimension, IntegerVertex... toConcat) {
         return new IntegerConcatenationVertex(dimension, toConcat);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/CastIntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/CastIntegerVertex.java
@@ -11,6 +11,7 @@ public class CastIntegerVertex extends IntegerVertex implements NonProbabilistic
     private final Vertex<IntegerTensor> inputVertex;
 
     public CastIntegerVertex(Vertex<IntegerTensor> inputVertex) {
+        super(inputVertex.getShape());
         this.inputVertex = inputVertex;
         setParents(inputVertex);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/ConstantIntegerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/ConstantIntegerVertex.java
@@ -11,6 +11,7 @@ public class ConstantIntegerVertex extends IntegerVertex implements NonProbabili
 
     @ExportVertexToPythonBindings
     public ConstantIntegerVertex(IntegerTensor constant) {
+        super(constant.getShape());
         setValue(constant);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/IntegerProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/IntegerProxyVertex.java
@@ -24,7 +24,7 @@ public class IntegerProxyVertex extends IntegerVertex implements ProxyVertex<Int
     }
 
     public IntegerProxyVertex(long[] shape, VertexLabel label) {
-        setValue(IntegerTensor.placeHolder(shape));
+        super(shape);
         setLabel(label);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/IntegerModelResultVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/IntegerModelResultVertex.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices.intgr.nonprobabilistic.operators;
 
+import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.intgr.IntegerTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
@@ -18,6 +19,7 @@ public class IntegerModelResultVertex extends IntegerVertex implements ModelResu
     private final ModelResult<IntegerTensor> delegate;
 
     public IntegerModelResultVertex(ModelVertex model, VertexLabel label) {
+        super(Tensor.SCALAR_SHAPE);
         this.delegate = new ModelResult<>(model, label);
         setParents((Vertex) model);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/binary/IntegerBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/binary/IntegerBinaryOpLambda.java
@@ -21,11 +21,11 @@ public class IntegerBinaryOpLambda<A, B> extends IntegerVertex implements NonPro
                                  Vertex<A> left,
                                  Vertex<B> right,
                                  BiFunction<A, B, IntegerTensor> op) {
+        super(shape);
         this.left = left;
         this.right = right;
         this.op = op;
         setParents(left, right);
-        setValue(IntegerTensor.placeHolder(shape));
     }
 
     public IntegerBinaryOpLambda(Vertex<A> left, Vertex<B> right, BiFunction<A, B, IntegerTensor> op) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/binary/IntegerBinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/binary/IntegerBinaryOpVertex.java
@@ -31,10 +31,10 @@ public abstract class IntegerBinaryOpVertex extends IntegerVertex implements Non
      * @param b     second input vertex
      */
     public IntegerBinaryOpVertex(long[] shape, IntegerVertex a, IntegerVertex b) {
+        super(shape);
         this.a = a;
         this.b = b;
         setParents(a, b);
-        setValue(IntegerTensor.placeHolder(shape));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/multiple/IntegerConcatenationVertex.java
@@ -23,28 +23,27 @@ public class IntegerConcatenationVertex extends IntegerVertex implements NonProb
      * @param input     the input vertices to concatenate
      */
     public IntegerConcatenationVertex(int dimension, IntegerVertex... input) {
+        super(checkShapesCanBeConcatenated(dimension, extractFromInputs(long[].class, Vertex::getShape, input)));
         this.dimension = dimension;
         this.input = input;
         setParents(input);
-        long[][] shapes = extractFromInputs(long[].class, Vertex::getShape);
-        setValue(IntegerTensor.placeHolder(checkShapesCanBeConcatenated(dimension, shapes)));
     }
 
     @Override
     public IntegerTensor calculate() {
-        return op(extractFromInputs(IntegerTensor.class, Vertex::getValue));
+        return op(extractFromInputs(IntegerTensor.class, Vertex::getValue, input));
     }
 
     @Override
     public IntegerTensor sample(KeanuRandom random) {
-        return op(extractFromInputs(IntegerTensor.class, Vertex::sample));
+        return op(extractFromInputs(IntegerTensor.class, Vertex::sample, input));
     }
 
     private IntegerTensor op(IntegerTensor... inputs) {
         return IntegerTensor.concat(dimension, inputs);
     }
 
-    private <T> T[] extractFromInputs(Class<T> clazz, Function<Vertex<IntegerTensor>, T> func) {
+    private static <T> T[] extractFromInputs(Class<T> clazz, Function<Vertex<IntegerTensor>, T> func, IntegerVertex[] input) {
         T[] extract = (T[]) Array.newInstance(clazz, input.length);
         for (int i = 0; i < input.length; i++) {
             extract[i] = func.apply(input[i]);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/unary/IntegerUnaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/unary/IntegerUnaryOpLambda.java
@@ -14,10 +14,10 @@ public class IntegerUnaryOpLambda<IN> extends IntegerVertex implements NonProbab
     protected final Function<IN, IntegerTensor> op;
 
     public IntegerUnaryOpLambda(long[] shape, Vertex<IN> inputVertex, Function<IN, IntegerTensor> op) {
+        super(shape);
         this.inputVertex = inputVertex;
         this.op = op;
         setParents(inputVertex);
-        setValue(IntegerTensor.placeHolder(shape));
     }
 
     public IntegerUnaryOpLambda(Vertex<IN> inputVertex, Function<IN, IntegerTensor> op) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/unary/IntegerUnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/nonprobabilistic/operators/unary/IntegerUnaryOpVertex.java
@@ -25,9 +25,9 @@ public abstract class IntegerUnaryOpVertex extends IntegerVertex implements NonP
      * @param inputVertex the input vertex
      */
     public IntegerUnaryOpVertex(long[] shape, IntegerVertex inputVertex) {
+        super(shape);
         this.inputVertex = inputVertex;
         setParents(inputVertex);
-        setValue(IntegerTensor.placeHolder(shape));
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/BinomialVertex.java
@@ -22,13 +22,12 @@ public class BinomialVertex extends IntegerVertex implements ProbabilisticIntege
     private final IntegerVertex n;
 
     public BinomialVertex(long[] tensorShape, DoubleVertex p, IntegerVertex n) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, p.getShape(), n.getShape());
         this.p = p;
         this.n = n;
 
         setParents(p, n);
-        setValue(IntegerTensor.placeHolder(tensorShape));
     }
 
     public BinomialVertex(long[] tensorShape, double p, IntegerVertex n) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/MultinomialVertex.java
@@ -21,7 +21,7 @@ public class MultinomialVertex extends IntegerVertex implements ProbabilisticInt
     private final IntegerVertex n;
 
     public MultinomialVertex(long[] tensorShape, IntegerVertex n, DoubleVertex p) {
-
+        super(tensorShape);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, n.getShape());
         long[] pShapeExcludingFirstDimension = ArrayUtils.remove(p.getShape(), 0);
         checkTensorsMatchNonScalarShapeOrAreScalar(tensorShape, pShapeExcludingFirstDimension);
@@ -31,7 +31,6 @@ public class MultinomialVertex extends IntegerVertex implements ProbabilisticInt
 
         setParents(p);
         addParent(n);
-        setValue(IntegerTensor.placeHolder(tensorShape));
     }
 
     public MultinomialVertex(IntegerVertex n, DoubleVertex p) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/PoissonVertex.java
@@ -32,12 +32,11 @@ public class PoissonVertex extends IntegerVertex implements ProbabilisticInteger
      * @param mu    the mu of the Poisson with either the same shape as specified for this vertex or a scalar
      */
     public PoissonVertex(long[] shape, DoubleVertex mu) {
-
+        super(shape);
         checkTensorsMatchNonScalarShapeOrAreScalar(shape, mu.getShape());
 
         this.mu = mu;
         setParents(mu);
-        setValue(IntegerTensor.placeHolder(shape));
     }
 
     public PoissonVertex(long[] shape, double mu) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/intgr/probabilistic/UniformIntVertex.java
@@ -27,13 +27,12 @@ public class UniformIntVertex extends IntegerVertex implements ProbabilisticInte
      * @param max   The exclusive upper bound.
      */
     public UniformIntVertex(long[] shape, IntegerVertex min, IntegerVertex max) {
-
+        super(shape);
         checkTensorsMatchNonScalarShapeOrAreScalar(shape, min.getShape(), max.getShape());
 
         this.min = min;
         this.max = max;
         setParents(min, max);
-        setValue(IntegerTensor.placeHolder(shape));
     }
 
     public UniformIntVertex(long[] shape, int min, int max) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/model/LambdaModelVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/model/LambdaModelVertex.java
@@ -36,6 +36,7 @@ public class LambdaModelVertex extends DoubleVertex implements ModelVertex<Doubl
     public LambdaModelVertex(Map<VertexLabel, Vertex<? extends Tensor>> inputs,
                              Consumer<Map<VertexLabel, Vertex<? extends Tensor>>> executor,
                              Function<Map<VertexLabel, Vertex<? extends Tensor>>, Map<VertexLabel, Tensor>> updateValues) {
+        super(Tensor.SCALAR_SHAPE);
         this.inputs = inputs;
         this.outputs = Collections.emptyMap();
         this.executor = executor;


### PR DESCRIPTION
Previously we were using empty vertex values with shapes to store the shape before there was a value. This required instantiating a tensor or whatever the vertex type was when all you want to do is store the shape. This PR removes the empty placeholder tensor create methods and passes the shape to the parent vertex class on construction where applicable.  