### PR TITLE
Generate python constructor docs from JavaDoc strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 task saveJavadocStringsToFile(type: Javadoc) {
     def keanuProject = rootProject.subprojects.find { subproject -> subproject.name == "keanu-project" }
     def codegenProject = rootProject.subprojects.find { subproject -> subproject.name == "codegen" }
-    dependsOn codegenProject.tasks.getByName("compileJava")
+    dependsOn "codegen:compileJava"
 
     source = keanuProject.layout.getProjectDirectory().asFileTree.matching({ filter -> filter.include("**/*.java") })
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,11 @@ dependencies {
 task saveJavadocStringsToFile(type: Javadoc) {
     def keanuProject = rootProject.subprojects.find { subproject -> subproject.name == "keanu-project" }
     def codegenProject = rootProject.subprojects.find { subproject -> subproject.name == "codegen" }
+    dependsOn codegenProject.tasks.getByName("compileJava")
 
     source = keanuProject.layout.getProjectDirectory().asFileTree.matching({ filter -> filter.include("**/*.java") })
 
-    File classFile = codegenProject.layout.getProjectDirectory().getAsFileTree().files
-        .find( { File file -> file.name.contains("KeanuProjectDoclet.class") })
-        .parentFile.parentFile.parentFile.parentFile.parentFile.parentFile
+    File classFile = new File(codegenProject.layout.projectDirectory.get().path + "/build/classes/java/main")
 
     def docletClasspath = compileJava.classpath.files.toList()
     docletClasspath.add(classFile)

--- a/build.gradle
+++ b/build.gradle
@@ -25,21 +25,3 @@ dependencies {
     compile 'com.google.code.gson:gson:2.7'
     compile project(":keanu-project")
 }
-
-task saveJavadocStringsToFile(type: Javadoc) {
-    def keanuProject = rootProject.subprojects.find { subproject -> subproject.name == "keanu-project" }
-    def codegenProject = rootProject.subprojects.find { subproject -> subproject.name == "codegen" }
-    dependsOn "codegen:compileJava"
-
-    source = keanuProject.layout.getProjectDirectory().asFileTree.matching({ filter -> filter.include("**/*.java") })
-
-    File classFile = new File(codegenProject.layout.projectDirectory.get().path + "/build/classes/java/main")
-
-    def docletClasspath = compileJava.classpath.files.toList()
-    docletClasspath.add(classFile)
-    options.setDocletpath(docletClasspath)
-    options.setDoclet("io.improbable.keanu.codegen.python.KeanuProjectDoclet")
-
-    def mainClasspath = keanuProject.layout.projectDirectory.asFileTree.files.toList()
-    options.setClasspath(mainClasspath)
-}

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile project(":keanu-project")
 }
 
-task myJavadocs(type: Javadoc) {
+task saveJavadocStringsToFile(type: Javadoc) {
     def keanuProject = rootProject.subprojects.find { subproject -> subproject.name == "keanu-project" }
     def codegenProject = rootProject.subprojects.find { subproject -> subproject.name == "codegen" }
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,5 @@ task myJavadocs(type: Javadoc) {
     options.setDoclet("io.improbable.keanu.codegen.python.KeanuProjectDoclet")
 
     def mainClasspath = keanuProject.layout.projectDirectory.asFileTree.files.toList()
-    println mainClasspath
     options.setClasspath(mainClasspath)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,5 @@ allprojects {
 }
 
 dependencies {
-    compile 'com.google.code.gson:gson:2.7'
     compile project(":keanu-project")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,26 @@ allprojects {
 }
 
 dependencies {
+    compile 'com.google.code.gson:gson:2.7'
     compile project(":keanu-project")
 }
 
+task myJavadocs(type: Javadoc) {
+    def keanuProject = rootProject.subprojects.find { subproject -> subproject.name == "keanu-project" }
+    def codegenProject = rootProject.subprojects.find { subproject -> subproject.name == "codegen" }
+
+    source = keanuProject.layout.getProjectDirectory().asFileTree.matching({ filter -> filter.include("**/*.java") })
+
+    File classFile = codegenProject.layout.getProjectDirectory().getAsFileTree().files
+        .find( { File file -> file.name.contains("KeanuProjectDoclet.class") })
+        .parentFile.parentFile.parentFile.parentFile.parentFile.parentFile
+
+    def docletClasspath = compileJava.classpath.files.toList()
+    docletClasspath.add(classFile)
+    options.setDocletpath(docletClasspath)
+    options.setDoclet("io.improbable.keanu.codegen.python.KeanuProjectDoclet")
+
+    def mainClasspath = keanuProject.layout.projectDirectory.asFileTree.files.toList()
+    println mainClasspath
+    options.setClasspath(mainClasspath)
+}

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     //testing
     testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:2.19.1'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -7,6 +7,7 @@ mainClassName = 'io.improbable.keanu.codegen.python.Runner'
 
 dependencies {
     compile 'org.reflections:reflections:0.9.11'
+    compile 'com.google.code.gson:gson:2.7'
     compile 'org.freemarker:freemarker:2.3.28'
     compile project(':keanu-project')
     compile files("${System.getProperty('java.home')}/../lib/tools.jar")

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 }
 
 task codeGen (type: JavaExec) {
+    dependsOn rootProject.getTasks().getByName("saveJavadocStringsToFile")
     classpath sourceSets.main.runtimeClasspath
     main = mainClassName
     args += project.rootDir.toString() + '/keanu-python/keanu/vertex/'

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compile 'org.reflections:reflections:0.9.11'
     compile 'org.freemarker:freemarker:2.3.28'
     compile project(':keanu-project')
+    compile files("${System.getProperty('java.home')}/../lib/tools.jar")
 
     //testing
     testCompile 'junit:junit:4.12'

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -16,8 +16,25 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
+task saveJavadocStringsToFile(type: Javadoc) {
+    def keanuProject = rootProject.subprojects.find { subproject -> subproject.name == "keanu-project" }
+
+    source = keanuProject.layout.getProjectDirectory().asFileTree.matching({ filter -> filter.include("**/*.java") })
+
+    println layout.projectDirectory.get().path + "/build/classes/java/main"
+    File classFile = new File(layout.projectDirectory.get().path + "/build/classes/java/main")
+
+    def docletClasspath = rootProject.compileJava.classpath.files.toList()
+    docletClasspath.add(classFile)
+    options.setDocletpath(docletClasspath)
+    options.setDoclet("io.improbable.keanu.codegen.python.KeanuProjectDoclet")
+
+    def mainClasspath = keanuProject.layout.projectDirectory.asFileTree.files.toList()
+    options.setClasspath(mainClasspath)
+}
+
 task codeGen (type: JavaExec) {
-    dependsOn rootProject.getTasks().getByName("saveJavadocStringsToFile")
+    dependsOn saveJavadocStringsToFile
     classpath sourceSets.main.runtimeClasspath
     main = mainClassName
     args += project.rootDir.toString() + '/keanu-python/keanu/vertex/'

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -17,19 +17,14 @@ dependencies {
 }
 
 task saveJavadocStringsToFile(type: Javadoc) {
-    def keanuProject = rootProject.subprojects.find { subproject -> subproject.name == "keanu-project" }
-
-    source = keanuProject.layout.getProjectDirectory().asFileTree.matching({ filter -> filter.include("**/*.java") })
-
-    println layout.projectDirectory.get().path + "/build/classes/java/main"
-    File classFile = new File(layout.projectDirectory.get().path + "/build/classes/java/main")
+    source = fileTree(dir:'../keanu-project', includes:["**/*.java"])
 
     def docletClasspath = rootProject.compileJava.classpath.files.toList()
-    docletClasspath.add(classFile)
+    docletClasspath.add(new File(layout.projectDirectory.get().path + "/build/classes/java/main"))
     options.setDocletpath(docletClasspath)
     options.setDoclet("io.improbable.keanu.codegen.python.KeanuProjectDoclet")
 
-    def mainClasspath = keanuProject.layout.projectDirectory.asFileTree.files.toList()
+    def mainClasspath = fileTree(dir:'../keanu-project').files.toList()
     options.setClasspath(mainClasspath)
 }
 

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -5,23 +5,31 @@ import java.util.Map;
 class DocString {
     private String comment;
     private Map<String, String> params;
-    private String methodName;
 
-    DocString(String comment, Map<String, String> params, String methodName) {
+    DocString(String comment, Map<String, String> params) {
         this.comment = comment;
         this.params = params;
-        this.methodName = methodName;
     }
 
-    String getComment() {
-        return comment;
+    private boolean isEmpty() {
+        return comment.isEmpty() && params.size() == 0;
     }
 
-    Map<String, String> getParams() {
-        return params;
-    }
-
-    String getMethodName() {
-        return methodName;
+    String getAsString() {
+        if (isEmpty()) {
+            return "";
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("\"\"\"\n    ");
+        stringBuilder.append(comment.replaceAll("\n ", "\n    "));
+        for (String param : params.keySet()) {
+            stringBuilder.append("\n    ");
+            stringBuilder.append(":param ");
+            stringBuilder.append(param);
+            stringBuilder.append(": ");
+            stringBuilder.append(params.get(param));
+        }
+        stringBuilder.append("\n    \"\"\"\n    ");
+        return stringBuilder.toString();
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -29,7 +29,7 @@ class DocString {
         stringBuilder.append(THREE_QUOTES);
         stringBuilder.append(NEW_LINE_TAB);
         stringBuilder.append(comment.replaceAll("\n ", NEW_LINE_TAB));
-        stringBuilder.append("\n");
+        stringBuilder.append(NEW_LINE_TAB);
         for (String param : params.keySet()) {
             stringBuilder.append(NEW_LINE_TAB);
             stringBuilder.append(":param ");
@@ -39,7 +39,6 @@ class DocString {
         }
         stringBuilder.append(NEW_LINE_TAB);
         stringBuilder.append(THREE_QUOTES);
-        stringBuilder.append("\n");
         return stringBuilder.toString();
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -39,7 +39,7 @@ class DocString {
         }
         stringBuilder.append(NEW_LINE_TAB);
         stringBuilder.append(THREE_QUOTES);
-        stringBuilder.append(NEW_LINE_TAB);
+        stringBuilder.append("\n");
         return stringBuilder.toString();
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -19,9 +19,13 @@ class DocString {
         if (isEmpty()) {
             return "";
         }
+        if (params.size() == 0) {
+            return "\"\"\"\n" + comment + "\n\"\"\"\n";
+        }
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("\"\"\"\n    ");
         stringBuilder.append(comment.replaceAll("\n ", "\n    "));
+        stringBuilder.append("\n");
         for (String param : params.keySet()) {
             stringBuilder.append("\n    ");
             stringBuilder.append(":param ");

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -1,0 +1,27 @@
+package io.improbable.keanu.codegen.python;
+
+import java.util.Map;
+
+class DocString {
+    private String comment;
+    private Map<String, String> params;
+    private String methodName;
+
+    DocString(String comment, Map<String, String> params, String methodName) {
+        this.comment = comment;
+        this.params = params;
+        this.methodName = methodName;
+    }
+
+    String getComment() {
+        return comment;
+    }
+
+    Map<String, String> getParams() {
+        return params;
+    }
+
+    String getMethodName() {
+        return methodName;
+    }
+}

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -1,41 +1,43 @@
 package io.improbable.keanu.codegen.python;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Map;
 
 class DocString {
     private static final String THREE_QUOTES = "\"\"\"";
     private static final String NEW_LINE_TAB = "\n    ";
 
-    private String comment;
-    private Map<String, String> params;
+    private final String methodDescription;
+    private final Map<String, String> parameterNameToDescriptionMap;
 
-    DocString(String comment, Map<String, String> params) {
-        this.comment = comment;
-        this.params = params;
+    DocString(String methodDescription, Map<String, String> parameterNameToDescriptionMap) {
+        this.methodDescription = methodDescription;
+        this.parameterNameToDescriptionMap = parameterNameToDescriptionMap;
     }
 
     private boolean isEmpty() {
-        return comment.isEmpty() && params.size() == 0;
+        return StringUtils.isEmpty(methodDescription) && parameterNameToDescriptionMap.isEmpty();
     }
 
     String getAsString() {
         if (isEmpty()) {
             return "";
         }
-        if (params.size() == 0) {
-            return THREE_QUOTES + "\n" + comment + THREE_QUOTES + "\n\n";
+        if (parameterNameToDescriptionMap.size() == 0) {
+            return THREE_QUOTES + "\n" + methodDescription + THREE_QUOTES + "\n\n";
         }
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(THREE_QUOTES);
         stringBuilder.append(NEW_LINE_TAB);
-        stringBuilder.append(comment.replaceAll("\n ", NEW_LINE_TAB));
+        stringBuilder.append(methodDescription.replaceAll("\n ", NEW_LINE_TAB));
         stringBuilder.append(NEW_LINE_TAB);
-        for (String param : params.keySet()) {
+        for (String param : parameterNameToDescriptionMap.keySet()) {
             stringBuilder.append(NEW_LINE_TAB);
             stringBuilder.append(":param ");
             stringBuilder.append(param);
             stringBuilder.append(": ");
-            stringBuilder.append(params.get(param));
+            stringBuilder.append(parameterNameToDescriptionMap.get(param));
         }
         stringBuilder.append(NEW_LINE_TAB);
         stringBuilder.append(THREE_QUOTES);

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -41,6 +41,7 @@ class DocString {
         }
         stringBuilder.append(NEW_LINE_TAB);
         stringBuilder.append(THREE_QUOTES);
+        stringBuilder.append(NEW_LINE_TAB);
         return stringBuilder.toString();
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -3,6 +3,9 @@ package io.improbable.keanu.codegen.python;
 import java.util.Map;
 
 class DocString {
+    private static final String THREE_QUOTES = "\"\"\"";
+    private static final String NEW_LINE_TAB = "\n    ";
+
     private String comment;
     private Map<String, String> params;
 
@@ -20,20 +23,23 @@ class DocString {
             return "";
         }
         if (params.size() == 0) {
-            return "\"\"\"\n" + comment + "\n\"\"\"\n";
+            return THREE_QUOTES + "\n" + comment + THREE_QUOTES + "\n\n";
         }
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("\"\"\"\n    ");
-        stringBuilder.append(comment.replaceAll("\n ", "\n    "));
+        stringBuilder.append(THREE_QUOTES);
+        stringBuilder.append(NEW_LINE_TAB);
+        stringBuilder.append(comment.replaceAll("\n ", NEW_LINE_TAB));
         stringBuilder.append("\n");
         for (String param : params.keySet()) {
-            stringBuilder.append("\n    ");
+            stringBuilder.append(NEW_LINE_TAB);
             stringBuilder.append(":param ");
             stringBuilder.append(param);
             stringBuilder.append(": ");
             stringBuilder.append(params.get(param));
         }
-        stringBuilder.append("\n    \"\"\"\n    ");
+        stringBuilder.append(NEW_LINE_TAB);
+        stringBuilder.append(THREE_QUOTES);
+        stringBuilder.append(NEW_LINE_TAB);
         return stringBuilder.toString();
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -2,7 +2,6 @@ package io.improbable.keanu.codegen.python;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.sun.javadoc.AnnotationDesc;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.ConstructorDoc;
 import com.sun.javadoc.RootDoc;
@@ -48,7 +47,7 @@ public class KeanuProjectDoclet extends Standard {
 
     private static boolean isConstructorAnnotated(ConstructorDoc constructorDoc) {
         return Arrays.stream(constructorDoc.annotations())
-            .anyMatch(an -> an.toString().equals(EXPORT_VERTEX_ANNOTATION_NAME))
+            .anyMatch(an -> an.toString().equals(EXPORT_VERTEX_ANNOTATION_NAME));
     }
 
     private static void writeDocStringsToFile(Map<String, DocString> docString) {
@@ -58,9 +57,7 @@ public class KeanuProjectDoclet extends Standard {
             outputFile.getParentFile().mkdirs();
             outputFile.createNewFile(); // if file already exists will do nothing
             OutputStream outputStream = new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME, false);
-            System.out.println("Writing docstrings");
             outputStream.write(json.getBytes());
-            System.out.println("Finished writing docstrings");
         } catch (IOException e) {
             e.printStackTrace();
             System.out.println("Could not write to file while processing JavaDoc strings");
@@ -74,7 +71,7 @@ public class KeanuProjectDoclet extends Standard {
             Reader reader = new FileReader(READ_DESTINATION + DESTINATION_FILE_NAME);
             return gson.fromJson(reader, listType);
         } catch (IOException e) {
-            throw new IOException("Could not read JavaDoc strings from file at " + System.getProperty("user.dir") + READ_DESTINATION + DESTINATION_FILE_NAME);
+            throw new IOException("Could not read JavaDoc strings from file at " + System.getProperty("user.dir") + READ_DESTINATION + DESTINATION_FILE_NAME, e);
         }
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 public class KeanuProjectDoclet extends Standard {
 
+    private static final Logger logger = LoggerFactory.getLogger(KeanuProjectDoclet.class);
+
     private static final String EXPORT_VERTEX_ANNOTATION_NAME = "@" + ExportVertexToPythonBindings.class.getName();
     private static final String DESTINATION_FILE_NAME = "javadocstrings.json";
     private static final String DESTINATION = "./build/resources/";
@@ -58,7 +60,6 @@ public class KeanuProjectDoclet extends Standard {
                  new FileOutputStream(DESTINATION + DESTINATION_FILE_NAME, false)) {
             outputStream.write(json.getBytes());
         } catch (IOException e) {
-            Logger logger = LoggerFactory.getLogger(KeanuProjectDoclet.class);
             logger.error("Could not write to file while processing JavaDoc strings", e);
         }
     }
@@ -69,7 +70,6 @@ public class KeanuProjectDoclet extends Standard {
         try {
             outputFile.createNewFile();
         } catch (IOException e) {
-            Logger logger = LoggerFactory.getLogger(KeanuProjectDoclet.class);
             logger.error("Could not write to file while processing JavaDoc strings", e);
         }
     }
@@ -77,9 +77,8 @@ public class KeanuProjectDoclet extends Standard {
     static Map<String, DocString> getDocStringsFromFile() throws IOException {
         try {
             Type listType = new TypeToken<Map<String, DocString>>(){}.getType();
-            Gson gson = new Gson();
             Reader reader = new FileReader(DESTINATION + DESTINATION_FILE_NAME);
-            return gson.fromJson(reader, listType);
+            return (new Gson()).fromJson(reader, listType);
         } catch (IOException e) {
             throw new IOException("Could not read JavaDoc strings from file at " + System.getProperty("user.dir") + DESTINATION + DESTINATION_FILE_NAME, e);
         }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -11,7 +11,8 @@ import java.util.*;
 
 public class KeanuProjectDoclet extends Standard {
 
-    private static final String JAVADOC_STRING_FILE_NAME = "javadocstrings.txt";
+    private static final String JAVADOC_STRING_FILE_NAME = "javadocstrings.json";
+    private static final String PATH_TO_OUT = "/codegen/out";
 
     public static boolean start(RootDoc root) {
 
@@ -46,9 +47,9 @@ public class KeanuProjectDoclet extends Standard {
             Gson gson = new Gson();
             String json = gson.toJson(docString);
             OutputStream outputStream = new FileOutputStream("./" + JAVADOC_STRING_FILE_NAME);
-            System.out.println("Writing docstrings to " + System.getProperty("user.dir") + "/" + JAVADOC_STRING_FILE_NAME);
+            System.out.println("Writing docstrings to " + System.getProperty("user.dir") + PATH_TO_OUT + "/" + JAVADOC_STRING_FILE_NAME);
             outputStream.write(json.getBytes());
-            System.out.println("Finished writing docstrings to " + System.getProperty("user.dir") + "/" + JAVADOC_STRING_FILE_NAME);
+            System.out.println("Finished writing docstrings to " + System.getProperty("user.dir") + PATH_TO_OUT + "/" + JAVADOC_STRING_FILE_NAME);
         } catch (IOException e) {
             System.out.println("Could not write to file while processing JavaDoc strings");
         }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -22,7 +22,7 @@ public class KeanuProjectDoclet extends Standard {
                 if (constructorDoc.annotations().length != 0) {
                     if (isConstructorAnnotated(constructorDoc)) {
                         Map<String, String> params = ParamStringProcessor.getNameToCommentMapping(constructorDoc);
-                        DocString docString = new DocString(constructorDoc.commentText(), params, constructorDoc.qualifiedName());
+                        DocString docString = new DocString(constructorDoc.commentText(), params);
                         docStrings.put(constructorDoc.qualifiedName(), docString);
                     }
                 }
@@ -54,7 +54,7 @@ public class KeanuProjectDoclet extends Standard {
         }
     }
 
-    public static Map<String, DocString> getDocStringsFromFile() {
+    static Map<String, DocString> getDocStringsFromFile() {
         try {
             Type listType = new TypeToken<Map<String, DocString>>(){}.getType();
             Gson gson = new Gson();

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -11,8 +11,9 @@ import java.util.*;
 
 public class KeanuProjectDoclet extends Standard {
 
-    private static final String JAVADOC_STRING_FILE_NAME = "javadocstrings.json";
-    private static final String PATH_TO_OUT = "/codegen/out";
+    private static final String DESTINATION_FILE_NAME = "javadocstrings.json";
+    private static final String READ_DESTINATION = "./out/";
+    private static final String WRITE_DESTINATION = "./codegen/out/";
 
     public static boolean start(RootDoc root) {
 
@@ -46,10 +47,10 @@ public class KeanuProjectDoclet extends Standard {
         try {
             Gson gson = new Gson();
             String json = gson.toJson(docString);
-            OutputStream outputStream = new FileOutputStream("./" + JAVADOC_STRING_FILE_NAME);
-            System.out.println("Writing docstrings to " + System.getProperty("user.dir") + PATH_TO_OUT + "/" + JAVADOC_STRING_FILE_NAME);
+            OutputStream outputStream = new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME);
+        System.out.println("Writing docstrings to " + System.getProperty("user.dir") + WRITE_DESTINATION + DESTINATION_FILE_NAME);
             outputStream.write(json.getBytes());
-            System.out.println("Finished writing docstrings to " + System.getProperty("user.dir") + PATH_TO_OUT + "/" + JAVADOC_STRING_FILE_NAME);
+            System.out.println("Finished writing docstrings");
         } catch (IOException e) {
             System.out.println("Could not write to file while processing JavaDoc strings");
         }
@@ -59,10 +60,10 @@ public class KeanuProjectDoclet extends Standard {
         try {
             Type listType = new TypeToken<Map<String, DocString>>(){}.getType();
             Gson gson = new Gson();
-            Reader reader = new FileReader("./" + JAVADOC_STRING_FILE_NAME);
+            Reader reader = new FileReader(READ_DESTINATION + DESTINATION_FILE_NAME);
             return gson.fromJson(reader, listType);
         } catch (IOException e) {
-            System.out.println("Could not read JavaDoc strings from file");
+            System.out.println("Could not read JavaDoc strings from file at " + System.getProperty("user.dir") + READ_DESTINATION + DESTINATION_FILE_NAME);
             return new HashMap<>();
         }
     }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -51,13 +51,22 @@ public class KeanuProjectDoclet extends Standard {
     }
 
     private static void writeDocStringsToFile(Map<String, DocString> docString) {
-        try {
-            String json = (new Gson()).toJson(docString);
-            File outputFile = new File(WRITE_DESTINATION + DESTINATION_FILE_NAME);
-            outputFile.getParentFile().mkdirs();
-            outputFile.createNewFile(); // if file already exists will do nothing
-            OutputStream outputStream = new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME, false);
+        String json = (new Gson()).toJson(docString);
+        createFilesIfNecessary();
+        try (OutputStream outputStream =
+                 new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME, false)) {
             outputStream.write(json.getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.out.println("Could not write to file while processing JavaDoc strings");
+        }
+    }
+
+    private static void createFilesIfNecessary() {
+        File outputFile = new File(WRITE_DESTINATION + DESTINATION_FILE_NAME);
+        outputFile.getParentFile().mkdirs();
+        try {
+            outputFile.createNewFile();
         } catch (IOException e) {
             e.printStackTrace();
             System.out.println("Could not write to file while processing JavaDoc strings");

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -7,6 +7,8 @@ import com.sun.javadoc.ConstructorDoc;
 import com.sun.javadoc.RootDoc;
 import com.sun.tools.doclets.standard.Standard;
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -57,8 +59,8 @@ public class KeanuProjectDoclet extends Standard {
                  new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME, false)) {
             outputStream.write(json.getBytes());
         } catch (IOException e) {
-            e.printStackTrace();
-            System.out.println("Could not write to file while processing JavaDoc strings");
+            Logger logger = LoggerFactory.getLogger(KeanuProjectDoclet.class);
+            logger.error("Could not write to file while processing JavaDoc strings", e);
         }
     }
 
@@ -68,8 +70,8 @@ public class KeanuProjectDoclet extends Standard {
         try {
             outputFile.createNewFile();
         } catch (IOException e) {
-            e.printStackTrace();
-            System.out.println("Could not write to file while processing JavaDoc strings");
+            Logger logger = LoggerFactory.getLogger(KeanuProjectDoclet.class);
+            logger.error("Could not write to file while processing JavaDoc strings", e);
         }
     }
 

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -5,8 +5,8 @@ import com.google.gson.reflect.TypeToken;
 import com.sun.javadoc.*;
 import com.sun.tools.doclets.standard.Standard;
 
-import java.lang.reflect.Type;
 import java.io.*;
+import java.lang.reflect.Type;
 import java.util.*;
 
 public class KeanuProjectDoclet extends Standard {
@@ -67,4 +67,3 @@ public class KeanuProjectDoclet extends Standard {
         }
     }
 }
-

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,18 +47,13 @@ public class KeanuProjectDoclet extends Standard {
     }
 
     private static boolean isConstructorAnnotated(ConstructorDoc constructorDoc) {
-        for (AnnotationDesc an: constructorDoc.annotations()) {
-            if (an.toString().equals(EXPORT_VERTEX_ANNOTATION_NAME)) {
-                return true;
-            }
-        }
-        return false;
+        return Arrays.stream(constructorDoc.annotations())
+            .anyMatch(an -> an.toString().equals(EXPORT_VERTEX_ANNOTATION_NAME))
     }
 
     private static void writeDocStringsToFile(Map<String, DocString> docString) {
         try {
-            Gson gson = new Gson();
-            String json = gson.toJson(docString);
+            String json = (new Gson()).toJson(docString);
             File outputFile = new File(WRITE_DESTINATION + DESTINATION_FILE_NAME);
             outputFile.getParentFile().mkdirs();
             outputFile.createNewFile(); // if file already exists will do nothing

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -12,8 +12,8 @@ import java.util.*;
 public class KeanuProjectDoclet extends Standard {
 
     private static final String DESTINATION_FILE_NAME = "javadocstrings.json";
-    private static final String READ_DESTINATION = "./out/";
-    private static final String WRITE_DESTINATION = "./codegen/out/";
+    private static final String READ_DESTINATION = "./build/resources/";
+    private static final String WRITE_DESTINATION = "./codegen/build/resources/";
 
     public static boolean start(RootDoc root) {
 
@@ -47,11 +47,15 @@ public class KeanuProjectDoclet extends Standard {
         try {
             Gson gson = new Gson();
             String json = gson.toJson(docString);
-            OutputStream outputStream = new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME);
-        System.out.println("Writing docstrings to " + System.getProperty("user.dir") + WRITE_DESTINATION + DESTINATION_FILE_NAME);
+            File outputFile = new File(WRITE_DESTINATION + DESTINATION_FILE_NAME);
+            outputFile.getParentFile().mkdirs();
+            outputFile.createNewFile(); // if file already exists will do nothing
+            OutputStream outputStream = new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME, false);
+        System.out.println("Writing docstrings");
             outputStream.write(json.getBytes());
             System.out.println("Finished writing docstrings");
         } catch (IOException e) {
+            e.printStackTrace();
             System.out.println("Could not write to file while processing JavaDoc strings");
         }
     }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.sun.javadoc.*;
 import com.sun.tools.doclets.standard.Standard;
+import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 
 import java.io.*;
 import java.lang.reflect.Type;
@@ -36,7 +37,8 @@ public class KeanuProjectDoclet extends Standard {
 
     private static boolean isConstructorAnnotated(ConstructorDoc constructorDoc) {
         for (AnnotationDesc an: constructorDoc.annotations()) {
-            if (an.toString().contains("ExportVertexToPythonBindings")) {
+            String exportVertexAnnotationName = "@" + ExportVertexToPythonBindings.class.getName();
+            if (an.toString().equals(exportVertexAnnotationName)) {
                 return true;
             }
         }
@@ -51,7 +53,7 @@ public class KeanuProjectDoclet extends Standard {
             outputFile.getParentFile().mkdirs();
             outputFile.createNewFile(); // if file already exists will do nothing
             OutputStream outputStream = new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME, false);
-        System.out.println("Writing docstrings");
+            System.out.println("Writing docstrings");
             outputStream.write(json.getBytes());
             System.out.println("Finished writing docstrings");
         } catch (IOException e) {
@@ -60,15 +62,14 @@ public class KeanuProjectDoclet extends Standard {
         }
     }
 
-    static Map<String, DocString> getDocStringsFromFile() {
+    static Map<String, DocString> getDocStringsFromFile() throws IOException {
         try {
             Type listType = new TypeToken<Map<String, DocString>>(){}.getType();
             Gson gson = new Gson();
             Reader reader = new FileReader(READ_DESTINATION + DESTINATION_FILE_NAME);
             return gson.fromJson(reader, listType);
         } catch (IOException e) {
-            System.out.println("Could not read JavaDoc strings from file at " + System.getProperty("user.dir") + READ_DESTINATION + DESTINATION_FILE_NAME);
-            return new HashMap<>();
+            throw new IOException("Could not read JavaDoc strings from file at " + System.getProperty("user.dir") + READ_DESTINATION + DESTINATION_FILE_NAME);
         }
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -25,8 +25,7 @@ public class KeanuProjectDoclet extends Standard {
 
     private static final String EXPORT_VERTEX_ANNOTATION_NAME = "@" + ExportVertexToPythonBindings.class.getName();
     private static final String DESTINATION_FILE_NAME = "javadocstrings.json";
-    private static final String READ_DESTINATION = "./build/resources/";
-    private static final String WRITE_DESTINATION = "./codegen/build/resources/";
+    private static final String DESTINATION = "./build/resources/";
 
     public static boolean start(RootDoc root) {
 
@@ -56,7 +55,7 @@ public class KeanuProjectDoclet extends Standard {
         String json = (new Gson()).toJson(docString);
         createFilesIfNecessary();
         try (OutputStream outputStream =
-                 new FileOutputStream(WRITE_DESTINATION + DESTINATION_FILE_NAME, false)) {
+                 new FileOutputStream(DESTINATION + DESTINATION_FILE_NAME, false)) {
             outputStream.write(json.getBytes());
         } catch (IOException e) {
             Logger logger = LoggerFactory.getLogger(KeanuProjectDoclet.class);
@@ -65,7 +64,7 @@ public class KeanuProjectDoclet extends Standard {
     }
 
     private static void createFilesIfNecessary() {
-        File outputFile = new File(WRITE_DESTINATION + DESTINATION_FILE_NAME);
+        File outputFile = new File(DESTINATION + DESTINATION_FILE_NAME);
         outputFile.getParentFile().mkdirs();
         try {
             outputFile.createNewFile();
@@ -79,10 +78,10 @@ public class KeanuProjectDoclet extends Standard {
         try {
             Type listType = new TypeToken<Map<String, DocString>>(){}.getType();
             Gson gson = new Gson();
-            Reader reader = new FileReader(READ_DESTINATION + DESTINATION_FILE_NAME);
+            Reader reader = new FileReader(DESTINATION + DESTINATION_FILE_NAME);
             return gson.fromJson(reader, listType);
         } catch (IOException e) {
-            throw new IOException("Could not read JavaDoc strings from file at " + System.getProperty("user.dir") + READ_DESTINATION + DESTINATION_FILE_NAME, e);
+            throw new IOException("Could not read JavaDoc strings from file at " + System.getProperty("user.dir") + DESTINATION + DESTINATION_FILE_NAME, e);
         }
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -1,0 +1,69 @@
+package io.improbable.keanu.codegen.python;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.sun.javadoc.*;
+import com.sun.tools.doclets.standard.Standard;
+
+import java.lang.reflect.Type;
+import java.io.*;
+import java.util.*;
+
+public class KeanuProjectDoclet extends Standard {
+
+    private static final String JAVADOC_STRING_FILE_NAME = "javadocstrings.txt";
+
+    public static boolean start(RootDoc root) {
+
+        Map<String, DocString> docStrings = new HashMap<>();
+        ClassDoc[] classes = root.classes();
+        for (ClassDoc classDoc : classes) {
+            for (ConstructorDoc constructorDoc : classDoc.constructors()) {
+                if (constructorDoc.annotations().length != 0) {
+                    if (isConstructorAnnotated(constructorDoc)) {
+                        Map<String, String> params = ParamStringProcessor.getNameToCommentMapping(constructorDoc);
+                        DocString docString = new DocString(constructorDoc.commentText(), params, constructorDoc.qualifiedName());
+                        docStrings.put(constructorDoc.qualifiedName(), docString);
+                    }
+                }
+            }
+        }
+        writeDocStringsToFile(docStrings);
+        return true;
+    }
+
+    private static boolean isConstructorAnnotated(ConstructorDoc constructorDoc) {
+        for (AnnotationDesc an: constructorDoc.annotations()) {
+            if (an.toString().contains("ExportVertexToPythonBindings")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void writeDocStringsToFile(Map<String, DocString> docString) {
+        try {
+            Gson gson = new Gson();
+            String json = gson.toJson(docString);
+            OutputStream outputStream = new FileOutputStream("./" + JAVADOC_STRING_FILE_NAME);
+            System.out.println("Writing docstrings to " + System.getProperty("user.dir") + "/" + JAVADOC_STRING_FILE_NAME);
+            outputStream.write(json.getBytes());
+            System.out.println("Finished writing docstrings to " + System.getProperty("user.dir") + "/" + JAVADOC_STRING_FILE_NAME);
+        } catch (IOException e) {
+            System.out.println("Could not write to file while processing JavaDoc strings");
+        }
+    }
+
+    public static Map<String, DocString> getDocStringsFromFile() {
+        try {
+            Type listType = new TypeToken<Map<String, DocString>>(){}.getType();
+            Gson gson = new Gson();
+            Reader reader = new FileReader("./" + JAVADOC_STRING_FILE_NAME);
+            return gson.fromJson(reader, listType);
+        } catch (IOException e) {
+            System.out.println("Could not read JavaDoc strings from file");
+            return new HashMap<>();
+        }
+    }
+}
+

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -2,7 +2,10 @@ package io.improbable.keanu.codegen.python;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.sun.javadoc.*;
+import com.sun.javadoc.RootDoc;
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.ConstructorDoc;
+import com.sun.javadoc.AnnotationDesc;
 import com.sun.tools.doclets.standard.Standard;
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/KeanuProjectDoclet.java
@@ -2,19 +2,26 @@ package io.improbable.keanu.codegen.python;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.sun.javadoc.RootDoc;
+import com.sun.javadoc.AnnotationDesc;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.ConstructorDoc;
-import com.sun.javadoc.AnnotationDesc;
+import com.sun.javadoc.RootDoc;
 import com.sun.tools.doclets.standard.Standard;
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Reader;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class KeanuProjectDoclet extends Standard {
 
+    private static final String EXPORT_VERTEX_ANNOTATION_NAME = "@" + ExportVertexToPythonBindings.class.getName();
     private static final String DESTINATION_FILE_NAME = "javadocstrings.json";
     private static final String READ_DESTINATION = "./build/resources/";
     private static final String WRITE_DESTINATION = "./codegen/build/resources/";
@@ -40,8 +47,7 @@ public class KeanuProjectDoclet extends Standard {
 
     private static boolean isConstructorAnnotated(ConstructorDoc constructorDoc) {
         for (AnnotationDesc an: constructorDoc.annotations()) {
-            String exportVertexAnnotationName = "@" + ExportVertexToPythonBindings.class.getName();
-            if (an.toString().equals(exportVertexAnnotationName)) {
+            if (an.toString().equals(EXPORT_VERTEX_ANNOTATION_NAME)) {
                 return true;
             }
         }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
@@ -1,9 +1,9 @@
 package io.improbable.keanu.codegen.python;
 
+import com.google.common.collect.ImmutableMap;
 import com.sun.javadoc.ConstructorDoc;
 import com.sun.javadoc.Tag;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
@@ -11,13 +11,14 @@ import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 
 class ParamStringProcessor {
     static Map<String, String> getNameToCommentMapping(ConstructorDoc constructorDoc) {
-        Map<String, String> nameToCommentMapping = new HashMap<>();
+        ImmutableMap.Builder<String, String> nameToCommentMapping = ImmutableMap.builder();
         Tag[] params = constructorDoc.tags("@param");
         for (Tag param: params) {
-            String snakeCaseParamName = UPPER_CAMEL.to(LOWER_UNDERSCORE, param.name());
-            String paramComment = param.text();
+            String[] text = param.text().split(" ", 2);
+            String snakeCaseParamName = UPPER_CAMEL.to(LOWER_UNDERSCORE, text[0]);
+            String paramComment = text[1].trim();
             nameToCommentMapping.put(snakeCaseParamName, paramComment);
         }
-        return nameToCommentMapping;
+        return nameToCommentMapping.build();
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
@@ -5,6 +5,9 @@ import com.sun.javadoc.ConstructorDoc;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
+import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+
 class ParamStringProcessor {
     static Map<String, String> getNameToCommentMapping(ConstructorDoc constructorDoc) {
         String rawComment = constructorDoc.getRawCommentText();
@@ -16,22 +19,10 @@ class ParamStringProcessor {
             }
             commentLine = commentLine.replaceFirst("[ ]{2,}", " ");
             String[] splitComment = commentLine.split(" ", 4);
-            String snakeCaseParamName = toSnakeCase(splitComment[2]);
+            String snakeCaseParamName = UPPER_CAMEL.to(LOWER_UNDERSCORE, splitComment[2]);
             String paramComment = splitComment[3];
             nameToCommentMapping.put(snakeCaseParamName, paramComment);
         }
         return nameToCommentMapping;
-    }
-
-    static String toSnakeCase(String camelCase) {
-        String[] camelCaseWords = camelCase.split("(?=\\p{Upper})");
-        StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(camelCaseWords[0]);
-        for(int i=1; i<camelCaseWords.length; i++) {
-            stringBuilder.append("_");
-            stringBuilder.append(camelCaseWords[i].substring(0,1).toLowerCase());
-            stringBuilder.append(camelCaseWords[i].substring(1));
-        }
-        return stringBuilder.toString();
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.codegen.python;
 
 import com.sun.javadoc.ConstructorDoc;
+import com.sun.javadoc.Tag;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,17 +11,11 @@ import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 
 class ParamStringProcessor {
     static Map<String, String> getNameToCommentMapping(ConstructorDoc constructorDoc) {
-        String rawComment = constructorDoc.getRawCommentText();
-        String[] rawCommentLines = rawComment.split("\\r?\\n");
         Map<String, String> nameToCommentMapping = new HashMap<>();
-        for (String commentLine : rawCommentLines) {
-            if (!commentLine.contains("@param")) {
-                continue;
-            }
-            commentLine = commentLine.replaceFirst("[ ]{2,}", " ");
-            String[] splitComment = commentLine.split(" ", 4);
-            String snakeCaseParamName = UPPER_CAMEL.to(LOWER_UNDERSCORE, splitComment[2]);
-            String paramComment = splitComment[3];
+        Tag[] params = constructorDoc.tags("@param");
+        for (Tag param: params) {
+            String snakeCaseParamName = UPPER_CAMEL.to(LOWER_UNDERSCORE, param.name());
+            String paramComment = param.text();
             nameToCommentMapping.put(snakeCaseParamName, paramComment);
         }
         return nameToCommentMapping;

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
@@ -1,0 +1,23 @@
+package io.improbable.keanu.codegen.python;
+
+import com.sun.javadoc.ConstructorDoc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class ParamStringProcessor {
+    static Map<String, String> getNameToCommentMapping(ConstructorDoc constructorDoc) {
+        String rawComment = constructorDoc.getRawCommentText();
+        String[] rawCommentLines = rawComment.split("\\r?\\n");
+        Map<String, String> nameToCommentMapping = new HashMap<>();
+        for (String commentLine : rawCommentLines) {
+            if (!commentLine.contains("@param")) {
+                continue;
+            }
+            commentLine = commentLine.replaceFirst("[ ]{2,}", " ");
+            String[] splitComment = commentLine.split(" ", 4);
+            nameToCommentMapping.put(splitComment[2], splitComment[3]);
+        }
+        return nameToCommentMapping;
+    }
+}

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/ParamStringProcessor.java
@@ -16,8 +16,22 @@ class ParamStringProcessor {
             }
             commentLine = commentLine.replaceFirst("[ ]{2,}", " ");
             String[] splitComment = commentLine.split(" ", 4);
-            nameToCommentMapping.put(splitComment[2], splitComment[3]);
+            String snakeCaseParamName = toSnakeCase(splitComment[2]);
+            String paramComment = splitComment[3];
+            nameToCommentMapping.put(snakeCaseParamName, paramComment);
         }
         return nameToCommentMapping;
+    }
+
+    static String toSnakeCase(String camelCase) {
+        String[] camelCaseWords = camelCase.split("(?=\\p{Upper})");
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(camelCaseWords[0]);
+        for(int i=1; i<camelCaseWords.length; i++) {
+            stringBuilder.append("_");
+            stringBuilder.append(camelCaseWords[i].substring(0,1).toLowerCase());
+            stringBuilder.append(camelCaseWords[i].substring(1));
+        }
+        return stringBuilder.toString();
     }
 }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/Runner.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/Runner.java
@@ -1,8 +1,10 @@
 package io.improbable.keanu.codegen.python;
 
+import java.io.IOException;
+
 public class Runner {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         String generatedDir = args[0];
         VertexProcessor.process(generatedDir);
     }

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/VertexProcessor.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/VertexProcessor.java
@@ -11,6 +11,7 @@ import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 
+import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -24,7 +25,7 @@ class VertexProcessor {
     final private static String TEMPLATE_FILE = "generated.py.ftl";
     final private static String GENERATED_FILE = "generated.py";
 
-    static void process(String generatedDir) {
+    static void process(String generatedDir) throws IOException {
         Map<String, Object> dataModel = buildDataModel();
         Template fileTemplate = TemplateProcessor.getFileTemplate(TEMPLATE_FILE);
         Writer fileWriter = TemplateProcessor.createFileWriter(generatedDir + GENERATED_FILE);
@@ -32,7 +33,7 @@ class VertexProcessor {
         TemplateProcessor.processDataModel(dataModel, fileTemplate, fileWriter);
     }
 
-    private static Map<String, Object> buildDataModel() {
+    private static Map<String, Object> buildDataModel() throws IOException {
         Reflections reflections = new Reflections(new ConfigurationBuilder()
             .setUrls(ClasspathHelper.forPackage("io.improbable.keanu.vertices"))
             .setScanners(new MethodAnnotationsScanner(), new TypeAnnotationsScanner(), new MethodParameterNamesScanner()));

--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/VertexProcessor.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/VertexProcessor.java
@@ -45,14 +45,17 @@ class VertexProcessor {
 
         root.put("imports", imports);
         root.put("constructors", pythonConstructors);
-
+        Map<String, DocString> nameToDocStringMap = KeanuProjectDoclet.getDocStringsFromFile();
         for (Constructor constructor : constructors) {
             String javaClass = constructor.getDeclaringClass().getSimpleName();
+            String qualifiedName = constructor.getName();
+            DocString docString = nameToDocStringMap.get(qualifiedName);
+
             String[] pythonParameters = reflections.getConstructorParamNames(constructor).stream().map(
                 parameter -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, parameter)).toArray(String[]::new);
 
             imports.add(new Import(constructor.getDeclaringClass().getCanonicalName()));
-            pythonConstructors.add(new PythonConstructor(javaClass, toPythonClass(javaClass), String.join(", ", pythonParameters)));
+            pythonConstructors.add(new PythonConstructor(javaClass, toPythonClass(javaClass), String.join(", ", pythonParameters), docString.getAsString()));
         }
 
         return root;
@@ -85,11 +88,14 @@ class VertexProcessor {
         private String pythonClass;
         @Getter
         private String pythonParameters;
+        @Getter
+        private String docString;
 
-        PythonConstructor(String javaClass, String pythonClass, String pythonParameters) {
+        PythonConstructor(String javaClass, String pythonClass, String pythonParameters, String docString) {
             this.javaClass = javaClass;
             this.pythonClass = pythonClass;
             this.pythonParameters = pythonParameters;
+            this.docString = docString;
         }
     }
 

--- a/codegen/src/main/resources/generated.py.ftl
+++ b/codegen/src/main/resources/generated.py.ftl
@@ -14,5 +14,6 @@ java_import(context.jvm_view(), "${import.packageName}")
 
 
 def ${constructor.pythonClass}(${constructor.pythonParameters}) -> context.jvm_view().${constructor.javaClass}:
-    ${constructor.docString}return Vertex(context.jvm_view().${constructor.javaClass}, ${constructor.pythonParameters})
+    ${constructor.docString}
+    return Vertex(context.jvm_view().${constructor.javaClass}, ${constructor.pythonParameters})
 </#list>

--- a/codegen/src/main/resources/generated.py.ftl
+++ b/codegen/src/main/resources/generated.py.ftl
@@ -14,5 +14,5 @@ java_import(context.jvm_view(), "${import.packageName}")
 
 
 def ${constructor.pythonClass}(${constructor.pythonParameters}) -> context.jvm_view().${constructor.javaClass}:
-    return Vertex(context.jvm_view().${constructor.javaClass}, ${constructor.pythonParameters})
+    ${constructor.docString}return Vertex(context.jvm_view().${constructor.javaClass}, ${constructor.pythonParameters})
 </#list>

--- a/codegen/src/main/resources/generated.py.ftl
+++ b/codegen/src/main/resources/generated.py.ftl
@@ -14,6 +14,5 @@ java_import(context.jvm_view(), "${import.packageName}")
 
 
 def ${constructor.pythonClass}(${constructor.pythonParameters}) -> context.jvm_view().${constructor.javaClass}:
-    ${constructor.docString}
-    return Vertex(context.jvm_view().${constructor.javaClass}, ${constructor.pythonParameters})
+    ${constructor.docString}return Vertex(context.jvm_view().${constructor.javaClass}, ${constructor.pythonParameters})
 </#list>

--- a/codegen/src/test/java/io/improbable/keanu/codegen/python/ParamStringProcessorTest.java
+++ b/codegen/src/test/java/io/improbable/keanu/codegen/python/ParamStringProcessorTest.java
@@ -2,7 +2,6 @@ package io.improbable.keanu.codegen.python;
 
 import com.sun.javadoc.ConstructorDoc;
 import com.sun.javadoc.Tag;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,6 +13,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.improbable.keanu.codegen.python.ParamStringProcessor.getNameToCommentMapping;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.when;
@@ -28,11 +29,15 @@ public class ParamStringProcessorTest {
     private static final String SECOND_PARAM_COMMENT = "This is another comment about the second parameter anotherParamTest";
     private static final String FIRST_PARAM_TEXT = FIRST_PARAM_NAME_CAMEL_CASE + " " + FIRST_PARAM_COMMENT;
     private static final String SECOND_PARAM_TEXT = SECOND_PARAM_NAME_CAMEL_CASE + "   " + SECOND_PARAM_COMMENT;
+    private static final String RETURN_TAG_TEXT = "this";
+
     private static final String PARAM_TAG_NAME = "@param";
+    private static final String RETURN_TAG_NAME = "@return";
 
     @Mock ConstructorDoc constructorDoc;
     @Mock Tag tag1;
     @Mock Tag tag2;
+    @Mock Tag tag3;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -46,14 +51,18 @@ public class ParamStringProcessorTest {
 
         when(tag2.name()).thenReturn(PARAM_TAG_NAME);
         when(tag2.text()).thenReturn(SECOND_PARAM_TEXT);
+
+        when(tag3.name()).thenReturn(RETURN_TAG_NAME);
+        when(tag3.text()).thenReturn(RETURN_TAG_TEXT);
     }
 
     @Test
     public void testParamStringMapping() {
         Map<String, String> nameToCommentMap = getNameToCommentMapping(constructorDoc);
         Set<String> keySet = nameToCommentMap.keySet();
-        Assert.assertThat(keySet, hasItems(FIRST_PARAM_NAME_SNAKE_CASE, SECOND_PARAM_NAME_SNAKE_CASE));
-        Assert.assertThat(nameToCommentMap.get(FIRST_PARAM_NAME_SNAKE_CASE), equalTo(FIRST_PARAM_COMMENT));
-        Assert.assertThat(nameToCommentMap.get(SECOND_PARAM_NAME_SNAKE_CASE), equalTo(SECOND_PARAM_COMMENT));
+        assertThat(keySet, hasItems(FIRST_PARAM_NAME_SNAKE_CASE, SECOND_PARAM_NAME_SNAKE_CASE));
+        assertThat(nameToCommentMap.get(FIRST_PARAM_NAME_SNAKE_CASE), equalTo(FIRST_PARAM_COMMENT));
+        assertThat(nameToCommentMap.get(SECOND_PARAM_NAME_SNAKE_CASE), equalTo(SECOND_PARAM_COMMENT));
+        assertThat(keySet, hasSize(2));
     }
 }

--- a/codegen/src/test/java/io/improbable/keanu/codegen/python/ParamStringProcessorTest.java
+++ b/codegen/src/test/java/io/improbable/keanu/codegen/python/ParamStringProcessorTest.java
@@ -1,0 +1,59 @@
+package io.improbable.keanu.codegen.python;
+
+import com.sun.javadoc.ConstructorDoc;
+import com.sun.javadoc.Tag;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.improbable.keanu.codegen.python.ParamStringProcessor.getNameToCommentMapping;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.when;
+
+public class ParamStringProcessorTest {
+
+    private static final String FIRST_PARAM_NAME_CAMEL_CASE = "paramTest";
+    private static final String FIRST_PARAM_NAME_SNAKE_CASE = "param_test";
+    private static final String SECOND_PARAM_NAME_CAMEL_CASE = "anotherParamTest";
+    private static final String SECOND_PARAM_NAME_SNAKE_CASE = "another_param_test";
+    private static final String FIRST_PARAM_COMMENT = "This is a comment about the first parameter paramTest";
+    private static final String SECOND_PARAM_COMMENT = "This is another comment about the second parameter anotherParamTest";
+    private static final String FIRST_PARAM_TEXT = FIRST_PARAM_NAME_CAMEL_CASE + " " + FIRST_PARAM_COMMENT;
+    private static final String SECOND_PARAM_TEXT = SECOND_PARAM_NAME_CAMEL_CASE + "   " + SECOND_PARAM_COMMENT;
+    private static final String PARAM_TAG_NAME = "@param";
+
+    @Mock ConstructorDoc constructorDoc;
+    @Mock Tag tag1;
+    @Mock Tag tag2;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Before
+    public void initialiseMocks() {
+        when(constructorDoc.tags(PARAM_TAG_NAME)).thenReturn(new Tag[] {tag1, tag2});
+
+        when(tag1.name()).thenReturn(PARAM_TAG_NAME);
+        when(tag1.text()).thenReturn(FIRST_PARAM_TEXT);
+
+        when(tag2.name()).thenReturn(PARAM_TAG_NAME);
+        when(tag2.text()).thenReturn(SECOND_PARAM_TEXT);
+    }
+
+    @Test
+    public void testParamStringMapping() {
+        Map<String, String> nameToCommentMap = getNameToCommentMapping(constructorDoc);
+        Set<String> keySet = nameToCommentMap.keySet();
+        Assert.assertThat(keySet, hasItems(FIRST_PARAM_NAME_SNAKE_CASE, SECOND_PARAM_NAME_SNAKE_CASE));
+        Assert.assertThat(nameToCommentMap.get(FIRST_PARAM_NAME_SNAKE_CASE), equalTo(FIRST_PARAM_COMMENT));
+        Assert.assertThat(nameToCommentMap.get(SECOND_PARAM_NAME_SNAKE_CASE), equalTo(SECOND_PARAM_COMMENT));
+    }
+}

--- a/codegen/src/test/java/io/improbable/keanu/codegen/python/ParamStringProcessorTest.java
+++ b/codegen/src/test/java/io/improbable/keanu/codegen/python/ParamStringProcessorTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import static io.improbable.keanu.codegen.python.ParamStringProcessor.getNameToCommentMapping;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -61,8 +62,8 @@ public class ParamStringProcessorTest {
         Map<String, String> nameToCommentMap = getNameToCommentMapping(constructorDoc);
         Set<String> keySet = nameToCommentMap.keySet();
         assertThat(keySet, hasItems(FIRST_PARAM_NAME_SNAKE_CASE, SECOND_PARAM_NAME_SNAKE_CASE));
-        assertThat(nameToCommentMap.get(FIRST_PARAM_NAME_SNAKE_CASE), equalTo(FIRST_PARAM_COMMENT));
-        assertThat(nameToCommentMap.get(SECOND_PARAM_NAME_SNAKE_CASE), equalTo(SECOND_PARAM_COMMENT));
+        assertThat(nameToCommentMap, hasEntry(equalTo(FIRST_PARAM_NAME_SNAKE_CASE), equalTo(FIRST_PARAM_COMMENT)));
+        assertThat(nameToCommentMap, hasEntry(equalTo(SECOND_PARAM_NAME_SNAKE_CASE), equalTo(SECOND_PARAM_COMMENT)));
         assertThat(keySet, hasSize(2));
     }
 }

--- a/keanu-python/keanu/vertex/generated.py
+++ b/keanu-python/keanu/vertex/generated.py
@@ -38,52 +38,42 @@ java_import(context.jvm_view(), "io.improbable.keanu.vertices.intgr.probabilisti
 
 
 def ConstantBool(constant) -> context.jvm_view().ConstantBoolVertex:
-    
     return Vertex(context.jvm_view().ConstantBoolVertex, constant)
 
 
 def Equals(a, b) -> context.jvm_view().EqualsVertex:
-    
     return Vertex(context.jvm_view().EqualsVertex, a, b)
 
 
 def GreaterThanOrEqual(a, b) -> context.jvm_view().GreaterThanOrEqualVertex:
-    
     return Vertex(context.jvm_view().GreaterThanOrEqualVertex, a, b)
 
 
 def GreaterThan(a, b) -> context.jvm_view().GreaterThanVertex:
-    
     return Vertex(context.jvm_view().GreaterThanVertex, a, b)
 
 
 def LessThanOrEqual(a, b) -> context.jvm_view().LessThanOrEqualVertex:
-    
     return Vertex(context.jvm_view().LessThanOrEqualVertex, a, b)
 
 
 def LessThan(a, b) -> context.jvm_view().LessThanVertex:
-    
     return Vertex(context.jvm_view().LessThanVertex, a, b)
 
 
 def NotEquals(a, b) -> context.jvm_view().NotEqualsVertex:
-    
     return Vertex(context.jvm_view().NotEqualsVertex, a, b)
 
 
 def CastDouble(input_vertex) -> context.jvm_view().CastDoubleVertex:
-    
     return Vertex(context.jvm_view().CastDoubleVertex, input_vertex)
 
 
 def ConstantDouble(constant) -> context.jvm_view().ConstantDoubleVertex:
-    
     return Vertex(context.jvm_view().ConstantDoubleVertex, constant)
 
 
 def DoubleIf(shape, predicate, thn, els) -> context.jvm_view().DoubleIfVertex:
-    
     return Vertex(context.jvm_view().DoubleIfVertex, shape, predicate, thn, els)
 
 
@@ -177,7 +167,6 @@ def Round(input_vertex) -> context.jvm_view().RoundVertex:
 
 
 def Cauchy(location, scale) -> context.jvm_view().CauchyVertex:
-    
     return Vertex(context.jvm_view().CauchyVertex, location, scale)
 
 
@@ -201,7 +190,6 @@ def Gamma(theta, k) -> context.jvm_view().GammaVertex:
 
 
 def Gaussian(mu, sigma) -> context.jvm_view().GaussianVertex:
-    
     return Vertex(context.jvm_view().GaussianVertex, mu, sigma)
 
 
@@ -217,7 +205,6 @@ def Uniform(x_min, x_max) -> context.jvm_view().UniformVertex:
 
 
 def ConstantInteger(constant) -> context.jvm_view().ConstantIntegerVertex:
-    
     return Vertex(context.jvm_view().ConstantIntegerVertex, constant)
 
 
@@ -242,5 +229,4 @@ def Poisson(mu) -> context.jvm_view().PoissonVertex:
 
 
 def UniformInt(min, max) -> context.jvm_view().UniformIntVertex:
-    
     return Vertex(context.jvm_view().UniformIntVertex, min, max)

--- a/keanu-python/keanu/vertex/generated.py
+++ b/keanu-python/keanu/vertex/generated.py
@@ -80,6 +80,7 @@ def DoubleIf(shape, predicate, thn, els) -> context.jvm_view().DoubleIfVertex:
 def Addition(left, right) -> context.jvm_view().AdditionVertex:
     """
     Adds one vertex to another
+
     :param left: a vertex to add
     :param right: a vertex to add
     """
@@ -89,6 +90,7 @@ def Addition(left, right) -> context.jvm_view().AdditionVertex:
 def Difference(left, right) -> context.jvm_view().DifferenceVertex:
     """
     Subtracts one vertex from another
+
     :param left: the vertex that will be subtracted from
     :param right: the vertex to subtract
     """
@@ -98,6 +100,7 @@ def Difference(left, right) -> context.jvm_view().DifferenceVertex:
 def Division(left, right) -> context.jvm_view().DivisionVertex:
     """
     Divides one vertex by another
+
     :param left: the vertex to be divided
     :param right: the vertex to divide
     """
@@ -107,6 +110,7 @@ def Division(left, right) -> context.jvm_view().DivisionVertex:
 def Multiplication(left, right) -> context.jvm_view().MultiplicationVertex:
     """
     Multiplies one vertex by another
+
     :param left: vertex to be multiplied
     :param right: vertex to be multiplied
     """
@@ -116,6 +120,7 @@ def Multiplication(left, right) -> context.jvm_view().MultiplicationVertex:
 def Power(base, exponent) -> context.jvm_view().PowerVertex:
     """
     Raises a vertex to the power of another
+
     :param base: the base vertex
     :param exponent: the exponent vertex
     """
@@ -125,6 +130,7 @@ def Power(base, exponent) -> context.jvm_view().PowerVertex:
 def Abs(input_vertex) -> context.jvm_view().AbsVertex:
     """
     Takes the absolute of a vertex
+
     :param input_vertex: the vertex
     """
     return Vertex(context.jvm_view().AbsVertex, input_vertex)
@@ -134,6 +140,7 @@ def Ceil(input_vertex) -> context.jvm_view().CeilVertex:
     """
     Applies the Ceiling operator to a vertex.
     This maps a vertex to the smallest integer greater than or equal to its value
+
     :param input_vertex: the vertex to be ceil'd
     """
     return Vertex(context.jvm_view().CeilVertex, input_vertex)
@@ -143,6 +150,7 @@ def Floor(input_vertex) -> context.jvm_view().FloorVertex:
     """
     Applies the Floor operator to a vertex.
     This maps a vertex to the biggest integer less than or equal to its value
+
     :param input_vertex: the vertex to be floor'd
     """
     return Vertex(context.jvm_view().FloorVertex, input_vertex)
@@ -152,6 +160,7 @@ def Round(input_vertex) -> context.jvm_view().RoundVertex:
     """
     Applies the Rounding operator to a vertex.
     This maps a vertex to the nearest integer value
+
     :param input_vertex: the vertex to be rounded
     """
     return Vertex(context.jvm_view().RoundVertex, input_vertex)
@@ -164,6 +173,7 @@ def Cauchy(location, scale) -> context.jvm_view().CauchyVertex:
 def Exponential(rate) -> context.jvm_view().ExponentialVertex:
     """
     One to one constructor for mapping some shape of rate to matching shaped exponential.
+
     :param rate: the rate of the Exponential with either the same shape as specified for this vertex or scalar
     """
     return Vertex(context.jvm_view().ExponentialVertex, rate)
@@ -172,6 +182,7 @@ def Exponential(rate) -> context.jvm_view().ExponentialVertex:
 def Gamma(theta, k) -> context.jvm_view().GammaVertex:
     """
     One to one constructor for mapping some shape of theta and k to matching shaped gamma.
+
     :param k: the k (shape) of the Gamma with either the same shape as specified for this vertex
     :param theta: the theta (scale) of the Gamma with either the same shape as specified for this vertex
     """
@@ -186,6 +197,7 @@ def Uniform(x_min, x_max) -> context.jvm_view().UniformVertex:
     """
     One to one constructor for mapping some shape of mu and sigma to
     a matching shaped Uniform Vertex
+
     :param x_max: the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
     :param x_min: the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
     """
@@ -199,6 +211,7 @@ def ConstantInteger(constant) -> context.jvm_view().ConstantIntegerVertex:
 def IntegerDivision(a, b) -> context.jvm_view().IntegerDivisionVertex:
     """
     Divides one vertex by another
+
     :param a: a vertex to be divided
     :param b: a vertex to divide by
     """
@@ -209,6 +222,7 @@ def Poisson(mu) -> context.jvm_view().PoissonVertex:
     """
     One to one constructor for mapping some shape of mu to
     a matching shaped Poisson.
+
     :param mu: mu with same shape as desired Poisson tensor or scalar
     """
     return Vertex(context.jvm_view().PoissonVertex, mu)

--- a/keanu-python/keanu/vertex/generated.py
+++ b/keanu-python/keanu/vertex/generated.py
@@ -183,8 +183,8 @@ def Gamma(theta, k) -> context.jvm_view().GammaVertex:
     """
     One to one constructor for mapping some shape of theta and k to matching shaped gamma.
 
-    :param k: the k (shape) of the Gamma with either the same shape as specified for this vertex
     :param theta: the theta (scale) of the Gamma with either the same shape as specified for this vertex
+    :param k: the k (shape) of the Gamma with either the same shape as specified for this vertex
     """
     return Vertex(context.jvm_view().GammaVertex, theta, k)
 
@@ -198,8 +198,8 @@ def Uniform(x_min, x_max) -> context.jvm_view().UniformVertex:
     One to one constructor for mapping some shape of mu and sigma to
     a matching shaped Uniform Vertex
 
-    :param x_max: the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
     :param x_min: the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
+    :param x_max: the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
     """
     return Vertex(context.jvm_view().UniformVertex, x_min, x_max)
 

--- a/keanu-python/keanu/vertex/generated.py
+++ b/keanu-python/keanu/vertex/generated.py
@@ -125,7 +125,7 @@ def Power(base, exponent) -> context.jvm_view().PowerVertex:
 def Abs(input_vertex) -> context.jvm_view().AbsVertex:
     """
     Takes the absolute of a vertex
-    :param inputVertex: the vertex
+    :param input_vertex: the vertex
     """
     return Vertex(context.jvm_view().AbsVertex, input_vertex)
 
@@ -134,7 +134,7 @@ def Ceil(input_vertex) -> context.jvm_view().CeilVertex:
     """
     Applies the Ceiling operator to a vertex.
     This maps a vertex to the smallest integer greater than or equal to its value
-    :param inputVertex: the vertex to be ceil'd
+    :param input_vertex: the vertex to be ceil'd
     """
     return Vertex(context.jvm_view().CeilVertex, input_vertex)
 
@@ -143,7 +143,7 @@ def Floor(input_vertex) -> context.jvm_view().FloorVertex:
     """
     Applies the Floor operator to a vertex.
     This maps a vertex to the biggest integer less than or equal to its value
-    :param inputVertex: the vertex to be floor'd
+    :param input_vertex: the vertex to be floor'd
     """
     return Vertex(context.jvm_view().FloorVertex, input_vertex)
 
@@ -152,7 +152,7 @@ def Round(input_vertex) -> context.jvm_view().RoundVertex:
     """
     Applies the Rounding operator to a vertex.
     This maps a vertex to the nearest integer value
-    :param inputVertex: the vertex to be rounded
+    :param input_vertex: the vertex to be rounded
     """
     return Vertex(context.jvm_view().RoundVertex, input_vertex)
 
@@ -186,8 +186,8 @@ def Uniform(x_min, x_max) -> context.jvm_view().UniformVertex:
     """
     One to one constructor for mapping some shape of mu and sigma to
     a matching shaped Uniform Vertex
-    :param xMax: the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
-    :param xMin: the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
+    :param x_max: the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
+    :param x_min: the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
     """
     return Vertex(context.jvm_view().UniformVertex, x_min, x_max)
 

--- a/keanu-python/keanu/vertex/generated.py
+++ b/keanu-python/keanu/vertex/generated.py
@@ -38,49 +38,59 @@ java_import(context.jvm_view(), "io.improbable.keanu.vertices.intgr.probabilisti
 
 
 def ConstantBool(constant) -> context.jvm_view().ConstantBoolVertex:
+    
     return Vertex(context.jvm_view().ConstantBoolVertex, constant)
 
 
 def Equals(a, b) -> context.jvm_view().EqualsVertex:
+    
     return Vertex(context.jvm_view().EqualsVertex, a, b)
 
 
 def GreaterThanOrEqual(a, b) -> context.jvm_view().GreaterThanOrEqualVertex:
+    
     return Vertex(context.jvm_view().GreaterThanOrEqualVertex, a, b)
 
 
 def GreaterThan(a, b) -> context.jvm_view().GreaterThanVertex:
+    
     return Vertex(context.jvm_view().GreaterThanVertex, a, b)
 
 
 def LessThanOrEqual(a, b) -> context.jvm_view().LessThanOrEqualVertex:
+    
     return Vertex(context.jvm_view().LessThanOrEqualVertex, a, b)
 
 
 def LessThan(a, b) -> context.jvm_view().LessThanVertex:
+    
     return Vertex(context.jvm_view().LessThanVertex, a, b)
 
 
 def NotEquals(a, b) -> context.jvm_view().NotEqualsVertex:
+    
     return Vertex(context.jvm_view().NotEqualsVertex, a, b)
 
 
 def CastDouble(input_vertex) -> context.jvm_view().CastDoubleVertex:
+    
     return Vertex(context.jvm_view().CastDoubleVertex, input_vertex)
 
 
 def ConstantDouble(constant) -> context.jvm_view().ConstantDoubleVertex:
+    
     return Vertex(context.jvm_view().ConstantDoubleVertex, constant)
 
 
 def DoubleIf(shape, predicate, thn, els) -> context.jvm_view().DoubleIfVertex:
+    
     return Vertex(context.jvm_view().DoubleIfVertex, shape, predicate, thn, els)
 
 
 def Addition(left, right) -> context.jvm_view().AdditionVertex:
     """
     Adds one vertex to another
-
+    
     :param left: a vertex to add
     :param right: a vertex to add
     """
@@ -90,7 +100,7 @@ def Addition(left, right) -> context.jvm_view().AdditionVertex:
 def Difference(left, right) -> context.jvm_view().DifferenceVertex:
     """
     Subtracts one vertex from another
-
+    
     :param left: the vertex that will be subtracted from
     :param right: the vertex to subtract
     """
@@ -100,7 +110,7 @@ def Difference(left, right) -> context.jvm_view().DifferenceVertex:
 def Division(left, right) -> context.jvm_view().DivisionVertex:
     """
     Divides one vertex by another
-
+    
     :param left: the vertex to be divided
     :param right: the vertex to divide
     """
@@ -110,7 +120,7 @@ def Division(left, right) -> context.jvm_view().DivisionVertex:
 def Multiplication(left, right) -> context.jvm_view().MultiplicationVertex:
     """
     Multiplies one vertex by another
-
+    
     :param left: vertex to be multiplied
     :param right: vertex to be multiplied
     """
@@ -120,7 +130,7 @@ def Multiplication(left, right) -> context.jvm_view().MultiplicationVertex:
 def Power(base, exponent) -> context.jvm_view().PowerVertex:
     """
     Raises a vertex to the power of another
-
+    
     :param base: the base vertex
     :param exponent: the exponent vertex
     """
@@ -130,7 +140,7 @@ def Power(base, exponent) -> context.jvm_view().PowerVertex:
 def Abs(input_vertex) -> context.jvm_view().AbsVertex:
     """
     Takes the absolute of a vertex
-
+    
     :param input_vertex: the vertex
     """
     return Vertex(context.jvm_view().AbsVertex, input_vertex)
@@ -140,7 +150,7 @@ def Ceil(input_vertex) -> context.jvm_view().CeilVertex:
     """
     Applies the Ceiling operator to a vertex.
     This maps a vertex to the smallest integer greater than or equal to its value
-
+    
     :param input_vertex: the vertex to be ceil'd
     """
     return Vertex(context.jvm_view().CeilVertex, input_vertex)
@@ -150,7 +160,7 @@ def Floor(input_vertex) -> context.jvm_view().FloorVertex:
     """
     Applies the Floor operator to a vertex.
     This maps a vertex to the biggest integer less than or equal to its value
-
+    
     :param input_vertex: the vertex to be floor'd
     """
     return Vertex(context.jvm_view().FloorVertex, input_vertex)
@@ -160,20 +170,21 @@ def Round(input_vertex) -> context.jvm_view().RoundVertex:
     """
     Applies the Rounding operator to a vertex.
     This maps a vertex to the nearest integer value
-
+    
     :param input_vertex: the vertex to be rounded
     """
     return Vertex(context.jvm_view().RoundVertex, input_vertex)
 
 
 def Cauchy(location, scale) -> context.jvm_view().CauchyVertex:
+    
     return Vertex(context.jvm_view().CauchyVertex, location, scale)
 
 
 def Exponential(rate) -> context.jvm_view().ExponentialVertex:
     """
     One to one constructor for mapping some shape of rate to matching shaped exponential.
-
+    
     :param rate: the rate of the Exponential with either the same shape as specified for this vertex or scalar
     """
     return Vertex(context.jvm_view().ExponentialVertex, rate)
@@ -182,7 +193,7 @@ def Exponential(rate) -> context.jvm_view().ExponentialVertex:
 def Gamma(theta, k) -> context.jvm_view().GammaVertex:
     """
     One to one constructor for mapping some shape of theta and k to matching shaped gamma.
-
+    
     :param theta: the theta (scale) of the Gamma with either the same shape as specified for this vertex
     :param k: the k (shape) of the Gamma with either the same shape as specified for this vertex
     """
@@ -190,6 +201,7 @@ def Gamma(theta, k) -> context.jvm_view().GammaVertex:
 
 
 def Gaussian(mu, sigma) -> context.jvm_view().GaussianVertex:
+    
     return Vertex(context.jvm_view().GaussianVertex, mu, sigma)
 
 
@@ -197,7 +209,7 @@ def Uniform(x_min, x_max) -> context.jvm_view().UniformVertex:
     """
     One to one constructor for mapping some shape of mu and sigma to
     a matching shaped Uniform Vertex
-
+    
     :param x_min: the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
     :param x_max: the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
     """
@@ -205,13 +217,14 @@ def Uniform(x_min, x_max) -> context.jvm_view().UniformVertex:
 
 
 def ConstantInteger(constant) -> context.jvm_view().ConstantIntegerVertex:
+    
     return Vertex(context.jvm_view().ConstantIntegerVertex, constant)
 
 
 def IntegerDivision(a, b) -> context.jvm_view().IntegerDivisionVertex:
     """
     Divides one vertex by another
-
+    
     :param a: a vertex to be divided
     :param b: a vertex to divide by
     """
@@ -222,11 +235,12 @@ def Poisson(mu) -> context.jvm_view().PoissonVertex:
     """
     One to one constructor for mapping some shape of mu to
     a matching shaped Poisson.
-
+    
     :param mu: mu with same shape as desired Poisson tensor or scalar
     """
     return Vertex(context.jvm_view().PoissonVertex, mu)
 
 
 def UniformInt(min, max) -> context.jvm_view().UniformIntVertex:
+    
     return Vertex(context.jvm_view().UniformIntVertex, min, max)

--- a/keanu-python/keanu/vertex/generated.py
+++ b/keanu-python/keanu/vertex/generated.py
@@ -78,38 +78,82 @@ def DoubleIf(shape, predicate, thn, els) -> context.jvm_view().DoubleIfVertex:
 
 
 def Addition(left, right) -> context.jvm_view().AdditionVertex:
+    """
+    Adds one vertex to another
+    :param left: a vertex to add
+    :param right: a vertex to add
+    """
     return Vertex(context.jvm_view().AdditionVertex, left, right)
 
 
 def Difference(left, right) -> context.jvm_view().DifferenceVertex:
+    """
+    Subtracts one vertex from another
+    :param left: the vertex that will be subtracted from
+    :param right: the vertex to subtract
+    """
     return Vertex(context.jvm_view().DifferenceVertex, left, right)
 
 
 def Division(left, right) -> context.jvm_view().DivisionVertex:
+    """
+    Divides one vertex by another
+    :param left: the vertex to be divided
+    :param right: the vertex to divide
+    """
     return Vertex(context.jvm_view().DivisionVertex, left, right)
 
 
 def Multiplication(left, right) -> context.jvm_view().MultiplicationVertex:
+    """
+    Multiplies one vertex by another
+    :param left: vertex to be multiplied
+    :param right: vertex to be multiplied
+    """
     return Vertex(context.jvm_view().MultiplicationVertex, left, right)
 
 
 def Power(base, exponent) -> context.jvm_view().PowerVertex:
+    """
+    Raises a vertex to the power of another
+    :param base: the base vertex
+    :param exponent: the exponent vertex
+    """
     return Vertex(context.jvm_view().PowerVertex, base, exponent)
 
 
 def Abs(input_vertex) -> context.jvm_view().AbsVertex:
+    """
+    Takes the absolute of a vertex
+    :param inputVertex: the vertex
+    """
     return Vertex(context.jvm_view().AbsVertex, input_vertex)
 
 
 def Ceil(input_vertex) -> context.jvm_view().CeilVertex:
+    """
+    Applies the Ceiling operator to a vertex.
+    This maps a vertex to the smallest integer greater than or equal to its value
+    :param inputVertex: the vertex to be ceil'd
+    """
     return Vertex(context.jvm_view().CeilVertex, input_vertex)
 
 
 def Floor(input_vertex) -> context.jvm_view().FloorVertex:
+    """
+    Applies the Floor operator to a vertex.
+    This maps a vertex to the biggest integer less than or equal to its value
+    :param inputVertex: the vertex to be floor'd
+    """
     return Vertex(context.jvm_view().FloorVertex, input_vertex)
 
 
 def Round(input_vertex) -> context.jvm_view().RoundVertex:
+    """
+    Applies the Rounding operator to a vertex.
+    This maps a vertex to the nearest integer value
+    :param inputVertex: the vertex to be rounded
+    """
     return Vertex(context.jvm_view().RoundVertex, input_vertex)
 
 
@@ -118,10 +162,19 @@ def Cauchy(location, scale) -> context.jvm_view().CauchyVertex:
 
 
 def Exponential(rate) -> context.jvm_view().ExponentialVertex:
+    """
+    One to one constructor for mapping some shape of rate to matching shaped exponential.
+    :param rate: the rate of the Exponential with either the same shape as specified for this vertex or scalar
+    """
     return Vertex(context.jvm_view().ExponentialVertex, rate)
 
 
 def Gamma(theta, k) -> context.jvm_view().GammaVertex:
+    """
+    One to one constructor for mapping some shape of theta and k to matching shaped gamma.
+    :param k: the k (shape) of the Gamma with either the same shape as specified for this vertex
+    :param theta: the theta (scale) of the Gamma with either the same shape as specified for this vertex
+    """
     return Vertex(context.jvm_view().GammaVertex, theta, k)
 
 
@@ -130,6 +183,12 @@ def Gaussian(mu, sigma) -> context.jvm_view().GaussianVertex:
 
 
 def Uniform(x_min, x_max) -> context.jvm_view().UniformVertex:
+    """
+    One to one constructor for mapping some shape of mu and sigma to
+    a matching shaped Uniform Vertex
+    :param xMax: the exclusive upper bound of the Uniform with either the same shape as specified for this vertex or a scalar
+    :param xMin: the inclusive lower bound of the Uniform with either the same shape as specified for this vertex or a scalar
+    """
     return Vertex(context.jvm_view().UniformVertex, x_min, x_max)
 
 
@@ -138,10 +197,20 @@ def ConstantInteger(constant) -> context.jvm_view().ConstantIntegerVertex:
 
 
 def IntegerDivision(a, b) -> context.jvm_view().IntegerDivisionVertex:
+    """
+    Divides one vertex by another
+    :param a: a vertex to be divided
+    :param b: a vertex to divide by
+    """
     return Vertex(context.jvm_view().IntegerDivisionVertex, a, b)
 
 
 def Poisson(mu) -> context.jvm_view().PoissonVertex:
+    """
+    One to one constructor for mapping some shape of mu to
+    a matching shaped Poisson.
+    :param mu: mu with same shape as desired Poisson tensor or scalar
+    """
     return Vertex(context.jvm_view().PoissonVertex, mu)
 
 


### PR DESCRIPTION
This PR introduces a feature to allow python constructors to pull in JavaDoc strings from their respective Java constructors. 
This is included as a gradle task that is run whenever `codegen:codegen` is run which is the existing way of generating python code.

What is not covered: 
 - Python docs in hand written code
 - Actually creation of python docs using e.g. Sphinx
 - Any sort of generated python code that isn't a constructor