### PR TITLE
Remove algorithm and vertex import in keanu.

### DIFF
--- a/keanu-python/keanu/__init__.py
+++ b/keanu-python/keanu/__init__.py
@@ -1,7 +1,3 @@
 from .model import Model
 from .keanu_random import KeanuRandom
 from .net import BayesNet
-from . import (
-    algorithm,
-    vertex
-)


### PR DESCRIPTION
Needed to be left out so we don't import algorithm and vertex when we import keanu.