### PR TITLE
Remove IntegerTensor constructor that takes long values

### DIFF
--- a/docs/src/test/java/io/improbable/snippet/Tensors.java
+++ b/docs/src/test/java/io/improbable/snippet/Tensors.java
@@ -47,7 +47,7 @@ BooleanTensor bTensor = BooleanTensor.create(true, new long[]{1, 4}); //[true, t
     private static void tensorExamples2() {
 //%%SNIPPET_START%% Tensor2by2
 DoubleTensor dTensor = DoubleTensor.create(new double[]{0.5, 1.5, 2.5, 3.5}, new long[]{2, 2});
-IntegerTensor iTensor = IntegerTensor.create(new long[]{1, 2, 3, 4}, new long[]{2, 2});
+IntegerTensor iTensor = IntegerTensor.create(new int[]{1, 2, 3, 4}, new long[]{2, 2});
 BooleanTensor bTensor = BooleanTensor.create(new boolean[]{true, true, false, false}, new long[]{2, 2});
 //%%SNIPPET_END%% Tensor2by2
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
@@ -1,6 +1,5 @@
 package io.improbable.keanu.tensor.intgr;
 
-import com.google.common.primitives.Ints;
 import io.improbable.keanu.kotlin.IntegerOperators;
 import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.Tensor;

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
@@ -35,14 +35,6 @@ public interface IntegerTensor extends NumberTensor<Integer, IntegerTensor>, Int
         }
     }
 
-    static IntegerTensor create(long[] values, long... shape) {
-        if (Arrays.equals(shape, Tensor.SCALAR_SHAPE) && values.length == 1) {
-            return new ScalarIntegerTensor(Ints.checkedCast(values[0]));
-        } else {
-            return Nd4jIntegerTensor.create(Arrays.stream(values).mapToInt(Ints::checkedCast).toArray(), shape);
-        }
-    }
-
     static IntegerTensor create(int... values) {
         return create(values, 1, values.length);
     }


### PR DESCRIPTION
Made it to fix some python tests, but no longer needed.