### PR TITLE
Make Differentiable interface reliable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@ nbproject
 build
 /out
 **/*.gpg
-keanu-python/dist/
-keanu-python/keanu/classpath

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiable.java
@@ -3,13 +3,25 @@ package io.improbable.keanu.vertices.dbl;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
+import java.util.Collections;
 import java.util.Map;
 
 public interface Differentiable {
 
-    PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs);
+    default PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        if (((Vertex)this).isObserved()) {
+            return PartialDerivatives.OF_CONSTANT;
+        } else {
+            return PartialDerivatives.withRespectToSelf(((Vertex)this).getId(), ((Vertex)this).getShape());
+        }
+    }
 
-    Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf);
+    default Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
+        return Collections.singletonMap(
+            ((Vertex)this),
+            PartialDerivatives.withRespectToSelf(((Vertex)this).getId(), ((Vertex)this).getShape())
+        );
+    }
 
     default PartialDerivatives getDerivativeWrtLatents() {
         return Differentiator.forwardModeAutoDiff((Vertex & Differentiable) this);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -47,7 +47,6 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVert
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TakeVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TanVertex;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -62,140 +62,140 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
      *                  dimension
      * @return a vertex that represents the concatenation of the toConcat
      */
-    public static DoubleVertex concat(int dimension, DoubleVertex... toConcat) {
+    public static ConcatenationVertex concat(int dimension, DoubleVertex... toConcat) {
         return new ConcatenationVertex(dimension, toConcat);
     }
 
-    public static DoubleVertex min(DoubleVertex a, DoubleVertex b) {
+    public static MinVertex min(DoubleVertex a, DoubleVertex b) {
         return new MinVertex(a, b);
     }
 
-    public static DoubleVertex max(DoubleVertex a, DoubleVertex b) {
+    public static MaxVertex max(DoubleVertex a, DoubleVertex b) {
         return new MaxVertex(a, b);
     }
 
-    public DoubleVertex minus(DoubleVertex that) {
+    public DifferenceVertex minus(DoubleVertex that) {
         return new DifferenceVertex(this, that);
     }
 
-    public DoubleVertex plus(DoubleVertex that) {
+    public AdditionVertex plus(DoubleVertex that) {
         return new AdditionVertex(this, that);
     }
 
-    public DoubleVertex multiply(DoubleVertex that) {
+    public MultiplicationVertex multiply(DoubleVertex that) {
         return new MultiplicationVertex(this, that);
     }
 
-    public DoubleVertex matrixMultiply(DoubleVertex that) {
+    public MatrixMultiplicationVertex matrixMultiply(DoubleVertex that) {
         return new MatrixMultiplicationVertex(this, that);
     }
 
-    public DoubleVertex matrixInverse() {
+    public MatrixInverseVertex matrixInverse() {
         return new MatrixInverseVertex(this);
     }
 
-    public DoubleVertex matrixDeterminant() {
+    public MatrixDeterminantVertex matrixDeterminant() {
         return new MatrixDeterminantVertex(this);
     }
 
-    public DoubleVertex divideBy(DoubleVertex that) {
+    public DivisionVertex divideBy(DoubleVertex that) {
         return new DivisionVertex(this, that);
     }
 
-    public DoubleVertex pow(DoubleVertex exponent) {
+    public PowerVertex pow(DoubleVertex exponent) {
         return new PowerVertex(this, exponent);
     }
 
     @Override
-    public DoubleVertex minus(double that) {
+    public DifferenceVertex minus(double that) {
         return minus(new ConstantDoubleVertex(that));
     }
 
     @Override
-    public DoubleVertex reverseMinus(double that) {
+    public DifferenceVertex reverseMinus(double that) {
         return new ConstantDoubleVertex(that).minus(this);
     }
 
     @Override
-    public DoubleVertex plus(double that) {
+    public AdditionVertex plus(double that) {
         return plus(new ConstantDoubleVertex(that));
     }
 
-    public DoubleVertex multiply(double that) {
+    public MultiplicationVertex multiply(double that) {
         return multiply(new ConstantDoubleVertex(that));
     }
 
-    public DoubleVertex divideBy(double that) {
+    public DivisionVertex divideBy(double that) {
         return divideBy(new ConstantDoubleVertex(that));
     }
 
     @Override
-    public DoubleVertex pow(double that) {
+    public PowerVertex pow(double that) {
         return pow(new ConstantDoubleVertex(that));
     }
 
-    public DoubleVertex abs() {
+    public AbsVertex abs() {
         return new AbsVertex(this);
     }
 
-    public DoubleVertex floor() {
+    public FloorVertex floor() {
         return new FloorVertex(this);
     }
 
-    public DoubleVertex ceil() {
+    public CeilVertex ceil() {
         return new CeilVertex(this);
     }
 
-    public DoubleVertex round() {
+    public RoundVertex round() {
         return new RoundVertex(this);
     }
 
     @Override
-    public DoubleVertex exp() {
+    public ExpVertex exp() {
         return new ExpVertex(this);
     }
 
-    public DoubleVertex log() {
+    public LogVertex log() {
         return new LogVertex(this);
     }
 
-    public DoubleVertex logGamma() {
+    public LogGammaVertex logGamma() {
         return new LogGammaVertex(this);
     }
 
-    public DoubleVertex sigmoid() {
+    public SigmoidVertex sigmoid() {
         return new SigmoidVertex(this);
     }
 
     @Override
-    public DoubleVertex sin() {
+    public SinVertex sin() {
         return new SinVertex(this);
     }
 
     @Override
-    public DoubleVertex cos() {
+    public CosVertex cos() {
         return new CosVertex(this);
     }
 
-    public DoubleVertex tan() {
+    public TanVertex tan() {
         return new TanVertex(this);
     }
 
     @Override
-    public DoubleVertex asin() {
+    public ArcSinVertex asin() {
         return new ArcSinVertex(this);
     }
 
     @Override
-    public DoubleVertex acos() {
+    public ArcCosVertex acos() {
         return new ArcCosVertex(this);
     }
 
-    public DoubleVertex atan() {
+    public ArcTanVertex atan() {
         return new ArcTanVertex(this);
     }
 
-    public DoubleVertex atan2(DoubleVertex that) {
+    public ArcTan2Vertex atan2(DoubleVertex that) {
         return new ArcTan2Vertex(this, that);
     }
 
@@ -204,7 +204,7 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
      *
      * @return a vertex representing the summation result
      */
-    public DoubleVertex sum() {
+    public SumVertex sum() {
         return new SumVertex(this);
     }
 
@@ -214,21 +214,21 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
      * @param sumOverDimensions dimensions to sum over. Negative dimension indexing is not supported
      * @return a vertex representing the summation result
      */
-    public DoubleVertex sum(int... sumOverDimensions) {
+    public SumVertex sum(int... sumOverDimensions) {
         return new SumVertex(this, sumOverDimensions);
     }
 
-    public DoubleVertex reshape(long... proposedShape) {
+    public ReshapeVertex reshape(long... proposedShape) {
         return new ReshapeVertex(this, proposedShape);
     }
 
-    public DoubleVertex lambda(long[] outputShape, Function<DoubleTensor, DoubleTensor> op,
+    public DoubleUnaryOpLambda<DoubleTensor> lambda(long[] outputShape, Function<DoubleTensor, DoubleTensor> op,
                                Function<Map<Vertex, PartialDerivatives>, PartialDerivatives> forwardModeAutoDiffLambda,
                                Function<PartialDerivatives, Map<Vertex, PartialDerivatives>> reverseModeAutoDiffLambda) {
         return new DoubleUnaryOpLambda<>(outputShape, this, op, forwardModeAutoDiffLambda, reverseModeAutoDiffLambda);
     }
 
-    public DoubleVertex lambda(Function<DoubleTensor, DoubleTensor> op,
+    public DoubleUnaryOpLambda<DoubleTensor> lambda(Function<DoubleTensor, DoubleTensor> op,
                                Function<Map<Vertex, PartialDerivatives>, PartialDerivatives> forwardModeAutoDiffLambda,
                                Function<PartialDerivatives, Map<Vertex, PartialDerivatives>> reverseModeAutoDiffLambda) {
         return new DoubleUnaryOpLambda<>(this, op, forwardModeAutoDiffLambda, reverseModeAutoDiffLambda);
@@ -236,32 +236,32 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
 
     // 'times' and 'div' are required to enable operator overloading in Kotlin (through the DoubleOperators interface)
     @Override
-    public DoubleVertex times(DoubleVertex that) {
+    public MultiplicationVertex times(DoubleVertex that) {
         return multiply(that);
     }
 
     @Override
-    public DoubleVertex div(DoubleVertex that) {
+    public DivisionVertex div(DoubleVertex that) {
         return divideBy(that);
     }
 
     @Override
-    public DoubleVertex times(double that) {
+    public MultiplicationVertex times(double that) {
         return multiply(that);
     }
 
     @Override
-    public DoubleVertex div(double that) {
+    public DivisionVertex div(double that) {
         return divideBy(that);
     }
 
     @Override
-    public DoubleVertex reverseDiv(double that) {
+    public DivisionVertex reverseDiv(double that) {
         return new ConstantDoubleVertex(that).div(this);
     }
 
     @Override
-    public DoubleVertex unaryMinus() {
+    public MultiplicationVertex unaryMinus() {
         return multiply(-1.0);
     }
 
@@ -289,11 +289,11 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return new LessThanOrEqualVertex<>(this, rhs);
     }
 
-    public DoubleVertex take(long... index) {
+    public TakeVertex take(long... index) {
         return new TakeVertex(this, index);
     }
 
-    public DoubleVertex slice(int dimension, int index) {
+    public SliceVertex slice(int dimension, int index) {
         return new SliceVertex(this, dimension, index);
     }
 
@@ -323,12 +323,5 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
 
     public double getValue(int... index) {
         return getValue().getValue(index);
-    }
-
-    public PartialDerivatives getDerivativeWrtLatents() {
-        if (this instanceof Differentiable) {
-            return Differentiator.forwardModeAutoDiff((Vertex & Differentiable) this);
-        }
-        throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -51,7 +51,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
-public abstract class DoubleVertex extends Vertex<DoubleTensor> implements DoubleOperators<DoubleVertex>, Differentiable {
+public abstract class DoubleVertex extends Vertex<DoubleTensor> implements DoubleOperators<DoubleVertex> {
 
     public DoubleVertex(long[] initialShape) {
         super(initialShape);
@@ -326,20 +326,10 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return getValue().getValue(index);
     }
 
-    @Override
-    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
-        if (isObserved()) {
-            return PartialDerivatives.OF_CONSTANT;
-        } else {
-            return PartialDerivatives.withRespectToSelf(this.getId(), this.getShape());
+    public PartialDerivatives getDerivativeWrtLatents() {
+        if (this instanceof Differentiable) {
+            return Differentiator.forwardModeAutoDiff((Vertex & Differentiable) this);
         }
-    }
-
-    @Override
-    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        return Collections.singletonMap(
-            this,
-            PartialDerivatives.withRespectToSelf(this.getId(), this.getShape())
-        );
+        throw new UnsupportedOperationException();
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -12,7 +12,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 
 import java.util.Map;
 
-public class CastDoubleVertex extends DoubleVertex  implements Differentiable, NonProbabilistic<DoubleTensor> {
+public class CastDoubleVertex extends DoubleVertex  implements NonProbabilistic<DoubleTensor> {
 
     private final Vertex<? extends NumberTensor> inputVertex;
 
@@ -31,15 +31,5 @@ public class CastDoubleVertex extends DoubleVertex  implements Differentiable, N
     @Override
     public DoubleTensor calculate() {
         return inputVertex.getValue().toDouble();
-    }
-
-    @Override
-    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
-        throw new UnsupportedOperationException("CastDoubleTensorVertex is non-differentiable");
-    }
-
-    @Override
-    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        throw new UnsupportedOperationException("CastDoubleTensorVertex is non-differentiable");
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/CastDoubleVertex.java
@@ -5,13 +5,14 @@ import io.improbable.keanu.tensor.NumberTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.Map;
 
-public class CastDoubleVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
+public class CastDoubleVertex extends DoubleVertex  implements Differentiable, NonProbabilistic<DoubleTensor> {
 
     private final Vertex<? extends NumberTensor> inputVertex;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.tensor.bool.BooleanTensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -12,7 +13,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives
 import java.util.HashMap;
 import java.util.Map;
 
-public class DoubleIfVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
+public class DoubleIfVertex extends DoubleVertex implements Differentiable, NonProbabilistic<DoubleTensor> {
 
     private final Vertex<? extends BooleanTensor> predicate;
     private final Vertex<? extends DoubleTensor> thn;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleModelResultVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleModelResultVertex.java
@@ -15,7 +15,7 @@ import io.improbable.keanu.vertices.model.ModelVertex;
 /**
  * A non-probabilistic double vertex whose value is extracted from an upstream model vertex.
  */
-public class DoubleModelResultVertex extends DoubleVertex implements Differentiable, ModelResultProvider<DoubleTensor>, NonProbabilistic<DoubleTensor> {
+public class DoubleModelResultVertex extends DoubleVertex implements ModelResultProvider<DoubleTensor>, NonProbabilistic<DoubleTensor> {
 
     private final ModelResult<DoubleTensor> delegate;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleModelResultVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleModelResultVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexLabel;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.model.ModelResult;
@@ -14,7 +15,7 @@ import io.improbable.keanu.vertices.model.ModelVertex;
 /**
  * A non-probabilistic double vertex whose value is extracted from an upstream model vertex.
  */
-public class DoubleModelResultVertex extends DoubleVertex implements ModelResultProvider<DoubleTensor>, NonProbabilistic<DoubleTensor> {
+public class DoubleModelResultVertex extends DoubleVertex implements Differentiable, ModelResultProvider<DoubleTensor>, NonProbabilistic<DoubleTensor> {
 
     private final ModelResult<DoubleTensor> delegate;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleProxyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleProxyVertex.java
@@ -7,6 +7,7 @@ import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.ProxyVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexLabel;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -16,7 +17,7 @@ import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class DoubleProxyVertex extends DoubleVertex implements ProxyVertex<DoubleVertex>, NonProbabilistic<DoubleTensor> {
+public class DoubleProxyVertex extends DoubleVertex implements Differentiable, ProxyVertex<DoubleVertex>, NonProbabilistic<DoubleTensor> {
 
     /**
      * This vertex acts as a "Proxy" to allow a BayesNet to be built up before parents are explicitly known (ie for

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpLambda.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -13,7 +14,7 @@ import java.util.function.Function;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 
-public class DoubleBinaryOpLambda<A, B> extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
+public class DoubleBinaryOpLambda<A, B> extends DoubleVertex implements Differentiable, NonProbabilistic<DoubleTensor> {
 
     protected final Vertex<A> left;
     protected final Vertex<B> right;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DoubleBinaryOpVertex.java
@@ -4,6 +4,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -12,7 +13,7 @@ import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 
-public abstract class DoubleBinaryOpVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
+public abstract class DoubleBinaryOpVertex extends DoubleVertex implements Differentiable, NonProbabilistic<DoubleTensor> {
 
     protected final DoubleVertex left;
     protected final DoubleVertex right;
@@ -67,7 +68,7 @@ public abstract class DoubleBinaryOpVertex extends DoubleVertex implements NonPr
         try {
             return forwardModeAutoDifferentiation(derivativeOfParentsWithRespectToInputs.get(left), derivativeOfParentsWithRespectToInputs.get(right));
         } catch (UnsupportedOperationException e) {
-            return super.forwardModeAutoDifferentiation(derivativeOfParentsWithRespectToInputs);
+            return Differentiable.super.forwardModeAutoDifferentiation(derivativeOfParentsWithRespectToInputs);
         }
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
@@ -3,11 +3,8 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
-import java.util.Map;
 
 public class AbsVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/AbsVertex.java
@@ -25,14 +25,4 @@ public class AbsVertex extends DoubleUnaryOpVertex {
     protected DoubleTensor op(DoubleTensor value) {
         return value.abs();
     }
-
-    @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class ArcCosVertex extends DoubleUnaryOpVertex {
+public class ArcCosVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Takes the inverse cosine of a vertex, Arccos(vertex)
@@ -25,7 +26,8 @@ public class ArcCosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
 
         DoubleTensor inputValue = inputVertex.getValue();
 
@@ -34,6 +36,7 @@ public class ArcCosVertex extends DoubleUnaryOpVertex {
         return derivativeOfParentWithRespectToInputs.multiplyAlongOfDimensions(dArcCos, inputVertex.getShape());
     }
 
+    @Override
     public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
         DoubleTensor inputValue = inputVertex.getValue();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class ArcSinVertex extends DoubleUnaryOpVertex {
+public class ArcSinVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Takes the inverse sin of a vertex, Arcsin(vertex)
@@ -25,7 +26,8 @@ public class ArcSinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
 
         DoubleTensor inputValue = inputVertex.getValue();
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class ArcTanVertex extends DoubleUnaryOpVertex {
+public class ArcTanVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Takes the inverse tan of a vertex, Arctan(vertex)
@@ -25,7 +26,8 @@ public class ArcTanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         DoubleTensor value = inputVertex.getValue();
 
         DoubleTensor dArcTan = value.pow(2).plusInPlace(1).reciprocalInPlace();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
@@ -2,11 +2,8 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
-import java.util.Map;
 
 public class CeilVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CeilVertex.java
@@ -25,14 +25,4 @@ public class CeilVertex extends DoubleUnaryOpVertex {
     protected DoubleTensor op(DoubleTensor value) {
         return value.ceil();
     }
-
-    @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class CosVertex extends DoubleUnaryOpVertex {
+public class CosVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Takes the cosine of a vertex, Cos(vertex)
@@ -25,8 +26,8 @@ public class CosVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
-
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         DoubleTensor inputValue = inputVertex.getValue();
 
         DoubleTensor dCos = inputValue.sin().unaryMinusInPlace();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpVertex.java
@@ -2,13 +2,8 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
-import io.improbable.keanu.vertices.Vertex;
-import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
-
-import java.util.Map;
 
 public abstract class DoubleUnaryOpVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor> {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/DoubleUnaryOpVertex.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -44,16 +45,5 @@ public abstract class DoubleUnaryOpVertex extends DoubleVertex implements NonPro
         return op(inputVertex.getValue());
     }
 
-    @Override
-    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
-        try {
-            return forwardModeAutoDifferentiation(derivativeOfParentsWithRespectToInputs.get(inputVertex));
-        } catch (UnsupportedOperationException e) {
-            return super.forwardModeAutoDifferentiation(derivativeOfParentsWithRespectToInputs);
-        }
-    }
-
     protected abstract DoubleTensor op(DoubleTensor value);
-
-    protected abstract PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs);
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class ExpVertex extends DoubleUnaryOpVertex {
+public class ExpVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Calculates the exponential of an input vertex
@@ -25,7 +26,8 @@ public class ExpVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         return derivativeOfParentWithRespectToInputs.multiplyAlongOfDimensions(this.getValue(), inputVertex.getShape());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
@@ -25,14 +25,4 @@ public class FloorVertex extends DoubleUnaryOpVertex {
     protected DoubleTensor op(DoubleTensor value) {
         return value.floor();
     }
-
-    @Override
-    protected  PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/FloorVertex.java
@@ -2,11 +2,8 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
-import java.util.Map;
 
 public class FloorVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class LogGammaVertex extends DoubleUnaryOpVertex {
+public class LogGammaVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Returns the log of the gamma of the inputVertex
@@ -25,7 +26,8 @@ public class LogGammaVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         return derivativeOfParentWithRespectToInputs.multiplyAlongOfDimensions(inputVertex.getValue().digamma(), getShape());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class LogVertex extends DoubleUnaryOpVertex {
+public class LogVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Returns the natural logarithm, base e, of a vertex
@@ -25,7 +26,8 @@ public class LogVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         return derivativeOfParentWithRespectToInputs.divideBy(inputVertex.getValue());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
@@ -19,7 +20,7 @@ import java.util.Map;
  * <p>
  * Forward mode differentiation is not implemented due to requiring a tensor trace, which is not yet implemented
  */
-public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
+public class MatrixDeterminantVertex extends DoubleUnaryOpVertex implements Differentiable {
     public MatrixDeterminantVertex(DoubleVertex vertex) {
         super(Tensor.SCALAR_SHAPE, vertex);
         TensorShapeValidation.checkShapeIsSquareMatrix(vertex.getShape());
@@ -31,7 +32,7 @@ public class MatrixDeterminantVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
         throw new UnsupportedOperationException();
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class MatrixInverseVertex extends DoubleUnaryOpVertex {
+public class MatrixInverseVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     public MatrixInverseVertex(DoubleVertex inputVertex) {
         super(checkInputIsSquareMatrix(inputVertex.getShape()), inputVertex);
@@ -20,7 +21,8 @@ public class MatrixInverseVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
 
         //dc = -A^-1 * da * A^-1
         DoubleTensor negatedValue = this.getValue().unaryMinus();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertex.java
@@ -4,13 +4,14 @@ import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class ReshapeVertex extends DoubleUnaryOpVertex {
+public class ReshapeVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     public ReshapeVertex(DoubleVertex inputVertex, long... proposedShape) {
         super(proposedShape, inputVertex);
@@ -22,7 +23,8 @@ public class ReshapeVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         return derivativeOfParentWithRespectToInputs.reshape(inputVertex.getValue().getRank(), getShape());
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/RoundVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/RoundVertex.java
@@ -25,14 +25,4 @@ public class RoundVertex extends DoubleUnaryOpVertex {
     protected DoubleTensor op(DoubleTensor value) {
         return value.round();
     }
-
-    @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<Vertex, PartialDerivatives> reverseModeAutoDifferentiation(PartialDerivatives derivativeOfOutputsWithRespectToSelf) {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/RoundVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/RoundVertex.java
@@ -2,11 +2,8 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
-import java.util.Map;
 
 public class RoundVertex extends DoubleUnaryOpVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class SigmoidVertex extends DoubleUnaryOpVertex {
+public class SigmoidVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Applies the sigmoid function to a vertex.
@@ -26,7 +27,8 @@ public class SigmoidVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         DoubleTensor x = inputVertex.getValue();
         DoubleTensor xExp = x.exp();
         DoubleTensor dxdfx = xExp.divInPlace(xExp.plus(1).powInPlace(2));

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class SinVertex extends DoubleUnaryOpVertex {
+public class SinVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Takes the sine of a vertex. Sin(vertex).
@@ -25,7 +26,8 @@ public class SinVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         DoubleTensor dSin = inputVertex.getValue().cos();
         return derivativeOfParentWithRespectToInputs.multiplyAlongOfDimensions(dSin, this.getValue().getShape());
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SliceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SliceVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
@@ -12,7 +13,7 @@ import java.util.Map;
 
 import static io.improbable.keanu.tensor.TensorShape.shapeSlice;
 
-public class SliceVertex extends DoubleUnaryOpVertex {
+public class SliceVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     private final int dimension;
     private final long index;
@@ -50,7 +51,8 @@ public class SliceVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         boolean needReshape = this.getValue().getRank() == inputVertex.getValue().getRank();
         return derivativeOfParentWithRespectToInputs.slice(dimension, index, needReshape);
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
@@ -16,7 +17,7 @@ import java.util.Map;
 
 import static java.util.Collections.singletonMap;
 
-public class SumVertex extends DoubleUnaryOpVertex {
+public class SumVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     private final int[] overDimensions;
 
@@ -78,7 +79,8 @@ public class SumVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         DoubleTensor sumResult = this.getValue();
         int operandRank = inputVertex.getValue().getRank();
         return derivativeOfParentWithRespectToInputs.sumOverOfDimensions(overDimensions, sumResult.getShape(), operandRank);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.tensor.TensorShapeValidation;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
@@ -13,7 +14,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TakeVertex extends DoubleUnaryOpVertex {
+public class TakeVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     private final long[] index;
 
@@ -35,7 +36,8 @@ public class TakeVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
 
         Map<VertexId, DoubleTensor> partialsOf = new HashMap<>();
         DoubleTensor newValue = this.getValue();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertex.java
@@ -2,13 +2,14 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class TanVertex extends DoubleUnaryOpVertex {
+public class TanVertex extends DoubleUnaryOpVertex implements Differentiable {
 
     /**
      * Takes the tangent of a vertex. Tan(vertex).
@@ -25,7 +26,8 @@ public class TanVertex extends DoubleUnaryOpVertex {
     }
 
     @Override
-    protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+    public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+        PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
         DoubleTensor dTan = inputVertex.getValue().cos().powInPlace(2).reciprocalInPlace();
         return derivativeOfParentWithRespectToInputs.multiplyAlongOfDimensions(dTan, this.getValue().getShape());
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/BetaVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -20,7 +21,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class BetaVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class BetaVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex alpha;
     private final DoubleVertex beta;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/CauchyVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -20,7 +21,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class CauchyVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class CauchyVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex location;
     private final DoubleVertex scale;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ChiSquaredVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -15,7 +16,7 @@ import java.util.Set;
 
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class ChiSquaredVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class ChiSquaredVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private IntegerVertex k;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/DirichletVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -16,7 +17,7 @@ import java.util.Set;
 import static io.improbable.keanu.distributions.hyperparam.Diffs.C;
 import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 
-public class DirichletVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class DirichletVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex concentration;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ExponentialVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -19,7 +20,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class ExponentialVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class ExponentialVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex rate;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GammaVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -20,7 +21,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class GammaVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class GammaVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex theta;
     private final DoubleVertex k;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/GaussianVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -21,7 +22,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class GaussianVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class GaussianVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex mu;
     private final DoubleVertex sigma;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/InverseGammaVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -19,7 +20,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class InverseGammaVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class InverseGammaVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex alpha;
     private final DoubleVertex beta;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/KDEVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.Samplable;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -13,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class KDEVertex extends DoubleVertex implements ProbabilisticDouble, Samplable<DoubleTensor> {
+public class KDEVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, Samplable<DoubleTensor> {
 
     private final double bandwidth;
     private DoubleTensor samples;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LaplaceVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -19,7 +20,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class LaplaceVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class LaplaceVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex mu;
     private final DoubleVertex beta;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogNormalVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -19,7 +20,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class LogNormalVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class LogNormalVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex mu;
     private final DoubleVertex sigma;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/LogisticVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -19,7 +20,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class LogisticVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class LogisticVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex mu;
     private final DoubleVertex s;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -5,13 +5,14 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
 import java.util.Map;
 import java.util.Set;
 
-public class MultivariateGaussianVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class MultivariateGaussianVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex mu;
     private final DoubleVertex covariance;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/ParetoVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.distributions.hyperparam.Diffs;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -20,7 +21,7 @@ import static io.improbable.keanu.distributions.hyperparam.Diffs.X;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class ParetoVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class ParetoVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex scale;
     private final DoubleVertex location;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/SmoothUniformVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.distributions.continuous.SmoothUniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -18,7 +19,7 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNon
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 import static java.util.Collections.singletonMap;
 
-public class SmoothUniformVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class SmoothUniformVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private static final double DEFAULT_EDGE_SHARPNESS = 0.01;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/StudentTVertex.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.tensor.Tensor;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
@@ -18,7 +19,7 @@ import java.util.Set;
 import static io.improbable.keanu.distributions.hyperparam.Diffs.T;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class StudentTVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class StudentTVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final IntegerVertex v;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/TriangularVertex.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.distributions.continuous.Triangular;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -14,7 +15,7 @@ import java.util.Set;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNonScalarShapeOrAllScalar;
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 
-public class TriangularVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class TriangularVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex xMin;
     private final DoubleVertex xMax;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/UniformVertex.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.distributions.continuous.Uniform;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.SamplableWithManyScalars;
 import io.improbable.keanu.vertices.Vertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -17,7 +18,7 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkHasSingleNon
 import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatchNonScalarShapeOrAreScalar;
 import static java.util.Collections.singletonMap;
 
-public class UniformVertex extends DoubleVertex implements ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
+public class UniformVertex extends DoubleVertex implements Differentiable, ProbabilisticDouble, SamplableWithManyScalars<DoubleTensor> {
 
     private final DoubleVertex xMin;
     private final DoubleVertex xMax;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/If.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/If.java
@@ -62,7 +62,7 @@ public class If {
             this.thn = thn;
         }
 
-        public Vertex<Tensor<T>> orElse(Vertex<? extends Tensor<T>> els) {
+        public IfVertex<T> orElse(Vertex<? extends Tensor<T>> els) {
             assertShapesMatchOrAreScalar(thn.getShape(), els.getShape(), predicate.getShape());
             return new IfVertex<>(els.getShape(), predicate, thn, els);
         }
@@ -79,7 +79,7 @@ public class If {
             this.thn = thn;
         }
 
-        public BoolVertex orElse(Vertex<? extends BooleanTensor> els) {
+        public BooleanIfVertex orElse(Vertex<? extends BooleanTensor> els) {
             assertShapesMatchOrAreScalar(thn.getShape(), els.getShape(), predicate.getShape());
             return new BooleanIfVertex(els.getShape(), predicate, thn, els);
         }
@@ -96,12 +96,12 @@ public class If {
             this.thn = thn;
         }
 
-        public DoubleVertex orElse(Vertex<? extends DoubleTensor> els) {
+        public DoubleIfVertex orElse(Vertex<? extends DoubleTensor> els) {
             assertShapesMatchOrAreScalar(thn.getShape(), els.getShape(), predicate.getShape());
             return new DoubleIfVertex(els.getShape(), predicate, thn, els);
         }
 
-        public DoubleVertex orElse(double els) {
+        public DoubleIfVertex orElse(double els) {
             return orElse(new ConstantDoubleVertex(els));
         }
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/AutoDiffPropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/AutoDiffPropagationTest.java
@@ -16,7 +16,7 @@ public class AutoDiffPropagationTest {
         DoubleVertex start = ConstantVertex.of(Math.PI / 3).sin();
 
         int links = 20;
-        DoubleVertex end = TestGraphGenerator.addLinks(start, n, m, links);
+        TestGraphGenerator.SumVertex end = TestGraphGenerator.addLinks(start, n, m, links);
 
         end.getDerivativeWrtLatents();
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/EvalPropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/EvalPropagationTest.java
@@ -1,14 +1,17 @@
 package io.improbable.keanu.vertices;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import org.apache.commons.lang3.builder.DiffResult;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -106,7 +109,7 @@ public class EvalPropagationTest {
         assertEquals(3, n.get());
     }
 
-    static class BlackBoxVertex extends DoubleUnaryOpVertex {
+    static class BlackBoxVertex extends DoubleUnaryOpVertex implements Differentiable {
 
         private final AtomicInteger n;
 
@@ -122,7 +125,7 @@ public class EvalPropagationTest {
         }
 
         @Override
-        protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+        public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
             return null;
         }
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/EvalPropagationTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/EvalPropagationTest.java
@@ -6,7 +6,6 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleUnaryOpVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
-import org.apache.commons.lang3.builder.DiffResult;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
@@ -1,6 +1,7 @@
 package io.improbable.keanu.vertices;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DoubleBinaryOpVertex;
@@ -8,6 +9,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.DoubleU
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -26,7 +28,7 @@ public class TestGraphGenerator {
         return end;
     }
 
-    static class PassThroughVertex extends DoubleUnaryOpVertex {
+    static class PassThroughVertex extends DoubleUnaryOpVertex implements Differentiable {
 
         private final AtomicInteger opCount;
         private final AtomicInteger autoDiffCount;
@@ -47,7 +49,8 @@ public class TestGraphGenerator {
         }
 
         @Override
-        protected PartialDerivatives forwardModeAutoDifferentiation(PartialDerivatives derivativeOfParentWithRespectToInputs) {
+        public PartialDerivatives forwardModeAutoDifferentiation(Map<Vertex, PartialDerivatives> derivativeOfParentsWithRespectToInputs) {
+            PartialDerivatives derivativeOfParentWithRespectToInputs = derivativeOfParentsWithRespectToInputs.get(inputVertex);
             autoDiffCount.incrementAndGet();
             return derivativeOfParentWithRespectToInputs;
         }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/TestGraphGenerator.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.vertices;
 
+import com.google.common.base.Preconditions;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
@@ -17,7 +18,8 @@ public class TestGraphGenerator {
 
     private static final Logger log = LoggerFactory.getLogger(TestGraphGenerator.class);
 
-    static DoubleVertex addLinks(DoubleVertex end, AtomicInteger opCount, AtomicInteger autoDiffCount, int links) {
+    static SumVertex addLinks(DoubleVertex end, AtomicInteger opCount, AtomicInteger autoDiffCount, int links) {
+        Preconditions.checkArgument(links > 0);
 
         for (int i = 0; i < links; i++) {
             DoubleVertex left = passThroughVertex(end, opCount, autoDiffCount, id -> log.info("OP on id:" + id));
@@ -25,7 +27,7 @@ public class TestGraphGenerator {
             end = sumVertex(left, right, opCount, autoDiffCount, id -> log.info("OP on id:" + id));
         }
 
-        return end;
+        return (SumVertex) end;
     }
 
     static class PassThroughVertex extends DoubleUnaryOpVertex implements Differentiable {
@@ -89,7 +91,7 @@ public class TestGraphGenerator {
         }
     }
 
-    static DoubleVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<VertexId> onOp) {
+    static SumVertex sumVertex(DoubleVertex left, DoubleVertex right, AtomicInteger opCount, AtomicInteger dualNumberCount, Consumer<VertexId> onOp) {
         return new SumVertex(left, right, opCount, dualNumberCount, onOp);
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DifferentiatorTest.java
@@ -8,6 +8,8 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.bool.BoolVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
 import org.junit.Test;
@@ -22,7 +24,7 @@ public class DifferentiatorTest {
 
         DoubleVertex A = new GaussianVertex(0, 1);
         DoubleVertex B = new GaussianVertex(0, 1);
-        DoubleVertex C = A.times(B);
+        MultiplicationVertex C = A.times(B);
 
         PartialDerivatives dC = C.getDerivativeWrtLatents();
 
@@ -83,7 +85,7 @@ public class DifferentiatorTest {
         DoubleVertex E = C.times(D).pow(A).acos();
         DoubleVertex G = E.log().tan().asin().atan();
         DoubleVertex F = D.plus(B).exp();
-        DoubleVertex H = G.plus(F).sum();
+        SumVertex H = G.plus(F).sum();
 
         PartialDerivatives dHReverse = Differentiator.reverseModeAutoDiff(H, ImmutableSet.of(A, B));
         PartialDerivatives dHForward = H.getDerivativeWrtLatents();
@@ -115,7 +117,7 @@ public class DifferentiatorTest {
         DoubleVertex E = J.times(D).pow(A).acos();
         DoubleVertex G = E.log().tan().atan();
         DoubleVertex F = D.plus(B).exp();
-        DoubleVertex H = G.plus(F).sum().times(A).sum().times(C);
+        MultiplicationVertex H = G.plus(F).sum().times(A).sum().times(C);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B, C), H, 0.001, 1e-3);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
@@ -9,6 +9,9 @@ import io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex;
 import io.improbable.keanu.vertices.bool.probabilistic.BernoulliVertex;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.AdditionVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MatrixMultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import io.improbable.keanu.vertices.generic.nonprobabilistic.If;
@@ -27,13 +30,13 @@ public class DoubleIfVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
-        DoubleVertex c = a.matrixMultiply(b);
+        MatrixMultiplicationVertex c = a.matrixMultiply(b);
         DoubleVertex d = b.matrixMultiply(a);
 
         DoubleTensor dCda = c.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dCdb = c.getDerivativeWrtLatents().withRespectTo(b);
 
-        DoubleVertex ifVertex = If.isTrue(bool)
+        DoubleIfVertex ifVertex = If.isTrue(bool)
             .then(c)
             .orElse(d);
 
@@ -57,13 +60,13 @@ public class DoubleIfVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.arange(0, 8).reshape(2, 2, 2));
 
-        DoubleVertex c = a.times(b);
+        MultiplicationVertex c = a.times(b);
         DoubleVertex d = b.div(a);
 
         DoubleTensor dCda = c.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dCdb = c.getDerivativeWrtLatents().withRespectTo(b);
 
-        DoubleVertex ifVertex = If.isTrue(bool)
+        DoubleIfVertex ifVertex = If.isTrue(bool)
             .then(c)
             .orElse(d);
 
@@ -91,12 +94,12 @@ public class DoubleIfVertexTest {
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
         DoubleVertex c = a.matrixMultiply(b);
-        DoubleVertex d = b.matrixMultiply(a);
+        MatrixMultiplicationVertex d = b.matrixMultiply(a);
 
         DoubleTensor dDda = d.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dDdb = d.getDerivativeWrtLatents().withRespectTo(b);
 
-        DoubleVertex ifVertex = If.isTrue(bool)
+        DoubleIfVertex ifVertex = If.isTrue(bool)
             .then(c)
             .orElse(d);
 
@@ -120,13 +123,13 @@ public class DoubleIfVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
-        DoubleVertex c = a.matrixMultiply(b);
-        DoubleVertex d = b.matrixMultiply(a);
+        MatrixMultiplicationVertex c = a.matrixMultiply(b);
+        MatrixMultiplicationVertex d = b.matrixMultiply(a);
 
         DoubleTensor dCda = c.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dDda = d.getDerivativeWrtLatents().withRespectTo(a);
 
-        DoubleVertex ifVertex = If.isTrue(bool)
+        DoubleIfVertex ifVertex = If.isTrue(bool)
             .then(c)
             .orElse(d);
 
@@ -157,7 +160,7 @@ public class DoubleIfVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
-        DoubleVertex c = a.matrixMultiply(b);
+        MatrixMultiplicationVertex c = a.matrixMultiply(b);
 
         DoubleVertex d = new UniformVertex(0, 10);
         d.setValue(DoubleTensor.create(new double[]{9, 10, 11, 12}, 2, 2));
@@ -165,12 +168,12 @@ public class DoubleIfVertexTest {
         DoubleVertex e = new UniformVertex(0, 10);
         e.setValue(DoubleTensor.create(new double[]{13, 14, 15, 16}, 2, 2));
 
-        DoubleVertex f = d.matrixMultiply(e);
+        MatrixMultiplicationVertex f = d.matrixMultiply(e);
 
         DoubleTensor dCda = c.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dFdd = f.getDerivativeWrtLatents().withRespectTo(d);
 
-        DoubleVertex ifVertex = If.isTrue(bool)
+        DoubleIfVertex ifVertex = If.isTrue(bool)
             .then(c)
             .orElse(f);
 
@@ -213,7 +216,7 @@ public class DoubleIfVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.arange(10, 18).reshape(2, 2, 2));
 
-        DoubleVertex c = a.times(b);
+        MultiplicationVertex c = a.times(b);
 
         DoubleVertex d = new UniformVertex(0, 10);
         d.setValue(DoubleTensor.arange(20, 28).reshape(2, 2, 2));
@@ -221,12 +224,12 @@ public class DoubleIfVertexTest {
         DoubleVertex e = new UniformVertex(0, 10);
         e.setValue(DoubleTensor.arange(30, 38).reshape(2, 2, 2));
 
-        DoubleVertex f = d.plus(e);
+        AdditionVertex f = d.plus(e);
 
         DoubleTensor dCda = c.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dFdd = f.getDerivativeWrtLatents().withRespectTo(d);
 
-        DoubleVertex ifVertex = If.isTrue(bool)
+        DoubleIfVertex ifVertex = If.isTrue(bool)
             .then(c)
             .orElse(f);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffTensorTest.java
@@ -4,6 +4,8 @@ import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Test;
 
@@ -25,7 +27,7 @@ public class AutoDiffTensorTest {
 
         DoubleVertex prod2 = sum.times(ConstantVertex.of(new double[]{2, 4, 6, 8}));
 
-        DoubleVertex output = prod2.plus(5).times(2);
+        MultiplicationVertex output = prod2.plus(5).times(2);
 
         PartialDerivatives derivative = output.getDerivativeWrtLatents();
 
@@ -51,7 +53,7 @@ public class AutoDiffTensorTest {
 
         DoubleVertex prod2 = sum.times(ConstantVertex.of(new double[]{2, 4, 6, 8}));
 
-        DoubleVertex output = prod2.plus(5).times(2);
+        MultiplicationVertex output = prod2.plus(5).times(2);
 
         PartialDerivatives derivative = output.getDerivativeWrtLatents();
 
@@ -69,7 +71,7 @@ public class AutoDiffTensorTest {
         DoubleVertex A = new UniformVertex(new long[]{2, 2}, 0, 1);
         A.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 2, 2));
 
-        DoubleVertex B = A.sum().times(ConstantVertex.of(new double[]{1, 2, 3, 4})).sum();
+        SumVertex B = A.sum().times(ConstantVertex.of(new double[]{1, 2, 3, 4})).sum();
 
         PartialDerivatives derivative = B.getDerivativeWrtLatents();
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffTest.java
@@ -2,7 +2,9 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.diff;
 
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +48,7 @@ public class AutoDiffTest {
     public void diffOverPlusMinusMultiplyCombination() {
         DoubleVertex vC = vA.plus(vB);
         DoubleVertex vD = vA.minus(vB);
-        DoubleVertex vE = vC.multiply(vD);
+        MultiplicationVertex vE = vC.multiply(vD);
         assertDiffIsCorrect(vA, vB, vE);
     }
 
@@ -58,7 +60,7 @@ public class AutoDiffTest {
         assertDiffIsCorrect(vA, vB, vE.log());
     }
 
-    private void assertDiffIsCorrect(DoubleVertex vA, DoubleVertex vB, DoubleVertex vC) {
+    private <T extends DoubleVertex & Differentiable> void assertDiffIsCorrect(DoubleVertex vA, DoubleVertex vB, T vC) {
 
         double A = 1.0;
         double B = 2.0;

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/LogProbGradientCalculatorTest.java
@@ -8,6 +8,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.VertexId;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import org.junit.Test;
 
@@ -138,7 +139,7 @@ public class LogProbGradientCalculatorTest {
         DoubleVertex E = C.times(D).pow(A).acos();
         DoubleVertex G = E.log().tan().asin().atan();
         DoubleVertex F = D.plus(B).exp();
-        DoubleVertex H = G.plus(F).sum();
+        SumVertex H = G.plus(F).sum();
         GaussianVertex J = new GaussianVertex(H, 1);
         J.observe(0.5);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/TensorTestOperations.java
@@ -2,6 +2,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators;
 
 import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 
@@ -11,32 +12,36 @@ import static io.improbable.keanu.tensor.TensorMatchers.allCloseTo;
 import static org.junit.Assert.assertThat;
 
 public class TensorTestOperations {
-    public static void finiteDifferenceMatchesForwardAndReverseModeGradient(List<DoubleVertex> inputVertices,
-                                                                            DoubleVertex outputVertex,
+    public static <T extends DoubleVertex & Differentiable>
+    void finiteDifferenceMatchesForwardAndReverseModeGradient(List<DoubleVertex> inputVertices,
+                                                                            T outputVertex,
                                                                             double incrementAmount,
                                                                             Double delta) {
         finiteDifferenceMatchesForwardModeGradient(inputVertices, outputVertex, incrementAmount, delta);
         finiteDifferenceMatchesReverseModeGradient(inputVertices, outputVertex, incrementAmount, delta);
     }
 
-    public static void finiteDifferenceMatchesForwardModeGradient(List<DoubleVertex> inputVertices,
-                                                                  DoubleVertex outputVertex,
+    public static <T extends DoubleVertex & Differentiable>
+    void finiteDifferenceMatchesForwardModeGradient(List<DoubleVertex> inputVertices,
+                                                                  T outputVertex,
                                                                   double incrementAmount,
                                                                   double delta) {
         inputVertices.forEach(v ->
             runGradientTestOnSingleInput(v, outputVertex, incrementAmount, delta, true));
     }
 
-    public static void finiteDifferenceMatchesReverseModeGradient(List<DoubleVertex> inputVertices,
-                                                                  DoubleVertex outputVertex,
+    public static <T extends DoubleVertex & Differentiable>
+    void finiteDifferenceMatchesReverseModeGradient(List<DoubleVertex> inputVertices,
+                                                                  T outputVertex,
                                                                   double incrementAmount,
                                                                   double delta) {
         inputVertices.forEach(v ->
             runGradientTestOnSingleInput(v, outputVertex, incrementAmount, delta, false));
     }
 
-    private static void runGradientTestOnSingleInput(DoubleVertex inputVertex,
-                                                     DoubleVertex outputVertex,
+    private static <T extends DoubleVertex & Differentiable>
+    void runGradientTestOnSingleInput(DoubleVertex inputVertex,
+                                                     T outputVertex,
                                                      double incrementAmount,
                                                      double delta,
                                                      boolean isForwardMode) {
@@ -60,7 +65,8 @@ public class TensorTestOperations {
         }
     }
 
-    private static DoubleTensor dOutputWrtInput(DoubleVertex outputVertex, DoubleVertex inputVertex, boolean isForwardMode) {
+    private static <T extends DoubleVertex & Differentiable>
+    DoubleTensor dOutputWrtInput(T outputVertex, DoubleVertex inputVertex, boolean isForwardMode) {
         if (isForwardMode) {
             return outputVertex.getDerivativeWrtLatents().withRespectTo(inputVertex);
         } else {

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/AdditionVertexTest.java
@@ -79,7 +79,7 @@ public class AdditionVertexTest {
     public void changesMatchGradient() {
         DoubleVertex A = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex B = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex C = A.plus(B);
+        AdditionVertex C = A.plus(B);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/BinaryOperationTestHelpers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/BinaryOperationTestHelpers.java
@@ -3,6 +3,7 @@ package io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary;
 import com.google.common.collect.ImmutableSet;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -28,17 +29,18 @@ public class BinaryOperationTestHelpers {
         assertEquals(expected, op.apply(A, B).getValue().scalar(), 1e-5);
     }
 
-    public static void calculatesDerivativeOfTwoScalars(double aValue,
-                                                        double bValue,
-                                                        double expectedGradientWrtA,
-                                                        double expectedGradientWrtB,
-                                                        BiFunction<DoubleVertex, DoubleVertex, DoubleVertex> op) {
+    public static <T extends DoubleVertex & Differentiable>
+    void calculatesDerivativeOfTwoScalars(double aValue,
+                                          double bValue,
+                                          double expectedGradientWrtA,
+                                          double expectedGradientWrtB,
+                                          BiFunction<DoubleVertex, DoubleVertex, T> op) {
 
         UniformVertex A = new UniformVertex(0.0, 1.0);
         A.setAndCascade(Nd4jDoubleTensor.scalar(aValue));
         UniformVertex B = new UniformVertex(0.0, 1.0);
         B.setAndCascade(Nd4jDoubleTensor.scalar(bValue));
-        DoubleVertex output = op.apply(A, B);
+        T output = op.apply(A, B);
 
         PartialDerivatives wrtForward = output.getDerivativeWrtLatents();
         assertEquals(expectedGradientWrtA, wrtForward.withRespectTo(A).scalar(), 1e-5);
@@ -69,18 +71,19 @@ public class BinaryOperationTestHelpers {
         assertEquals(expectedTensor.getValue(1, 1), result.getValue(1, 1), 1e-5);
     }
 
-    public static void calculatesDerivativeOfTwoMatricesElementWiseOperator(DoubleTensor aValues,
+    public static <T extends DoubleVertex & Differentiable>
+    void calculatesDerivativeOfTwoMatricesElementWiseOperator(DoubleTensor aValues,
                                                                             DoubleTensor bValues,
                                                                             DoubleTensor expectedGradientWrtA,
                                                                             DoubleTensor expectedGradientWrtB,
-                                                                            BiFunction<DoubleVertex, DoubleVertex, DoubleVertex> op) {
+                                                                            BiFunction<DoubleVertex, DoubleVertex, T> op) {
 
         UniformVertex A = new UniformVertex(aValues.getShape(), 0.0, 1.0);
         A.setAndCascade(aValues);
         UniformVertex B = new UniformVertex(bValues.getShape(), 0.0, 1.0);
         B.setAndCascade(bValues);
 
-        DoubleVertex output = op.apply(A, B);
+        T output = op.apply(A, B);
         PartialDerivatives wrtForward = output.getDerivativeWrtLatents();
 
         DoubleTensor wrtAForward = wrtForward.withRespectTo(A);
@@ -102,17 +105,18 @@ public class BinaryOperationTestHelpers {
         assertArrayEquals(expectedGradientWrtB.getShape(), wrtBReverse.getShape());
     }
 
-    public static void calculatesDerivativeOfAVectorAndScalar(DoubleTensor aValues,
+    public static <T extends DoubleVertex & Differentiable>
+    void calculatesDerivativeOfAVectorAndScalar(DoubleTensor aValues,
                                                               double bValue,
                                                               DoubleTensor expectedGradientWrtA,
                                                               DoubleTensor expectedGradientWrtB,
-                                                              BiFunction<DoubleVertex, DoubleVertex, DoubleVertex> op) {
+                                                              BiFunction<DoubleVertex, DoubleVertex, T> op) {
         UniformVertex A = new UniformVertex(aValues.getShape(), 0.0, 1.0);
         A.setAndCascade(aValues);
         UniformVertex B = new UniformVertex(0.0, 1.0);
         B.setAndCascade(DoubleTensor.scalar(bValue));
 
-        DoubleVertex output = op.apply(A, B);
+        T output = op.apply(A, B);
         PartialDerivatives wrtForward = output.getDerivativeWrtLatents();
 
         DoubleTensor wrtAForward = wrtForward.withRespectTo(A);
@@ -133,17 +137,18 @@ public class BinaryOperationTestHelpers {
         assertArrayEquals(expectedGradientWrtB.getShape(), wrtBReverse.getShape());
     }
 
-    public static void calculatesDerivativeOfAScalarAndVector(double aValue,
+    public static <T extends DoubleVertex & Differentiable>
+    void calculatesDerivativeOfAScalarAndVector(double aValue,
                                                               DoubleTensor bValues,
                                                               DoubleTensor expectedGradientWrtA,
                                                               DoubleTensor expectedGradientWrtB,
-                                                              BiFunction<DoubleVertex, DoubleVertex, DoubleVertex> op) {
+                                                              BiFunction<DoubleVertex, DoubleVertex, T> op) {
         UniformVertex A = new UniformVertex(0.0, 1.0);
         A.setAndCascade(DoubleTensor.scalar(aValue));
         UniformVertex B = new UniformVertex(bValues.getShape(), 0.0, 1.0);
         B.setAndCascade(bValues);
 
-        DoubleVertex output = op.apply(A, B);
+        T output = op.apply(A, B);
         PartialDerivatives wrtForward = output.getDerivativeWrtLatents();
 
         DoubleTensor wrtAForward = wrtForward.withRespectTo(A);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/ConcatenationVertexTest.java
@@ -8,6 +8,7 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Assert;
 import org.junit.Test;
@@ -144,8 +145,8 @@ public class ConcatenationVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        DoubleVertex c = a.times(b);
-        DoubleVertex d = a.plus(b);
+        MultiplicationVertex c = a.times(b);
+        AdditionVertex d = a.plus(b);
 
         ConcatenationVertex concat = new ConcatenationVertex(0, c, d);
         PartialDerivatives concatPartialForward = concat.getDerivativeWrtLatents();
@@ -182,7 +183,7 @@ public class ConcatenationVertexTest {
         DoubleVertex d = b.plus(ConstantVertex.of(DoubleTensor.linspace(1, 2, 8).reshape(2, 2, 2)));
 
         DoubleVertex concat = new ConcatenationVertex(2, c, d);
-        DoubleVertex sum = concat.sum(1);
+        SumVertex sum = concat.sum(1);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(Arrays.asList(a,b), sum, 10.0, 1e-10);
     }
@@ -308,8 +309,8 @@ public class ConcatenationVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        DoubleVertex c = sharedMatrix.matrixMultiply(a);
-        DoubleVertex d = sharedMatrix.matrixMultiply(b);
+        MatrixMultiplicationVertex c = sharedMatrix.matrixMultiply(a);
+        MatrixMultiplicationVertex d = sharedMatrix.matrixMultiply(b);
 
         DoubleTensor dCdshared = c.getDerivativeWrtLatents().withRespectTo(sharedMatrix);
         DoubleTensor dDdshared = d.getDerivativeWrtLatents().withRespectTo(sharedMatrix);
@@ -356,8 +357,8 @@ public class ConcatenationVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        DoubleVertex c = sharedMatrix.matrixMultiply(a);
-        DoubleVertex d = sharedMatrix.matrixMultiply(b);
+        MatrixMultiplicationVertex c = sharedMatrix.matrixMultiply(a);
+        MatrixMultiplicationVertex d = sharedMatrix.matrixMultiply(b);
 
         DoubleTensor dCdshared = c.getDerivativeWrtLatents().withRespectTo(sharedMatrix);
         DoubleTensor dDdshared = d.getDerivativeWrtLatents().withRespectTo(sharedMatrix);
@@ -408,9 +409,9 @@ public class ConcatenationVertexTest {
         DoubleVertex f = new UniformVertex(0, 10);
         f.setValue(DoubleTensor.create(new double[]{90, 91, 92, 93}, 2, 2));
 
-        DoubleVertex c = sharedMatrix.matrixMultiply(a);
-        DoubleVertex d = sharedMatrix.matrixMultiply(b);
-        DoubleVertex e = sharedMatrix.matrixMultiply(f);
+        MatrixMultiplicationVertex c = sharedMatrix.matrixMultiply(a);
+        MatrixMultiplicationVertex d = sharedMatrix.matrixMultiply(b);
+        MatrixMultiplicationVertex e = sharedMatrix.matrixMultiply(f);
 
         DoubleTensor dCdshared = c.getDerivativeWrtLatents().withRespectTo(sharedMatrix);
         DoubleTensor dDdshared = d.getDerivativeWrtLatents().withRespectTo(sharedMatrix);
@@ -461,7 +462,7 @@ public class ConcatenationVertexTest {
         DoubleVertex inputA = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex inputB = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         DoubleVertex inputC = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = new ConcatenationVertex(0, inputA, inputB, inputC);
+        ConcatenationVertex outputVertex = new ConcatenationVertex(0, inputA, inputB, inputC);
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, 10.0, 1e-10);
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/DivisionVertexTest.java
@@ -79,7 +79,7 @@ public class DivisionVertexTest {
     public void changesMatchGradient() {
         DoubleVertex A = new UniformVertex(new long[]{2, 2, 2}, 1.0, 10.0);
         DoubleVertex B = new UniformVertex(new long[]{2, 2, 2}, 100.0, 150.0);
-        DoubleVertex C = A.div(B).times(A);
+        MultiplicationVertex C = A.div(B).times(A);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B), C, 0.001, 1e-5);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -39,7 +39,7 @@ public class MatrixMultiplicationVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
-        DoubleVertex c = a.matrixMultiply(b);
+        MatrixMultiplicationVertex c = a.matrixMultiply(b);
 
         //of c wrt a,b
         DoubleTensor dCda = c.getDerivativeWrtLatents().withRespectTo(a);
@@ -77,7 +77,7 @@ public class MatrixMultiplicationVertexTest {
         assertEquals(expecteddCda, dCdaReverse);
         assertEquals(expecteddCdb, dCdbReverse);
 
-        DoubleVertex d = b.matrixMultiply(a);
+        MatrixMultiplicationVertex d = b.matrixMultiply(a);
 
         DoubleTensor dDda = d.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dDdb = d.getDerivativeWrtLatents().withRespectTo(b);
@@ -113,7 +113,7 @@ public class MatrixMultiplicationVertexTest {
         assertEquals(expecteddDda, dDdaReverse);
         assertEquals(expecteddDdb, dDdbReverse);
 
-        DoubleVertex e = c.plus(d);
+        AdditionVertex e = c.plus(d);
 
         //of e wrt a, b
         DoubleTensor dEda = e.getDerivativeWrtLatents().withRespectTo(a);
@@ -141,7 +141,7 @@ public class MatrixMultiplicationVertexTest {
         DoubleVertex alpha = new UniformVertex(0, 10);
         alpha.setValue(DoubleTensor.create(new double[]{1, 3, 5, 2, 4, 6}, 2, 3));
 
-        DoubleVertex N = m.matrixMultiply(alpha);
+        MatrixMultiplicationVertex N = m.matrixMultiply(alpha);
         PartialDerivatives NDiff = N.getDerivativeWrtLatents();
 
         PartialDerivatives reverseModePartialDiff = Differentiator.reverseModeAutoDiff(N, new HashSet<>(Arrays.asList(m, alpha)));
@@ -189,7 +189,7 @@ public class MatrixMultiplicationVertexTest {
         }, 2, 2));
 
         DoubleVertex N = m.matrixMultiply(alpha);
-        DoubleVertex y = N.matrixMultiply(beta);
+        MatrixMultiplicationVertex y = N.matrixMultiply(beta);
 
         PartialDerivatives yDiff = y.getDerivativeWrtLatents();
         PartialDerivatives dydx = Differentiator.reverseModeAutoDiff(y, m, alpha, beta);
@@ -253,7 +253,7 @@ public class MatrixMultiplicationVertexTest {
         DoubleVertex N = alpha.matrixMultiply(m);
         DoubleVertex L = beta.matrixMultiply(alpha);
         //y = L x N = (beta x alpha) x (alpha x m)
-        DoubleVertex y = L.matrixMultiply(N);
+        MatrixMultiplicationVertex y = L.matrixMultiply(N);
         PartialDerivatives yDiff = y.getDerivativeWrtLatents();
         PartialDerivatives dydx = Differentiator.reverseModeAutoDiff(y, new HashSet<>(Arrays.asList(alpha)));
 
@@ -276,7 +276,7 @@ public class MatrixMultiplicationVertexTest {
     public void changesMatchGradient() {
         DoubleVertex inputA = new UniformVertex(new long[]{2, 5}, -10.0, 10.0);
         DoubleVertex inputB = new UniformVertex(new long[]{5, 4}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputA.matrixMultiply(inputB);
+        MatrixMultiplicationVertex outputVertex = inputA.matrixMultiply(inputB);
         final double INCREMENT = 10;
         final double DELTA = 1e-10;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MaxVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MaxVertexTest.java
@@ -33,7 +33,7 @@ public class MaxVertexTest {
         A.setValue(DoubleTensor.create(1, 2, 3, 4, 5, 6, 7, 8));
         DoubleVertex B = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         B.setValue(DoubleTensor.create(8, 7, 6, 5, 4, 3, 2, 1));
-        DoubleVertex C = DoubleVertex.max(A, B);
+        MaxVertex C = DoubleVertex.max(A, B);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MinVertexTest.java
@@ -33,7 +33,7 @@ public class MinVertexTest {
         A.setValue(DoubleTensor.create(1, 2, 3, 4, 5, 6, 7, 8));
         DoubleVertex B = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         B.setValue(DoubleTensor.create(8, 7, 6, 5, 4, 3, 2, 1));
-        DoubleVertex C = DoubleVertex.min(A, B);
+        MinVertex C = DoubleVertex.min(A, B);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(A, B), C, 1e-6, 1e-10);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -90,7 +90,7 @@ public class SliceVertexTest {
         DoubleVertex alpha = new UniformVertex(0, 10);
         alpha.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25, 30, 35}, 3, 2));
 
-        DoubleVertex N = m.matrixMultiply(alpha);
+        MatrixMultiplicationVertex N = m.matrixMultiply(alpha);
 
         SliceVertex sliceN = new SliceVertex(N, dim, ind);
 
@@ -117,7 +117,7 @@ public class SliceVertexTest {
         DoubleVertex alpha = new UniformVertex(0, 10);
         alpha.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        DoubleVertex N = m.matrixMultiply(alpha);
+        MatrixMultiplicationVertex N = m.matrixMultiply(alpha);
 
         SliceVertex sliceN = new SliceVertex(N, 1, 1);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcCosVertexTest.java
@@ -58,7 +58,7 @@ public class ArcCosVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -0.25, 0.25);
-        DoubleVertex outputVertex = inputVertex.times(3).acos();
+        ArcCosVertex outputVertex = inputVertex.times(3).acos();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcSinVertexTest.java
@@ -58,7 +58,7 @@ public class ArcSinVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -0.25, 0.25);
-        DoubleVertex outputVertex = inputVertex.times(2.0).asin();
+        ArcSinVertex outputVertex = inputVertex.times(2.0).asin();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ArcTanVertexTest.java
@@ -58,7 +58,7 @@ public class ArcTanVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -2.0, 2.0);
-        DoubleVertex outputVertex = inputVertex.times(2).atan();
+        ArcTanVertex outputVertex = inputVertex.times(2).atan();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-4);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/CosVertexTest.java
@@ -53,7 +53,7 @@ public class CosVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.times(3).cos();
+        CosVertex outputVertex = inputVertex.times(3).cos();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ExpVertexTest.java
@@ -53,7 +53,7 @@ public class ExpVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.div(3).exp();
+        ExpVertex outputVertex = inputVertex.div(3).exp();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogGammaVertexTest.java
@@ -60,7 +60,7 @@ public class LogGammaVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, 1.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.div(3).logGamma();
+        LogGammaVertex outputVertex = inputVertex.div(3).logGamma();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/LogVertexTest.java
@@ -53,7 +53,7 @@ public class LogVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, 1.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.div(3).log();
+        LogVertex outputVertex = inputVertex.div(3).log();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixDeterminantVertexTest.java
@@ -8,6 +8,7 @@ import io.improbable.keanu.vertices.VertexMatchers;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.apache.commons.math3.linear.SingularMatrixException;
@@ -51,7 +52,7 @@ public class MatrixDeterminantVertexTest {
         final long[] shape = new long[]{2, 2};
         final DoubleVertex input = new UniformVertex(shape, 0, 10);
         input.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, shape));
-        final DoubleVertex output = input.matrixDeterminant();
+        final MatrixDeterminantVertex output = input.matrixDeterminant();
         finiteDifferenceMatchesReverseModeGradient(ImmutableList.of(input), output, 0.001, 1e-5);
     }
 
@@ -60,7 +61,7 @@ public class MatrixDeterminantVertexTest {
         final long[] shape = new long[]{2, 2};
         final DoubleVertex input = new UniformVertex(shape, 0, 10);
         input.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, shape));
-        final DoubleVertex output = input.matrixDeterminant().times(input);
+        final MultiplicationVertex output = input.matrixDeterminant().times(input);
 
         finiteDifferenceMatchesReverseModeGradient(ImmutableList.of(input), output, 0.001, 1e-5);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.tensor.dbl.ScalarDoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MatrixMultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Test;
 
@@ -52,7 +53,7 @@ public class MatrixInverseVertexTest {
     public void canCalculateDiffCorrectly() {
         DoubleVertex matrix = new UniformVertex(1.0, 100.0);
         matrix.setValue(DoubleTensor.arange(1, 5).reshape(2, 2));
-        DoubleVertex inverse = matrix.matrixInverse();
+        MatrixInverseVertex inverse = matrix.matrixInverse();
 
         inverse.lazyEval();
 
@@ -79,7 +80,7 @@ public class MatrixInverseVertexTest {
     public void inverseMultipliedEqualsIdentity() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{4, 4}, -20.0, 20.0);
         DoubleVertex inverseVertex = inputVertex.matrixInverse();
-        DoubleVertex multiplied = inverseVertex.matrixMultiply(inputVertex);
+        MatrixMultiplicationVertex multiplied = inverseVertex.matrixMultiply(inputVertex);
 
         for (int i = 0; i < NUM_ITERATIONS; i++) {
             inputVertex.setValue(inputVertex.sample());
@@ -110,7 +111,7 @@ public class MatrixInverseVertexTest {
     @Test
     public void inverseDifferenceMatchesGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{3, 3}, 1.0, 25.0);
-        DoubleVertex invertVertex = inputVertex.matrixInverse();
+        MatrixInverseVertex invertVertex = inputVertex.matrixInverse();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(
             ImmutableList.of(inputVertex), invertVertex, 0.001, 1e-5);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
@@ -6,6 +6,8 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MatrixMultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,7 +36,7 @@ public class ReshapeVertexTest {
         DoubleVertex alpha = new UniformVertex(0, 10);
         alpha.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        DoubleVertex N = m.matrixMultiply(alpha);
+        MatrixMultiplicationVertex N = m.matrixMultiply(alpha);
 
         ReshapeVertex reshapedN = new ReshapeVertex(N, 4, 1);
 
@@ -58,7 +60,7 @@ public class ReshapeVertexTest {
         DoubleVertex a = new UniformVertex(0, 10);
         a.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        DoubleVertex N = m.matrixMultiply(a);
+        MatrixMultiplicationVertex N = m.matrixMultiply(a);
         PartialDerivatives NDiff = N.getDerivativeWrtLatents();
 
         DoubleTensor dNdm = NDiff.withRespectTo(m);
@@ -90,7 +92,7 @@ public class ReshapeVertexTest {
         DoubleVertex E = new UniformVertex(0, 10);
         E.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 4, 1));
 
-        DoubleVertex F = D.times(E);
+        MultiplicationVertex F = D.times(E);
 
         PartialDerivatives forward = F.getDerivativeWrtLatents();
         PartialDerivatives backward = Differentiator.reverseModeAutoDiff(F, ImmutableSet.of(A, B));
@@ -110,7 +112,7 @@ public class ReshapeVertexTest {
         DoubleVertex C = A.plus(B);
 
         DoubleVertex D = C.reshape(4, 2, 2);
-        DoubleVertex E = D.reshape(4, 4);
+        ReshapeVertex E = D.reshape(4, 4);
 
         PartialDerivatives forward = E.getDerivativeWrtLatents();
         PartialDerivatives backward = Differentiator.reverseModeAutoDiff(E, ImmutableSet.of(A, B));
@@ -122,7 +124,7 @@ public class ReshapeVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{4, 4}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.times(1.5).reshape(2, 2, 2, 2);
+        ReshapeVertex outputVertex = inputVertex.times(1.5).reshape(2, 2, 2, 2);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 10.0, 1e-10);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SigmoidVertexTest.java
@@ -67,7 +67,7 @@ public class SigmoidVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.times(3).sigmoid();
+        SigmoidVertex outputVertex = inputVertex.times(3).sigmoid();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-6);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SinVertexTest.java
@@ -53,7 +53,7 @@ public class SinVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputVertex.div(3).sin();
+        SinVertex outputVertex = inputVertex.div(3).sin();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.001, 1e-5);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/SumVertexTest.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Test;
 
@@ -79,7 +80,7 @@ public class SumVertexTest {
         DoubleVertex a = new UniformVertex(new long[]{2, 2, 2}, 0, 10);
         a.setValue(a.sample());
 
-        DoubleVertex b = a.sum();
+        SumVertex b = a.sum();
 
         DoubleTensor dbdaForward = b.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dbdaReverse = Differentiator.reverseModeAutoDiff(b, a).withRespectTo(a);
@@ -96,7 +97,7 @@ public class SumVertexTest {
         a.setValue(DoubleTensor.arange(0, 4).reshape(2, 2));
 
         int sumDimension = 1;
-        DoubleVertex b = a.sum(sumDimension);
+        SumVertex b = a.sum(sumDimension);
 
         DoubleTensor dbdaForward = b.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dbdaReverse = Differentiator.reverseModeAutoDiff(b, a).withRespectTo(a);
@@ -113,7 +114,7 @@ public class SumVertexTest {
         a.setValue(DoubleTensor.arange(0, 8).reshape(2, 2, 2));
 
         int sumDimension = 1;
-        DoubleVertex b = a.sum(sumDimension);
+        SumVertex b = a.sum(sumDimension);
 
         DoubleTensor dbdaForward = b.getDerivativeWrtLatents().withRespectTo(a);
         DoubleTensor dbdaReverse = Differentiator.reverseModeAutoDiff(b, a).withRespectTo(a);
@@ -134,7 +135,7 @@ public class SumVertexTest {
         DoubleVertex e = new UniformVertex(new long[]{2, 2}, 0, 10);
         e.setValue(DoubleTensor.arange(4, 8).reshape(2, 2));
 
-        DoubleVertex f = d.times(e);
+        MultiplicationVertex f = d.times(e);
 
         DoubleTensor dfdaForward = f.getDerivativeWrtLatents().withRespectTo(a);
 
@@ -166,7 +167,7 @@ public class SumVertexTest {
         DoubleVertex e = new UniformVertex(0, 10);
         e.setValue(2);
 
-        DoubleVertex f = d.times(e);
+        MultiplicationVertex f = d.times(e);
 
         DoubleTensor dfdaForward = f.getDerivativeWrtLatents().withRespectTo(a);
 
@@ -192,7 +193,7 @@ public class SumVertexTest {
         DoubleVertex e = new UniformVertex(0, 10);
         e.setValue(new double[]{1, 2, 3});
 
-        DoubleVertex f = d.times(e);
+        MultiplicationVertex f = d.times(e);
 
         DoubleTensor dfdaForward = f.getDerivativeWrtLatents().withRespectTo(a);
 
@@ -211,7 +212,7 @@ public class SumVertexTest {
     public void changesMatchGradientWhenSummingAll() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         inputVertex.setValue(DoubleTensor.arange(0, 8).reshape(2, 2, 2));
-        DoubleVertex outputVertex = inputVertex.sum().times(inputVertex);
+        MultiplicationVertex outputVertex = inputVertex.sum().times(inputVertex);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 1e-6, 1e-10);
     }
@@ -221,7 +222,7 @@ public class SumVertexTest {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         inputVertex.setValue(DoubleTensor.arange(0, 8).reshape(2, 2, 2));
 
-        DoubleVertex outputVertex = inputVertex.sum(0)
+        MultiplicationVertex outputVertex = inputVertex.sum(0)
             .times(
                 inputVertex.sum(1)
             ).times(

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TakeVertexTest.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.AdditionVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Test;
 
@@ -129,7 +130,7 @@ public class TakeVertexTest {
         DoubleVertex E = new UniformVertex(0, 10);
         E.setValue(DoubleTensor.create(new double[]{1, 2, 3, 4}, 1, 4));
 
-        DoubleVertex F = D.plus(E);
+        AdditionVertex F = D.plus(E);
 
         PartialDerivatives forward = F.getDerivativeWrtLatents();
         PartialDerivatives reverse = Differentiator.reverseModeAutoDiff(F, A, B);
@@ -144,7 +145,7 @@ public class TakeVertexTest {
         DoubleVertex inputA = new UniformVertex(new long[]{3, 3, 3}, -10.0, 10.0);
         DoubleVertex inputB = new UniformVertex(new long[]{3, 3, 3}, -10.0, 10.0);
         DoubleVertex inputC = new UniformVertex(new long[]{2, 2}, -10.0, 10.0);
-        DoubleVertex outputVertex = inputA.times(10.0).times(inputB).take(0, 1, 2).plus(inputC);
+        AdditionVertex outputVertex = inputA.times(10.0).times(inputB).take(0, 1, 2).plus(inputC);
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB), outputVertex, 10.0, 1e-10);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/TanVertexTest.java
@@ -58,7 +58,7 @@ public class TanVertexTest {
     @Test
     public void changesMatchGradient() {
         DoubleVertex inputVertex = new UniformVertex(new long[]{2, 2, 2}, -1.0, 1.0);
-        DoubleVertex outputVertex = inputVertex.div(3).tan();
+        TanVertex outputVertex = inputVertex.div(3).tan();
 
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputVertex), outputVertex, 0.0001, 1e-6);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/UnaryOperationTestHelpers.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/UnaryOperationTestHelpers.java
@@ -4,6 +4,7 @@ import io.improbable.keanu.tensor.TensorShape;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -26,13 +27,13 @@ public class UnaryOperationTestHelpers {
         assertEquals(expected, op.apply(A).getValue().scalar(), 1e-5);
     }
 
-    public static void calculatesDerivativeOfScalar(double aValue,
+    public static <T extends DoubleVertex & Differentiable> void calculatesDerivativeOfScalar(double aValue,
                                                     double expectedGradientWrtA,
-                                                    Function<DoubleVertex, DoubleVertex> op) {
+                                                    Function<DoubleVertex, T> op) {
 
         UniformVertex A = new UniformVertex(0.0, 1.0);
         A.setAndCascade(Nd4jDoubleTensor.scalar(aValue));
-        DoubleVertex output = op.apply(A);
+        T output = op.apply(A);
 
         DoubleTensor wrtAForward = output.getDerivativeWrtLatents().withRespectTo(A);
         assertEquals(
@@ -65,16 +66,16 @@ public class UnaryOperationTestHelpers {
         assertEquals(expectedTensor.getValue(1, 1), result.getValue(1, 1), 1e-5);
     }
 
-    public static void calculatesDerivativeOfMatrixElementWiseOperator(double[] aValues,
+    public static <T extends DoubleVertex & Differentiable> void calculatesDerivativeOfMatrixElementWiseOperator(double[] aValues,
                                                                        double[] expectedGradientWrtA,
-                                                                       Function<DoubleVertex, DoubleVertex> op) {
+                                                                       Function<DoubleVertex, T> op) {
 
         long[] matrixShape = new long[]{2, 2};
         long[] expectedShape = TensorShape.concat(matrixShape, matrixShape);
         UniformVertex A = new UniformVertex(matrixShape, 0.0, 1.0);
         A.setAndCascade(Nd4jDoubleTensor.create(aValues, matrixShape));
 
-        DoubleVertex output = op.apply(A);
+        T output = op.apply(A);
 
         PartialDerivatives result = output.getDerivativeWrtLatents();
         DoubleTensor wrtAForward = result.withRespectTo(A);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -6,6 +6,7 @@ import io.improbable.keanu.tensor.dbl.Nd4jDoubleTensor;
 import io.improbable.keanu.vertices.Probabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivatives;
@@ -208,7 +209,7 @@ public class ProbabilisticDoubleTensorContract {
             diffLnDensityApproxExpected, actualDiffLnDensity, 0.1);
     }
 
-    public static <V extends DoubleVertex & ProbabilisticDouble>
+    public static <V extends DoubleVertex & ProbabilisticDouble & Differentiable>
     void isTreatedAsConstantWhenObserved(V vertexUnderTest) {
         vertexUnderTest.observe(DoubleTensor.ones(vertexUnderTest.getValue().getShape()));
         assertTrue(vertexUnderTest.getDerivativeWrtLatents().asMap().isEmpty());

--- a/keanu-python/.gitignore
+++ b/keanu-python/.gitignore
@@ -2,3 +2,5 @@ keanu-python-all.jar
 *.egg-info/
 Pipfile.lock
 __pycache__/
+dist/
+keanu/classpath


### PR DESCRIPTION
Remove `Differentiable` interface from the `DoubleVertex` and make vertices that are differentiable implement Differentiable directly. Otherwise all vertices extending `DoubleVertex` seem to be differentiable, which is misleading, as `RoundVertex`, `CeilingVertex`, `FloorVertex` etc are not differentiable. The default implementation of `forwardModeAutoDifferentiation` and `reverseModeAutoDifferentiation` has been moved form `DoubleVertex` to `Differentiable` as a default method. 

Note: I'm not 100% taking the implementation of `forwardModeAutoDifferentiation` out of `DoubleUnaryOpVertex` is ok.