### PR TITLE
Python streaming samples

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -103,22 +103,10 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
 
         Map<VertexId, DoubleTensor> position = new HashMap<>();
         cachePosition(latentVertices, position);
-        Map<VertexId, DoubleTensor> positionBeforeLeapfrog = new HashMap<>();
-
         Map<VertexId, DoubleTensor> gradient = logProbGradientCalculator.getJointLogProbGradientWrtLatents();
-        Map<VertexId, DoubleTensor> gradientBeforeLeapfrog = new HashMap<>();
 
-        final Map<VertexId, DoubleTensor> momentum = new HashMap<>();
-        final Map<VertexId, DoubleTensor> momentumBeforeLeapfrog = new HashMap<>();
-
-        double logOfMasterPBeforeLeapfrog = bayesNet.getLogOfMasterP();
-        final List<Double> logOfMasterPForEachSample = new ArrayList<>();
-        logOfMasterPForEachSample.add(logOfMasterPBeforeLeapfrog);
-
-        final Map<VertexId, ?> sampleBeforeLeapfrog = new HashMap<>();
-
-        HamiltonianSampler.VertexState before = new HamiltonianSampler.VertexState(position, gradient, momentum);
-        HamiltonianSampler.VertexState after = new HamiltonianSampler.VertexState(positionBeforeLeapfrog, gradientBeforeLeapfrog, momentumBeforeLeapfrog);
+        HamiltonianSampler.VertexState before = new HamiltonianSampler.VertexState(position, gradient);
+        HamiltonianSampler.VertexState after = new HamiltonianSampler.VertexState(new HashMap<>(), new HashMap<>());
 
         return new HamiltonianSampler(
             latentVertices,
@@ -129,9 +117,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
             bayesNet,
             before,
             after,
-            logProbGradientCalculator,
-            sampleBeforeLeapfrog,
-            logOfMasterPBeforeLeapfrog
+            logProbGradientCalculator
         );
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -13,7 +13,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -118,13 +118,13 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
 
         final Map<VertexId, ?> sampleBeforeLeapfrog = new HashMap<>();
 
-        return new Sampler(latentVertices, position, gradient, momentum, positionBeforeLeapfrog,
+        return new HamiltonianSampler(latentVertices, position, gradient, momentum, positionBeforeLeapfrog,
             gradientBeforeLeapfrog, momentumBeforeLeapfrog, random, fromVertices, leapFrogCount,
             stepSize, logProbGradientCalculator, sampleBeforeLeapfrog, bayesNet, logOfMasterPBeforeLeapfrog
         );
     }
 
-    public static class Sampler implements SamplingAlgorithm {
+    public static class HamiltonianSampler implements SamplingAlgorithm {
 
         private List<Vertex<DoubleTensor>> latentVertices;
         private Map<VertexId, DoubleTensor> position;
@@ -142,7 +142,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         private BayesianNetwork bayesNet;
         private double logOfMasterPBeforeLeapfrog;
 
-        public Sampler(List<Vertex<DoubleTensor>> latentVertices,
+        public HamiltonianSampler(List<Vertex<DoubleTensor>> latentVertices,
                        Map<VertexId, DoubleTensor> position,
                        Map<VertexId, DoubleTensor> gradient,
                        Map<VertexId, DoubleTensor> momentum,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -1,8 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import static io.improbable.keanu.algorithms.mcmc.HamiltonianSampler.addSampleFromVertices;
-import static io.improbable.keanu.algorithms.mcmc.HamiltonianSampler.cachePosition;
-
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
 import io.improbable.keanu.network.BayesianNetwork;
@@ -21,6 +18,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static io.improbable.keanu.algorithms.mcmc.HamiltonianSampler.addSampleFromVertices;
+import static io.improbable.keanu.algorithms.mcmc.HamiltonianSampler.cachePosition;
 
 /**
  * Hamiltonian Monte Carlo is a method for obtaining samples from a probability

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -205,10 +205,11 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         @Override
         public NetworkState sample() {
             step();
-            return new SimpleNetworkState(sampleLogic(new HashMap<>()));
+            sampleLogic(new HashMap<>());
+            return new SimpleNetworkState(takeSample(fromVertices));
         }
 
-        private Map<VertexId, ?> sampleLogic(Map<VertexId, List<?>> samples) {
+        private Map<VertexId, List<?>> sampleLogic(Map<VertexId, List<?>> samples) {
             final double logOfMasterPAfterLeapfrog = bayesNet.getLogOfMasterP();
 
             final double likelihoodOfLeapfrog = getLikelihoodOfLeapfrog(
@@ -385,5 +386,13 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
     private static <T> void addSampleForVertex(VertexId id, T value, Map<VertexId, List<?>> samples) {
         List<T> samplesForVertex = (List<T>) samples.computeIfAbsent(id, v -> new ArrayList<T>());
         samplesForVertex.add(value);
+    }
+
+    private static Map<VertexId, ?> takeSample(List<? extends Vertex> fromVertices) {
+        Map<VertexId, Object> sample = new HashMap<>();
+        for (Vertex v : fromVertices) {
+            sample.put(v.getId(), v.getValue());
+        }
+        return sample;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -1,11 +1,11 @@
 package io.improbable.keanu.algorithms.mcmc;
 
+import static io.improbable.keanu.algorithms.mcmc.HamiltonianSampler.addSampleFromVertices;
+import static io.improbable.keanu.algorithms.mcmc.HamiltonianSampler.cachePosition;
+
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
-import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
 import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.network.NetworkState;
-import io.improbable.keanu.network.SimpleNetworkState;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.util.ProgressBar;
 import io.improbable.keanu.vertices.Vertex;
@@ -72,24 +72,23 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
      * @return Samples taken with Hamiltonian Monte Carlo
      */
     @Override
-    public NetworkSamples getPosteriorSamples(BayesianNetwork bayesNet,
-                                              List<? extends Vertex> fromVertices,
-                                              int sampleCount) {
+    public NetworkSamples getPosteriorSamples(final BayesianNetwork bayesNet,
+                                              final List<? extends Vertex> fromVertices,
+                                              final int sampleCount) {
         return generatePosteriorSamples(bayesNet, fromVertices)
             .generate(sampleCount);
     }
 
-    public NetworkSamples getPosteriorSamples(BayesianNetwork bayesianNetwork,
-                                              Vertex fromVertices,
-                                              int sampleCount) {
-        return generatePosteriorSamples(bayesianNetwork, Collections.singletonList(fromVertices))
-            .generate(sampleCount);
+    public NetworkSamples getPosteriorSamples(final BayesianNetwork bayesNet,
+                                              final Vertex fromVertex,
+                                              final int sampleCount) {
+        return getPosteriorSamples(bayesNet, Collections.singletonList(fromVertex), sampleCount);
     }
 
-    public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesianNetwork,
+    public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesNet,
                                                             final List<? extends Vertex> fromVertices) {
 
-        return new NetworkSamplesGenerator(setupSampler(bayesianNetwork, fromVertices), ProgressBar::new);
+        return new NetworkSamplesGenerator(setupSampler(bayesNet, fromVertices), ProgressBar::new);
     }
 
     private SamplingAlgorithm setupSampler(final BayesianNetwork bayesNet,
@@ -118,276 +117,22 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
 
         final Map<VertexId, ?> sampleBeforeLeapfrog = new HashMap<>();
 
-        return new HamiltonianSampler(latentVertices, position, gradient, momentum, positionBeforeLeapfrog,
-            gradientBeforeLeapfrog, momentumBeforeLeapfrog, random, fromVertices, leapFrogCount,
-            stepSize, logProbGradientCalculator, sampleBeforeLeapfrog, bayesNet, logOfMasterPBeforeLeapfrog
+        HamiltonianSampler.VertexState x = new HamiltonianSampler.VertexState(position, gradient, momentum);
+        HamiltonianSampler.VertexState y = new HamiltonianSampler.VertexState(positionBeforeLeapfrog, gradientBeforeLeapfrog, momentumBeforeLeapfrog);
+
+        return new HamiltonianSampler(
+            latentVertices,
+            random,
+            fromVertices,
+            leapFrogCount,
+            stepSize,
+            bayesNet,
+            x,
+            y,
+            logProbGradientCalculator,
+            sampleBeforeLeapfrog,
+            logOfMasterPBeforeLeapfrog
         );
-    }
-
-    public static class HamiltonianSampler implements SamplingAlgorithm {
-
-        private List<Vertex<DoubleTensor>> latentVertices;
-        private Map<VertexId, DoubleTensor> position;
-        private Map<VertexId, DoubleTensor> gradient;
-        private Map<VertexId, DoubleTensor> momentum;
-        private Map<VertexId, DoubleTensor> positionBeforeLeapfrog;
-        private Map<VertexId, DoubleTensor> gradientBeforeLeapfrog;
-        private Map<VertexId, DoubleTensor> momentumBeforeLeapfrog;
-        private KeanuRandom random;
-        private List<? extends Vertex> fromVertices;
-        private int leapFrogCount;
-        private double stepSize;
-        private LogProbGradientCalculator logProbGradientCalculator;
-        private Map<VertexId, ?> sampleBeforeLeapfrog;
-        private BayesianNetwork bayesNet;
-        private double logOfMasterPBeforeLeapfrog;
-
-        public HamiltonianSampler(List<Vertex<DoubleTensor>> latentVertices,
-                       Map<VertexId, DoubleTensor> position,
-                       Map<VertexId, DoubleTensor> gradient,
-                       Map<VertexId, DoubleTensor> momentum,
-                       Map<VertexId, DoubleTensor> positionBeforeLeapfrog,
-                       Map<VertexId, DoubleTensor> momentumBeforeLeapfrog,
-                       Map<VertexId, DoubleTensor> gradientBeforeLeapfrog,
-                       KeanuRandom random,
-                       List<? extends Vertex> fromVertices,
-                       int leapFrogCount,
-                       double stepSize,
-                       LogProbGradientCalculator logProbGradientCalculator,
-                       Map<VertexId, ?> sampleBeforeLeapfrog,
-                       BayesianNetwork bayesNet,
-                       double logOfMasterPBeforeLeapfrog) {
-
-            this.latentVertices = latentVertices;
-            this.position = position;
-            this.gradient = gradient;
-            this.momentum = momentum;
-            this.positionBeforeLeapfrog = positionBeforeLeapfrog;
-            this.momentumBeforeLeapfrog = momentumBeforeLeapfrog;
-            this.gradientBeforeLeapfrog = gradientBeforeLeapfrog;
-            this.random = random;
-            this.fromVertices = fromVertices;
-            this.leapFrogCount = leapFrogCount;
-            this.stepSize = stepSize;
-            this.logProbGradientCalculator = logProbGradientCalculator;
-            this.sampleBeforeLeapfrog = sampleBeforeLeapfrog;
-            this.bayesNet = bayesNet;
-            this.logOfMasterPBeforeLeapfrog = logOfMasterPBeforeLeapfrog;
-        }
-
-        @Override
-        public void step() {
-            cache(position, positionBeforeLeapfrog);
-            cache(gradient, gradientBeforeLeapfrog);
-
-            initializeMomentumForEachVertex(latentVertices, momentum, random);
-            cache(momentum, momentumBeforeLeapfrog);
-
-            putSample(sampleBeforeLeapfrog, fromVertices);
-
-            for (int leapFrogNum = 0; leapFrogNum < leapFrogCount; leapFrogNum++) {
-                gradient = leapfrog(
-                    latentVertices,
-                    position,
-                    gradient,
-                    momentum,
-                    stepSize,
-                    logProbGradientCalculator
-                );
-            }
-        }
-
-        @Override
-        public void sample(Map<VertexId, List<?>> samples, List<Double> logOfMasterPForEachSample) {
-            step();
-            addSampleFromCache(samples, acceptOrReject());
-            logOfMasterPForEachSample.add(logOfMasterPBeforeLeapfrog);
-        }
-
-        @Override
-        public NetworkState sample() {
-            step();
-            return new SimpleNetworkState(acceptOrReject());
-        }
-
-        private Map<VertexId, ?> acceptOrReject() {
-            final double logOfMasterPAfterLeapfrog = bayesNet.getLogOfMasterP();
-
-            final double likelihoodOfLeapfrog = getLikelihoodOfLeapfrog(
-                logOfMasterPAfterLeapfrog,
-                logOfMasterPBeforeLeapfrog,
-                momentum,
-                momentumBeforeLeapfrog
-            );
-
-            if (shouldReject(likelihoodOfLeapfrog, random)) {
-
-                //Revert to position and gradient before leapfrog
-                Map<VertexId, DoubleTensor> tempSwap = position;
-                position = positionBeforeLeapfrog;
-                positionBeforeLeapfrog = tempSwap;
-
-                tempSwap = gradient;
-                gradient = gradientBeforeLeapfrog;
-                gradientBeforeLeapfrog = tempSwap;
-
-                return sampleBeforeLeapfrog;
-            } else {
-                logOfMasterPBeforeLeapfrog = logOfMasterPAfterLeapfrog;
-                Map<VertexId, ?> sample = new HashMap<>();
-                putSample(sample, fromVertices);
-                return sample;
-            }
-        }
-
-    }
-
-    private static void cachePosition(List<Vertex<DoubleTensor>> latentVertices, Map<VertexId, DoubleTensor> position) {
-        for (Vertex<DoubleTensor> vertex : latentVertices) {
-            position.put(vertex.getId(), vertex.getValue());
-        }
-    }
-
-    private static void initializeMomentumForEachVertex(List<Vertex<DoubleTensor>> vertexes,
-                                                        Map<VertexId, DoubleTensor> momentums,
-                                                        KeanuRandom random) {
-        for (Vertex<DoubleTensor> currentVertex : vertexes) {
-            momentums.put(currentVertex.getId(), random.nextGaussian(currentVertex.getShape()));
-        }
-    }
-
-    private static void cache(Map<VertexId, DoubleTensor> from, Map<VertexId, DoubleTensor> to) {
-        for (Map.Entry<VertexId, DoubleTensor> entry : from.entrySet()) {
-            to.put(entry.getKey(), entry.getValue());
-        }
-    }
-
-    /**
-     * function Leapfrog(T, r)
-     * Set `r = r + (eps/2)dTL(T)
-     * Set `T = T + r`
-     * Set `r = r` + (eps/2)dTL(`T)
-     * return `T, r`
-     *
-     * @param latentVertices
-     * @param position
-     * @param gradient        gradient at current position
-     * @param momentums       current vertex momentums
-     * @param stepSize
-     * @param logProbGradient calculator of the logProb gradients
-     * @return the gradient at the updated position
-     */
-    private static Map<VertexId, DoubleTensor> leapfrog(final List<Vertex<DoubleTensor>> latentVertices,
-                                                        final Map<VertexId, DoubleTensor> position,
-                                                        final Map<VertexId, DoubleTensor> gradient,
-                                                        final Map<VertexId, DoubleTensor> momentums,
-                                                        final double stepSize,
-                                                        final LogProbGradientCalculator logProbGradient) {
-
-        final double halfTimeStep = stepSize / 2.0;
-
-        Map<VertexId, DoubleTensor> momentumsAtHalfTimeStep = new HashMap<>();
-
-        //Set `r = r + (eps/2)dTL(T)
-        for (Map.Entry<VertexId, DoubleTensor> vertexMomentum : momentums.entrySet()) {
-            final DoubleTensor updatedMomentum = gradient.get(vertexMomentum.getKey()).times(halfTimeStep).plusInPlace(vertexMomentum.getValue());
-            momentumsAtHalfTimeStep.put(vertexMomentum.getKey(), updatedMomentum);
-        }
-
-        //Set `T = T + `r.
-        for (Vertex<DoubleTensor> latent : latentVertices) {
-            final DoubleTensor nextPosition = momentumsAtHalfTimeStep.get(latent.getId()).times(halfTimeStep).plusInPlace(position.get(latent.getId()));
-            position.put(latent.getId(), nextPosition);
-            latent.setValue(nextPosition);
-        }
-
-        VertexValuePropagation.cascadeUpdate(latentVertices);
-
-        //Set `r = `r + (eps/2)dTL(`T)
-        Map<VertexId, DoubleTensor> newGradient = logProbGradient.getJointLogProbGradientWrtLatents();
-
-        for (Map.Entry<VertexId, DoubleTensor> halfTimeStepMomentum : momentumsAtHalfTimeStep.entrySet()) {
-            final DoubleTensor updatedMomentum = newGradient.get(halfTimeStepMomentum.getKey()).times(halfTimeStep).plusInPlace(halfTimeStepMomentum.getValue());
-            momentums.put(halfTimeStepMomentum.getKey(), updatedMomentum);
-        }
-
-        return newGradient;
-    }
-
-    private static double getLikelihoodOfLeapfrog(final double logOfMasterPAfterLeapfrog,
-                                                  final double previousLogOfMasterP,
-                                                  final Map<VertexId, DoubleTensor> leapfroggedMomentum,
-                                                  final Map<VertexId, DoubleTensor> momentumPreviousTimeStep) {
-
-        final double leapFroggedMomentumDotProduct = (0.5 * dotProduct(leapfroggedMomentum));
-        final double previousMomentumDotProduct = (0.5 * dotProduct(momentumPreviousTimeStep));
-
-        final double leapFroggedLikelihood = logOfMasterPAfterLeapfrog - leapFroggedMomentumDotProduct;
-        final double previousLikelihood = previousLogOfMasterP - previousMomentumDotProduct;
-
-        final double logLikelihoodOfLeapFrog = leapFroggedLikelihood - previousLikelihood;
-        final double likelihoodOfLeapfrog = Math.exp(logLikelihoodOfLeapFrog);
-
-        return Math.min(likelihoodOfLeapfrog, 1.0);
-    }
-
-    private static boolean shouldReject(double likelihood, KeanuRandom random) {
-        return likelihood < random.nextDouble();
-    }
-
-    private static double dotProduct(Map<VertexId, DoubleTensor> momentums) {
-        double dotProduct = 0.0;
-        for (DoubleTensor momentum : momentums.values()) {
-            dotProduct += momentum.pow(2).sum();
-        }
-        return dotProduct;
-    }
-
-    /**
-     * This is meant to be used for caching a pre-leapfrog sample. This sample
-     * will be used if the leapfrog is rejected.
-     *
-     * @param sample
-     * @param fromVertices
-     */
-    private static void putSample(Map<VertexId, ?> sample, List<? extends Vertex> fromVertices) {
-        for (Vertex<?> vertex : fromVertices) {
-            putValue(vertex, sample);
-        }
-    }
-
-    private static <T> void putValue(Vertex<T> vertex, Map<VertexId, ?> target) {
-        ((Map<VertexId, T>) target).put(vertex.getId(), vertex.getValue());
-    }
-
-    /**
-     * This is used when a leapfrog is rejected. At that point the vertices are in a post
-     * leapfrog state and a pre-leapfrog sample must be used.
-     *
-     * @param samples
-     * @param cachedSample a cached sample from before leapfrog
-     */
-    private static void addSampleFromCache(Map<VertexId, List<?>> samples, Map<VertexId, ?> cachedSample) {
-        for (Map.Entry<VertexId, ?> sampleEntry : cachedSample.entrySet()) {
-            addSampleForVertex(sampleEntry.getKey(), sampleEntry.getValue(), samples);
-        }
-    }
-
-    /**
-     * This is used when a leapfrog is accepted. At that point the vertices are in a
-     * post leapfrog state.
-     *
-     * @param fromVertices vertices from which to create and save new sample.
-     */
-    private static void addSampleFromVertices(Map<VertexId, List<?>> samples, List<? extends Vertex> fromVertices) {
-        for (Vertex<?> vertex : fromVertices) {
-            addSampleForVertex(vertex.getId(), vertex.getValue(), samples);
-        }
-    }
-
-    private static <T> void addSampleForVertex(VertexId id, T value, Map<VertexId, List<?>> samples) {
-        List<T> samplesForVertex = (List<T>) samples.computeIfAbsent(id, v -> new ArrayList<T>());
-        samplesForVertex.add(value);
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -117,8 +117,8 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
 
         final Map<VertexId, ?> sampleBeforeLeapfrog = new HashMap<>();
 
-        HamiltonianSampler.VertexState x = new HamiltonianSampler.VertexState(position, gradient, momentum);
-        HamiltonianSampler.VertexState y = new HamiltonianSampler.VertexState(positionBeforeLeapfrog, gradientBeforeLeapfrog, momentumBeforeLeapfrog);
+        HamiltonianSampler.VertexState before = new HamiltonianSampler.VertexState(position, gradient, momentum);
+        HamiltonianSampler.VertexState after = new HamiltonianSampler.VertexState(positionBeforeLeapfrog, gradientBeforeLeapfrog, momentumBeforeLeapfrog);
 
         return new HamiltonianSampler(
             latentVertices,
@@ -127,8 +127,8 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
             leapFrogCount,
             stepSize,
             bayesNet,
-            x,
-            y,
+            before,
+            after,
             logProbGradientCalculator,
             sampleBeforeLeapfrog,
             logOfMasterPBeforeLeapfrog

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -181,7 +181,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
             initializeMomentumForEachVertex(latentVertices, momentum, random);
             cache(momentum, momentumBeforeLeapfrog);
 
-            takeSample(sampleBeforeLeapfrog, fromVertices);
+            putSample(sampleBeforeLeapfrog, fromVertices);
 
             for (int leapFrogNum = 0; leapFrogNum < leapFrogCount; leapFrogNum++) {
                 gradient = leapfrog(
@@ -236,6 +236,14 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
                 logOfMasterPBeforeLeapfrog = logOfMasterPAfterLeapfrog;
             }
             return samples;
+        }
+
+        private static Map<VertexId, ?> takeSample(List<? extends Vertex> fromVertices) {
+            Map<VertexId, Object> sample = new HashMap<>();
+            for (Vertex v : fromVertices) {
+                sample.put(v.getId(), v.getValue());
+            }
+            return sample;
         }
     }
 
@@ -340,14 +348,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         return dotProduct;
     }
 
-    /**
-     * This is meant to be used for caching a pre-leapfrog sample. This sample
-     * will be used if the leapfrog is rejected.
-     *
-     * @param sample
-     * @param fromVertices
-     */
-    private static void takeSample(Map<VertexId, ?> sample, List<? extends Vertex> fromVertices) {
+    private static void putSample(Map<VertexId, ?> sample, List<? extends Vertex> fromVertices) {
         for (Vertex<?> vertex : fromVertices) {
             putValue(vertex, sample);
         }
@@ -388,11 +389,4 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
         samplesForVertex.add(value);
     }
 
-    private static Map<VertexId, ?> takeSample(List<? extends Vertex> fromVertices) {
-        Map<VertexId, Object> sample = new HashMap<>();
-        for (Vertex v : fromVertices) {
-            sample.put(v.getId(), v.getValue());
-        }
-        return sample;
-    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/HamiltonianSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/HamiltonianSampler.java
@@ -1,10 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.network.NetworkState;
@@ -14,6 +9,11 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class HamiltonianSampler implements SamplingAlgorithm {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/HamiltonianSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/HamiltonianSampler.java
@@ -253,7 +253,7 @@ public class HamiltonianSampler implements SamplingAlgorithm {
             this.momentum = new HashMap<>();
         }
 
-        void cacheState(VertexState that) {
+        private void cacheState(VertexState that) {
             that.position.putAll(position);
             that.gradient.putAll(gradient);
             that.momentum.putAll(momentum);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/HamiltonianSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/HamiltonianSampler.java
@@ -1,0 +1,280 @@
+package io.improbable.keanu.algorithms.mcmc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.improbable.keanu.algorithms.graphtraversal.VertexValuePropagation;
+import io.improbable.keanu.network.BayesianNetwork;
+import io.improbable.keanu.network.NetworkState;
+import io.improbable.keanu.network.SimpleNetworkState;
+import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
+
+public class HamiltonianSampler implements SamplingAlgorithm {
+
+    private final List<Vertex<DoubleTensor>> latentVertices;
+    private final KeanuRandom random;
+    private final List<? extends Vertex> fromVertices;
+    private final int leapFrogCount;
+    private final double stepSize;
+    private final BayesianNetwork bayesNet;
+
+    private VertexState during;
+    private VertexState before;
+    private LogProbGradientCalculator logProbGradientCalculator;
+    private Map<VertexId, ?> sampleBeforeLeapfrog;
+    private double logOfMasterPBeforeLeapfrog;
+
+    public HamiltonianSampler(List<Vertex<DoubleTensor>> latentVertices,
+                              KeanuRandom random,
+                              List<? extends Vertex> fromVertices,
+                              int leapFrogCount,
+                              double stepSize,
+                              BayesianNetwork bayesNet,
+                              VertexState during,
+                              VertexState before,
+                              LogProbGradientCalculator logProbGradientCalculator,
+                              Map<VertexId, ?> sampleBeforeLeapfrog,
+                              double logOfMasterPBeforeLeapfrog) {
+
+        this.latentVertices = latentVertices;
+        this.random = random;
+        this.fromVertices = fromVertices;
+        this.leapFrogCount = leapFrogCount;
+        this.stepSize = stepSize;
+        this.bayesNet = bayesNet;
+        this.during = during;
+        this.before = before;
+        this.logProbGradientCalculator = logProbGradientCalculator;
+        this.sampleBeforeLeapfrog = sampleBeforeLeapfrog;
+        this.logOfMasterPBeforeLeapfrog = logOfMasterPBeforeLeapfrog;
+    }
+
+    @Override
+    public void step() {
+        initializeMomentumForEachVertex(latentVertices, during.momentum, random);
+        cacheThings(during, before);
+        putSample(sampleBeforeLeapfrog, fromVertices);
+
+        for (int leapFrogNum = 0; leapFrogNum < leapFrogCount; leapFrogNum++) {
+            during.gradient = leapfrog(
+                latentVertices,
+                during,
+                stepSize,
+                logProbGradientCalculator
+            );
+        }
+    }
+
+    @Override
+    public void sample(Map<VertexId, List<?>> samples, List<Double> logOfMasterPForEachSample) {
+        step();
+        addSampleFromCache(samples, acceptOrReject());
+        logOfMasterPForEachSample.add(logOfMasterPBeforeLeapfrog);
+    }
+
+    @Override
+    public NetworkState sample() {
+        step();
+        return new SimpleNetworkState(acceptOrReject());
+    }
+
+    private Map<VertexId, ?> acceptOrReject() {
+        final double logOfMasterPAfterLeapfrog = bayesNet.getLogOfMasterP();
+
+        final double likelihoodOfLeapfrog = getLikelihoodOfLeapfrog(
+            logOfMasterPAfterLeapfrog,
+            logOfMasterPBeforeLeapfrog,
+            during.momentum,
+            before.momentum
+        );
+
+        if (shouldReject(likelihoodOfLeapfrog, random)) {
+
+            //Revert to position and gradient before leapfrog
+            Map<VertexId, DoubleTensor> tempSwap = during.position;
+            during.position = before.position;
+            before.position = tempSwap;
+
+            tempSwap = during.gradient;
+            during.gradient = before.gradient;
+            before.gradient = tempSwap;
+
+            return sampleBeforeLeapfrog;
+        } else {
+            logOfMasterPBeforeLeapfrog = logOfMasterPAfterLeapfrog;
+            Map<VertexId, ?> sample = new HashMap<>();
+            putSample(sample, fromVertices);
+            return sample;
+        }
+    }
+
+    private static void initializeMomentumForEachVertex(List<Vertex<DoubleTensor>> vertexes,
+                                                        Map<VertexId, DoubleTensor> momentums,
+                                                        KeanuRandom random) {
+        for (Vertex<DoubleTensor> currentVertex : vertexes) {
+            momentums.put(currentVertex.getId(), random.nextGaussian(currentVertex.getShape()));
+        }
+    }
+
+    private static void cacheThings(VertexState from, VertexState to) {
+        for (Map.Entry<VertexId, DoubleTensor> entry : from.position.entrySet()) {
+            to.position.put(entry.getKey(), entry.getValue());
+        }
+        for (Map.Entry<VertexId, DoubleTensor> entry : from.momentum.entrySet()) {
+            to.momentum.put(entry.getKey(), entry.getValue());
+        }
+        for (Map.Entry<VertexId, DoubleTensor> entry : from.gradient.entrySet()) {
+            to.gradient.put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * function Leapfrog(T, r)
+     * Set `r = r + (eps/2)dTL(T)
+     * Set `T = T + r`
+     * Set `r = r` + (eps/2)dTL(`T)
+     * return `T, r`
+     *
+     * @param latentVertices
+     * @param during          current vertex position, gradient and momentum
+     * @param stepSize
+     * @param logProbGradient calculator of the logProb gradients
+     * @return the gradient at the updated position
+     */
+    private static Map<VertexId, DoubleTensor> leapfrog(final List<Vertex<DoubleTensor>> latentVertices,
+                                                        final VertexState during,
+                                                        final double stepSize,
+                                                        final LogProbGradientCalculator logProbGradient) {
+
+        final double halfTimeStep = stepSize / 2.0;
+
+        Map<VertexId, DoubleTensor> momentumsAtHalfTimeStep = new HashMap<>();
+
+        //Set `r = r + (eps/2)dTL(T)
+        for (Map.Entry<VertexId, DoubleTensor> vertexMomentum : during.momentum.entrySet()) {
+            final DoubleTensor updatedMomentum = during.gradient.get(vertexMomentum.getKey()).times(halfTimeStep).plusInPlace(vertexMomentum.getValue());
+            momentumsAtHalfTimeStep.put(vertexMomentum.getKey(), updatedMomentum);
+        }
+
+        //Set `T = T + `r.
+        for (Vertex<DoubleTensor> latent : latentVertices) {
+            final DoubleTensor nextPosition = momentumsAtHalfTimeStep.get(latent.getId()).times(halfTimeStep).plusInPlace(during.position.get(latent.getId()));
+            during.position.put(latent.getId(), nextPosition);
+            latent.setValue(nextPosition);
+        }
+
+        VertexValuePropagation.cascadeUpdate(latentVertices);
+
+        //Set `r = `r + (eps/2)dTL(`T)
+        Map<VertexId, DoubleTensor> newGradient = logProbGradient.getJointLogProbGradientWrtLatents();
+
+        for (Map.Entry<VertexId, DoubleTensor> halfTimeStepMomentum : momentumsAtHalfTimeStep.entrySet()) {
+            final DoubleTensor updatedMomentum = newGradient.get(halfTimeStepMomentum.getKey()).times(halfTimeStep).plusInPlace(halfTimeStepMomentum.getValue());
+            during.momentum.put(halfTimeStepMomentum.getKey(), updatedMomentum);
+        }
+
+        return newGradient;
+    }
+
+    private static double getLikelihoodOfLeapfrog(final double logOfMasterPAfterLeapfrog,
+                                                  final double previousLogOfMasterP,
+                                                  final Map<VertexId, DoubleTensor> leapfroggedMomentum,
+                                                  final Map<VertexId, DoubleTensor> momentumPreviousTimeStep) {
+
+        final double leapFroggedMomentumDotProduct = (0.5 * dotProduct(leapfroggedMomentum));
+        final double previousMomentumDotProduct = (0.5 * dotProduct(momentumPreviousTimeStep));
+
+        final double leapFroggedLikelihood = logOfMasterPAfterLeapfrog - leapFroggedMomentumDotProduct;
+        final double previousLikelihood = previousLogOfMasterP - previousMomentumDotProduct;
+
+        final double logLikelihoodOfLeapFrog = leapFroggedLikelihood - previousLikelihood;
+        final double likelihoodOfLeapfrog = Math.exp(logLikelihoodOfLeapFrog);
+
+        return Math.min(likelihoodOfLeapfrog, 1.0);
+    }
+
+    private static boolean shouldReject(double likelihood, KeanuRandom random) {
+        return likelihood < random.nextDouble();
+    }
+
+    private static double dotProduct(Map<VertexId, DoubleTensor> momentums) {
+        double dotProduct = 0.0;
+        for (DoubleTensor momentum : momentums.values()) {
+            dotProduct += momentum.pow(2).sum();
+        }
+        return dotProduct;
+    }
+
+    /**
+     * This is meant to be used for caching a pre-leapfrog sample. This sample
+     * will be used if the leapfrog is rejected.
+     *
+     * @param sample
+     * @param fromVertices
+     */
+    private static void putSample(Map<VertexId, ?> sample, List<? extends Vertex> fromVertices) {
+        for (Vertex<?> vertex : fromVertices) {
+            putValue(vertex, sample);
+        }
+    }
+
+    private static <T> void putValue(Vertex<T> vertex, Map<VertexId, ?> target) {
+        ((Map<VertexId, T>) target).put(vertex.getId(), vertex.getValue());
+    }
+
+    /**
+     * This is used when a leapfrog is rejected. At that point the vertices are in a post
+     * leapfrog state and a pre-leapfrog sample must be used.
+     *
+     * @param samples
+     * @param cachedSample a cached sample from before leapfrog
+     */
+    private static void addSampleFromCache(Map<VertexId, List<?>> samples, Map<VertexId, ?> cachedSample) {
+        for (Map.Entry<VertexId, ?> sampleEntry : cachedSample.entrySet()) {
+            addSampleForVertex(sampleEntry.getKey(), sampleEntry.getValue(), samples);
+        }
+    }
+
+    static void cachePosition(List<Vertex<DoubleTensor>> latentVertices, Map<VertexId, DoubleTensor> position) {
+        for (Vertex<DoubleTensor> vertex : latentVertices) {
+            position.put(vertex.getId(), vertex.getValue());
+        }
+    }
+
+    /**
+     * This is used when a leapfrog is accepted. At that point the vertices are in a
+     * post leapfrog state.
+     *
+     * @param fromVertices vertices from which to create and save new sample.
+     */
+    static void addSampleFromVertices(Map<VertexId, List<?>> samples, List<? extends Vertex> fromVertices) {
+        for (Vertex<?> vertex : fromVertices) {
+            addSampleForVertex(vertex.getId(), vertex.getValue(), samples);
+        }
+    }
+
+    static <T> void addSampleForVertex(VertexId id, T value, Map<VertexId, List<?>> samples) {
+        List<T> samplesForVertex = (List<T>) samples.computeIfAbsent(id, v -> new ArrayList<T>());
+        samplesForVertex.add(value);
+    }
+
+    static class VertexState {
+
+        Map<VertexId, DoubleTensor> position;
+        Map<VertexId, DoubleTensor> gradient;
+        Map<VertexId, DoubleTensor> momentum;
+
+        public VertexState(Map<VertexId, DoubleTensor> position, Map<VertexId, DoubleTensor> gradient, Map<VertexId, DoubleTensor> momentum) {
+            this.position = position;
+            this.gradient = gradient;
+            this.momentum = momentum;
+        }
+    }
+
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -106,10 +106,10 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
 
         double logProbabilityBeforeStep = bayesianNetwork.getLogOfMasterP();
 
-        return new MetropolisHastingSampler(latentVertices, verticesToSampleFrom, mhStep, variableSelector, logProbabilityBeforeStep);
+        return new MetropolisHastingsSampler(latentVertices, verticesToSampleFrom, mhStep, variableSelector, logProbabilityBeforeStep);
     }
 
-    public static class MetropolisHastingSampler implements SamplingAlgorithm {
+    public static class MetropolisHastingsSampler implements SamplingAlgorithm {
 
         private final List<Vertex> latentVertices;
         private final List<? extends Vertex> verticesToSampleFrom;
@@ -119,7 +119,7 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
         private double logProbabilityBeforeStep;
         private int sampleNum;
 
-        public MetropolisHastingSampler(List<Vertex> latentVertices,
+        public MetropolisHastingsSampler(List<Vertex> latentVertices,
                        List<? extends Vertex> verticesToSampleFrom,
                        MetropolisHastingsStep mhStep,
                        MHStepVariableSelector variableSelector,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -106,10 +106,10 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
 
         double logProbabilityBeforeStep = bayesianNetwork.getLogOfMasterP();
 
-        return new Sampler(latentVertices, verticesToSampleFrom, mhStep, variableSelector, logProbabilityBeforeStep);
+        return new MetropolisHastingSampler(latentVertices, verticesToSampleFrom, mhStep, variableSelector, logProbabilityBeforeStep);
     }
 
-    public static class Sampler implements SamplingAlgorithm {
+    public static class MetropolisHastingSampler implements SamplingAlgorithm {
 
         private final List<Vertex> latentVertices;
         private final List<? extends Vertex> verticesToSampleFrom;
@@ -119,7 +119,7 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
         private double logProbabilityBeforeStep;
         private int sampleNum;
 
-        public Sampler(List<Vertex> latentVertices,
+        public MetropolisHastingSampler(List<Vertex> latentVertices,
                        List<? extends Vertex> verticesToSampleFrom,
                        MetropolisHastingsStep mhStep,
                        MHStepVariableSelector variableSelector,

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
@@ -11,6 +11,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertTrue;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -111,5 +113,27 @@ public class HamiltonianTest {
         assertNull(hmc.getRandom());
 
         assertFalse(posteriorSamples.get(A).asList().isEmpty());
+    }
+
+    @Test
+    public void canStreamSamples() {
+
+        Hamiltonian algo = Hamiltonian.withDefaultConfig();
+
+        int sampleCount = 1000;
+        int dropCount = 100;
+        int downSampleInterval = 1;
+        GaussianVertex A = new GaussianVertex(0, 1);
+        BayesianNetwork network = new BayesianNetwork(A.getConnectedGraph());
+
+        double averageA = algo.generatePosteriorSamples(network, network.getLatentVertices())
+            .dropCount(dropCount)
+            .downSampleInterval(downSampleInterval)
+            .stream()
+            .limit(sampleCount)
+            .mapToDouble(networkState -> networkState.get(A).scalar())
+            .average().getAsDouble();
+
+        assertEquals(0.0, averageA, 0.1);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
@@ -3,27 +3,23 @@ package io.improbable.keanu.algorithms.mcmc;
 import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.network.BayesianNetwork;
-import io.improbable.keanu.network.NetworkState;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
-
-import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class HamiltonianTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
@@ -11,7 +11,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertTrue;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
@@ -40,7 +40,7 @@ public class HamiltonianTest {
         NetworkSamples posteriorSamples = hmc.getPosteriorSamples(
             simpleGaussian,
             simpleGaussian.getLatentVertices(),
-            7500
+            1000
         );
 
         Vertex<DoubleTensor> vertex = simpleGaussian.getContinuousLatentVertices().get(0);

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
@@ -45,7 +45,7 @@ public class HamiltonianTest {
 
         Vertex<DoubleTensor> vertex = simpleGaussian.getContinuousLatentVertices().get(0);
 
-        MCMCTestDistributions.samplesMatchSimpleGaussian(mu, sigma, posteriorSamples.get(vertex).asList());
+        MCMCTestDistributions.samplesMatchSimpleGaussian(mu, sigma, posteriorSamples.get(vertex).asList(), 0.1);
     }
 
     @Test
@@ -130,21 +130,19 @@ public class HamiltonianTest {
             .stepSize(0.4)
             .build();
 
-        int sampleCount = 7500;
-        int downSampleInterval = 1;
         double mu = 0;
         double sigma = 1;
-        GaussianVertex A = new GaussianVertex(0, 1);
+        GaussianVertex A = new GaussianVertex(mu, sigma);
         BayesianNetwork network = new BayesianNetwork(A.getConnectedGraph());
 
         List<DoubleTensor> samples = hmc.generatePosteriorSamples(network, network.getLatentVertices())
-            .downSampleInterval(downSampleInterval)
+            .downSampleInterval(1)
             .stream()
-            .limit(sampleCount)
+            .limit(500)
             .map(x -> x.get(A))
             .collect(Collectors.toList());
 
-        MCMCTestDistributions.samplesMatchSimpleGaussian(mu, sigma, samples);
+        MCMCTestDistributions.samplesMatchSimpleGaussian(mu, sigma, samples, 0.3);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MCMCTestDistributions.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MCMCTestDistributions.java
@@ -20,7 +20,7 @@ public class MCMCTestDistributions {
         return new BayesianNetwork(A.getConnectedGraph());
     }
 
-    public static void samplesMatchSimpleGaussian(double mu, double sigma, List<DoubleTensor> samples) {
+    public static void samplesMatchSimpleGaussian(double mu, double sigma, List<DoubleTensor> samples, double delta) {
 
         long[] shape = samples.get(0).getShape();
 
@@ -40,7 +40,7 @@ public class MCMCTestDistributions {
 
         for (int i = 0; i < means.length; i++) {
             assertEquals(mu, means[i], 0.05);
-            assertEquals(sigma, standardDeviations[i], 0.1);
+            assertEquals(sigma, standardDeviations[i], delta);
         }
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MCMCTestDistributions.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MCMCTestDistributions.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 public class MCMCTestDistributions {
 
     public static BayesianNetwork createSimpleGaussian(double mu, double sigma, KeanuRandom random) {
-        GaussianVertex A = new GaussianVertex(mu, sigma);
+        GaussianVertex A = new GaussianVertex(new long[]{2, 1}, mu, sigma);
         A.setAndCascade(A.sample(random));
         return new BayesianNetwork(A.getConnectedGraph());
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MCMCTestDistributions.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MCMCTestDistributions.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 public class MCMCTestDistributions {
 
     public static BayesianNetwork createSimpleGaussian(double mu, double sigma, KeanuRandom random) {
-        GaussianVertex A = new GaussianVertex(new long[]{2, 1}, mu, sigma);
+        GaussianVertex A = new GaussianVertex(mu, sigma);
         A.setAndCascade(A.sample(random));
         return new BayesianNetwork(A.getConnectedGraph());
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NUTSTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NUTSTest.java
@@ -42,7 +42,7 @@ public class NUTSTest {
 
         Vertex<DoubleTensor> vertex = simpleGaussian.getContinuousLatentVertices().get(0);
 
-        MCMCTestDistributions.samplesMatchSimpleGaussian(mu, sigma, posteriorSamples.get(vertex).asList());
+        MCMCTestDistributions.samplesMatchSimpleGaussian(mu, sigma, posteriorSamples.get(vertex).asList(), 0.1);
     }
 
     @Test

--- a/keanu-python/keanu/algorithm/__init__.py
+++ b/keanu-python/keanu/algorithm/__init__.py
@@ -2,4 +2,4 @@ from .optimization import (
     GradientOptimizer,
     NonGradientOptimizer
 )
-from .sampling import sample, iterate_samples
+from .sampling import sample, generate_samples

--- a/keanu-python/keanu/algorithm/__init__.py
+++ b/keanu-python/keanu/algorithm/__init__.py
@@ -2,4 +2,4 @@ from .optimization import (
     GradientOptimizer,
     NonGradientOptimizer
 )
-from .sampling import sample
+from .sampling import sample, iterate_samples

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -21,15 +21,15 @@ def sample(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_i
 
     return vertex_samples
 
-def iterate_samples(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_interval=1):
+def iterate_samples(net, sample_from, algo='metropolis', drop=0, down_sample_interval=1):
 	vertices_unwrapped = k.to_java_object_list(sample_from)
 
 	sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped).dropCount(drop).downSampleInterval(down_sample_interval).stream().iterator()
 	
-	return _iterator_samples(sample_iterator, draws, vertices_unwrapped)
+	return _iterator_samples(sample_iterator, vertices_unwrapped)
 
-def _iterator_samples(sample_iterator, draws, vertices_unwrapped):
-	for _ in range(draws):
+def _iterator_samples(sample_iterator, vertices_unwrapped):
+	while (True):
 		network_sample = sample_iterator.next()
 		sample = {Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(network_sample.get(vertex_unwrapped)) for vertex_unwrapped in vertices_unwrapped}
 		yield sample

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -24,7 +24,9 @@ def sample(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_i
 def iterate_samples(net, sample_from, algo='metropolis', drop=0, down_sample_interval=1):
 	vertices_unwrapped = k.to_java_object_list(sample_from)
 
-	sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped).dropCount(drop).downSampleInterval(down_sample_interval).stream().iterator()
+	sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
+	sample_iterator.dropCount(drop).downSampleInterval(down_sample_interval)
+	sample_iterator.stream().iterator()
 	
 	return _iterator_samples(sample_iterator, vertices_unwrapped)
 

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -26,9 +26,9 @@ def iterate_samples(net, sample_from, algo='metropolis', draws=500, drop=0, down
 
 	sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped).dropCount(drop).downSampleInterval(down_sample_interval).stream().iterator()
 	
-	return iterator_samples(sample_iterator, draws, vertices_unwrapped)
+	return _iterator_samples(sample_iterator, draws, vertices_unwrapped)
 
-def iterator_samples(sample_iterator, draws, vertices_unwrapped):
+def _iterator_samples(sample_iterator, draws, vertices_unwrapped):
 	for _ in range(draws):
 		network_sample = sample_iterator.next()
 		sample = {Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(network_sample.get(vertex_unwrapped)) for vertex_unwrapped in vertices_unwrapped}

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -24,13 +24,13 @@ def sample(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_i
 def iterate_samples(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_interval=1):
 	vertices_unwrapped = k.to_java_object_list(sample_from)
 
-	network_samples = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped).dropCount(drop).downSampleInterval(down_sample_interval).stream().iterator()
+	sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped).dropCount(drop).downSampleInterval(down_sample_interval).stream().iterator()
 	
-	return iterator_samples(network_samples, draws, vertices_unwrapped)
+	return iterator_samples(sample_iterator, draws, vertices_unwrapped)
 
 
-def iterator_samples(network_samples, draws, vertices_unwrapped):
-	for i in range(draws):
-		network_sample = network_samples.next()
+def iterator_samples(sample_iterator, draws, vertices_unwrapped):
+	for _ in range(draws):
+		network_sample = sample_iterator.next()
 		sample = {Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(network_sample.get(vertex_unwrapped)) for vertex_unwrapped in vertices_unwrapped}
 		yield sample

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -21,16 +21,16 @@ def sample(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_i
 
     return vertex_samples
 
-def iterate_samples(net, sample_from, algo='metropolis', drop=0, down_sample_interval=1):
+def generate_samples(net, sample_from, algo='metropolis', drop=0, down_sample_interval=1):
 	vertices_unwrapped = k.to_java_object_list(sample_from)
 
 	sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
 	sample_iterator = sample_iterator.dropCount(drop).downSampleInterval(down_sample_interval)
 	sample_iterator = sample_iterator.stream().iterator()
 	
-	return _iterator_samples(sample_iterator, vertices_unwrapped)
+	return _samples_generator(sample_iterator, vertices_unwrapped)
 
-def _iterator_samples(sample_iterator, vertices_unwrapped):
+def _samples_generator(sample_iterator, vertices_unwrapped):
 	while (True):
 		network_sample = sample_iterator.next()
 		sample = {Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(network_sample.get(vertex_unwrapped)) for vertex_unwrapped in vertices_unwrapped}

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -25,8 +25,8 @@ def iterate_samples(net, sample_from, algo='metropolis', drop=0, down_sample_int
 	vertices_unwrapped = k.to_java_object_list(sample_from)
 
 	sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
-	sample_iterator.dropCount(drop).downSampleInterval(down_sample_interval)
-	sample_iterator.stream().iterator()
+	sample_iterator = sample_iterator.dropCount(drop).downSampleInterval(down_sample_interval)
+	sample_iterator = sample_iterator.stream().iterator()
 	
 	return _iterator_samples(sample_iterator, vertices_unwrapped)
 

--- a/keanu-python/keanu/keanu_random.py
+++ b/keanu-python/keanu/keanu_random.py
@@ -14,5 +14,6 @@ class KeanuRandom(JavaObjectWrapper):
         else:
             super(KeanuRandom, self).__init__(k.jvm_view().KeanuRandom(seed))
 
-    def set_default_random_seed(self, seed):
+    @staticmethod
+    def set_default_random_seed(seed):
     	k.jvm_view().KeanuRandom.setDefaultRandomSeed(seed)

--- a/keanu-python/keanu/sampling.py
+++ b/keanu-python/keanu/sampling.py
@@ -21,3 +21,17 @@ def sample(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_i
     vertex_samples = {Vertex._get_python_id(vertex_unwrapped): list(map(Tensor._to_ndarray, network_samples.get(vertex_unwrapped).asList())) for vertex_unwrapped in vertices_unwrapped}
 
     return vertex_samples
+
+def samples_iter(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_interval=1):
+	vertices_unwrapped = k.to_java_object_list(sample_from)
+
+	network_samples = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped).dropCount(drop).downSampleInterval(down_sample_interval).stream().iterator()
+	
+	return samples_gen(network_samples, draws, vertices_unwrapped)
+
+
+def samples_gen(network_samples, draws, vertices_unwrapped):
+	for i in range(draws):
+		network_sample = network_samples.next()
+		sample = {Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(network_sample.get(vertex_unwrapped)) for vertex_unwrapped in vertices_unwrapped}
+		yield sample

--- a/keanu-python/keanu/sampling.py
+++ b/keanu-python/keanu/sampling.py
@@ -22,15 +22,15 @@ def sample(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_i
 
     return vertex_samples
 
-def samples_iter(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_interval=1):
+def iterate_samples(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_interval=1):
 	vertices_unwrapped = k.to_java_object_list(sample_from)
 
 	network_samples = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped).dropCount(drop).downSampleInterval(down_sample_interval).stream().iterator()
 	
-	return samples_gen(network_samples, draws, vertices_unwrapped)
+	return iterator_samples(network_samples, draws, vertices_unwrapped)
 
 
-def samples_gen(network_samples, draws, vertices_unwrapped):
+def iterator_samples(network_samples, draws, vertices_unwrapped):
 	for i in range(draws):
 		network_sample = network_samples.next()
 		sample = {Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(network_sample.get(vertex_unwrapped)) for vertex_unwrapped in vertices_unwrapped}

--- a/keanu-python/tests/test_gradient_optimization.py
+++ b/keanu-python/tests/test_gradient_optimization.py
@@ -6,7 +6,7 @@ from keanu.algorithm import GradientOptimizer
 
 @pytest.fixture
 def model():
-    KeanuRandom().set_default_random_seed(1)
+    KeanuRandom.set_default_random_seed(1)
     model = Thermometer.model()
     model.thermometer_one.observe(22.0)
     model.thermometer_two.observe(20.0)

--- a/keanu-python/tests/test_non_gradient_optimization.py
+++ b/keanu-python/tests/test_non_gradient_optimization.py
@@ -6,7 +6,7 @@ from keanu.algorithm import NonGradientOptimizer
 
 @pytest.fixture
 def model():
-    KeanuRandom().set_default_random_seed(1)
+    KeanuRandom.set_default_random_seed(1)
     with Model() as m:
         m.a = Gaussian(0., 50.)
         m.b = Gaussian(0., 50.)

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -4,7 +4,7 @@ from py4j.java_gateway import java_import
 from examples import Thermometer
 from keanu.vertex import Gamma, Exponential, Cauchy
 from keanu.algorithm import sample, iterate_samples
-from keanu import BayesNet
+from keanu import BayesNet, KeanuRandom
 
 @pytest.fixture
 def net():
@@ -64,7 +64,7 @@ def test_down_sample_interval(net):
 ])
 def test_iter_is_correct_size(algo, net):
     draws = 10
-    samples = kn.iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws, down_sample_interval=1)
+    samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws, down_sample_interval=1)
     assert sum(1 for i in samples) == 10
 
 
@@ -75,15 +75,15 @@ def test_iter_is_correct_size(algo, net):
 def test_iter_returns_same_result_as_sample(algo):
     draws = 100
     model = Thermometer.model()
-    net = kn.BayesNet(model.temperature.get_connected_graph())
+    net = BayesNet(model.temperature.get_connected_graph())
     set_starting_state(model)
     samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     set_starting_state(model)
     iter_samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     iter_samples_dict = {}
 
-    for sample in iter_samples:
-        for vertex_id, vertex_sample in sample.items():
+    for next_sample in iter_samples:
+        for vertex_id, vertex_sample in next_sample.items():
             if vertex_id in iter_samples_dict:    
                 iter_samples_dict[vertex_id] += vertex_sample
             else:
@@ -94,7 +94,7 @@ def test_iter_returns_same_result_as_sample(algo):
         np.testing.assert_almost_equal(average, np.average(samples[vertex_id]))
 
 def set_starting_state(model):
-    kn.KeanuRandom().set_default_random_seed(1)
+    KeanuRandom().set_default_random_seed(1)
     model.temperature.set_value(model.temperature.sample())
     model.thermometer_one.set_value(model.thermometer_one.sample())
     model.thermometer_two.set_value(model.thermometer_two.sample())

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -91,7 +91,7 @@ def test_iter_returns_same_result_as_sample(algo):
     [samples_dataframe.append(pd.DataFrame(list(next_sample.items()))) for next_sample in islice(iter_samples, draws)]
 
     for vertex_id in samples_dataframe:
-        np.testing.assert_almost_equal(np.average(dataframe[vertex_id], np.average(samples[vertex_id])))
+        np.testing.assert_almost_equal(dataframe[vertex_id].mean(), np.average(samples[vertex_id]))
 
 
 def set_starting_state(model):

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
 from py4j.java_gateway import java_import
-from examples import thermometers
+from examples import Thermometer
 from keanu.vertex import Gamma, Exponential, Cauchy
-from keanu.algorithm import sample
+from keanu.algorithm import sample, iterate_samples
 from keanu import BayesNet
 
 @pytest.fixture
@@ -74,12 +74,12 @@ def test_iter_is_correct_size(algo, net):
 ])
 def test_iter_returns_same_result_as_sample(algo):
     draws = 100
-    model = thermometers.model()
+    model = Thermometer.model()
     net = kn.BayesNet(model.temperature.get_connected_graph())
     set_starting_state(model)
-    samples = kn.sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
+    samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     set_starting_state(model)
-    iter_samples = kn.iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
+    iter_samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     iter_samples_dict = {}
 
     for sample in iter_samples:

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -52,3 +52,10 @@ def test_down_sample_interval(net):
 
     expected_num_samples = draws / down_sample_interval
     assert all(len(vertex_samples) == expected_num_samples for vertex_id, vertex_samples in samples.items())
+
+
+def test_streaming_samples(net):
+    draws = 10
+    samples_stream = kn.samples_iter(net=net, sample_from=net.get_latent_vertices(), draws=draws, down_sample_interval=1)
+    assert sum(1 for i in samples_stream) == 10
+

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -5,6 +5,7 @@ from examples import Thermometer
 from keanu.vertex import Gamma, Exponential, Cauchy
 from keanu.algorithm import sample, iterate_samples
 from keanu import BayesNet, KeanuRandom
+from collections import defaultdict
 
 @pytest.fixture
 def net():
@@ -80,21 +81,19 @@ def test_iter_returns_same_result_as_sample(algo):
     samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     set_starting_state(model)
     iter_samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
-    iter_samples_dict = {}
+    iter_samples_dict = defaultdict(float)
 
     for next_sample in iter_samples:
         for vertex_id, vertex_sample in next_sample.items():
-            if vertex_id in iter_samples_dict:    
-                iter_samples_dict[vertex_id] += vertex_sample
-            else:
-                iter_samples_dict[vertex_id] = vertex_sample
+            iter_samples_dict[vertex_id] += vertex_sample
 
     for vertex_id, summed_vertex_sample in iter_samples_dict.items():
         average = summed_vertex_sample / draws
         np.testing.assert_almost_equal(average, np.average(samples[vertex_id]))
 
+
 def set_starting_state(model):
-    KeanuRandom().set_default_random_seed(1)
+    KeanuRandom.set_default_random_seed(1)
     model.temperature.set_value(model.temperature.sample())
     model.thermometer_one.set_value(model.thermometer_one.sample())
     model.thermometer_two.set_value(model.thermometer_two.sample())

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -6,6 +6,7 @@ from keanu.vertex import Gamma, Exponential, Cauchy
 from keanu.algorithm import sample, iterate_samples
 from keanu import BayesNet, KeanuRandom
 from collections import defaultdict
+from itertools import islice
 
 @pytest.fixture
 def net():
@@ -63,10 +64,13 @@ def test_down_sample_interval(net):
     ("metropolis"),
     ("hamiltonian")
 ])
-def test_iter_is_correct_size(algo, net):
+def test_can_iter_through_samples(algo, net):
     draws = 10
-    samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws, down_sample_interval=1)
-    assert sum(1 for i in samples) == 10
+    samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, down_sample_interval=1)
+    count = 0
+    for sample in islice(samples, draws):
+        count += 1
+    assert count == num_samples
 
 
 @pytest.mark.parametrize("algo", [
@@ -80,10 +84,10 @@ def test_iter_returns_same_result_as_sample(algo):
     set_starting_state(model)
     samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     set_starting_state(model)
-    iter_samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
+    iter_samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo)
     iter_samples_dict = defaultdict(float)
 
-    for next_sample in iter_samples:
+    for next_sample in islice(iter_samples, draws):
         for vertex_id, vertex_sample in next_sample.items():
             iter_samples_dict[vertex_id] += vertex_sample
 

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -54,8 +54,12 @@ def test_down_sample_interval(net):
     assert all(len(vertex_samples) == expected_num_samples for vertex_id, vertex_samples in samples.items())
 
 
-def test_streaming_samples(net):
+@pytest.mark.parametrize("algo", [
+    ("metropolis"),
+    ("hamiltonian")
+])
+def test_streaming_samples(algo, net):
     draws = 10
-    samples_stream = kn.samples_iter(net=net, sample_from=net.get_latent_vertices(), draws=draws, down_sample_interval=1)
+    samples_stream = kn.samples_iter(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws, down_sample_interval=1)
     assert sum(1 for i in samples_stream) == 10
 

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 from py4j.java_gateway import java_import
 from examples import Thermometer
@@ -85,15 +86,12 @@ def test_iter_returns_same_result_as_sample(algo):
     samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     set_starting_state(model)
     iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo)
-    iter_samples_dict = defaultdict(float)
 
-    for next_sample in islice(iter_samples, draws):
-        for vertex_id, vertex_sample in next_sample.items():
-            iter_samples_dict[vertex_id] += vertex_sample
+    samples_dataframe = pd.DataFrame()
+    [samples_dataframe.append(pd.DataFrame(list(next_sample.items()))) for next_sample in islice(iter_samples, draws)]
 
-    for vertex_id, summed_vertex_sample in iter_samples_dict.items():
-        average = summed_vertex_sample / draws
-        np.testing.assert_almost_equal(average, np.average(samples[vertex_id]))
+    for vertex_id in samples_dataframe:
+        np.testing.assert_almost_equal(np.average(dataframe[vertex_id], np.average(samples[vertex_id])))
 
 
 def set_starting_state(model):

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -66,7 +66,7 @@ def test_down_sample_interval(net):
 ])
 def test_can_iter_through_samples(algo, net):
     draws = 10
-    samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, down_sample_interval=1)
+    samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, down_sample_interval=1)
     count = 0
     for sample in islice(samples, draws):
         count += 1
@@ -84,7 +84,7 @@ def test_iter_returns_same_result_as_sample(algo):
     set_starting_state(model)
     samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     set_starting_state(model)
-    iter_samples = iterate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo)
+    iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo)
     iter_samples_dict = defaultdict(float)
 
     for next_sample in islice(iter_samples, draws):

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -3,7 +3,7 @@ import pytest
 from py4j.java_gateway import java_import
 from examples import Thermometer
 from keanu.vertex import Gamma, Exponential, Cauchy
-from keanu.algorithm import sample, iterate_samples
+from keanu.algorithm import sample, generate_samples
 from keanu import BayesNet, KeanuRandom
 from collections import defaultdict
 from itertools import islice

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -70,7 +70,7 @@ def test_can_iter_through_samples(algo, net):
     count = 0
     for sample in islice(samples, draws):
         count += 1
-    assert count == num_samples
+    assert count == draws
 
 
 @pytest.mark.parametrize("algo", [


### PR DESCRIPTION
- Refactor Hamiltonian to use the `Sampler` interface. 
- Allows users to create a generator for reading samples from a java stream

Works by turning the java stream into an iterator and then calling `next` on that each time the user calls `next` on the python generator