### PR TITLE
Python formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ For IntelliJ:
 
 We use [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle) to automatically enforce some basic code style checks. If your build fails due to a formatting issue, simply run `./gradlew spotlessApply` and commit the changes.
 
+We use [yapf](https://github.com/google/yapf) for formatting python code. If your build fails due to a python formatting issue, run './gradlew keanu-python:formatApply' and commit the changes.  
+
 
 #### Python Code Generation
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For IntelliJ:
 
 We use [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle) to automatically enforce some basic code style checks. If your build fails due to a formatting issue, simply run `./gradlew spotlessApply` and commit the changes.
 
-We use [yapf](https://github.com/google/yapf) for formatting python code. If your build fails due to a python formatting issue, run './gradlew keanu-python:formatApply' and commit the changes.  
+We use [yapf](https://github.com/google/yapf) for formatting python code. If your build fails due to a python formatting issue, run `./gradlew keanu-python:formatApply` and commit the changes.  
 
 
 #### Python Code Generation

--- a/README.md
+++ b/README.md
@@ -74,10 +74,7 @@ For IntelliJ:
 
 #### Formatting
 
-We use [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle) to automatically enforce some basic code style checks. If your build fails due to a formatting issue, simply run `./gradlew spotlessApply` and commit the changes.
-
-We use [yapf](https://github.com/google/yapf) for formatting python code. If your build fails due to a python formatting issue, run `./gradlew keanu-python:formatApply` and commit the changes.  
-
+We use [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle) and [yapf](https://github.com/google/yapf) to automatically enforce some basic code style checks. If your build fails due to a formatting issue, simply run `./gradlew formatApply` and commit the changes.
 
 #### Python Code Generation
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,3 +25,8 @@ allprojects {
 dependencies {
     compile project(":keanu-project")
 }
+
+task formatApply {
+    dependsOn("spotlessApply")
+    dependsOn("keanu-python:formatApply")
+}

--- a/keanu-python/.style.yapf
+++ b/keanu-python/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style = google
+column_limit = 120

--- a/keanu-python/.style.yapf
+++ b/keanu-python/.style.yapf
@@ -1,3 +1,4 @@
 [style]
 based_on_style = google
 column_limit = 120
+spaces_around_power_operator = True

--- a/keanu-python/Pipfile
+++ b/keanu-python/Pipfile
@@ -12,6 +12,7 @@ pandas = "*"
 [dev-packages]
 pytest = "*"
 sphinx = "*"
+yapf = "*"
 
 [requires]
 python_version = "3.6"

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -103,7 +103,9 @@ task formatCheck {
     dependsOn("preparePythonEnvironment")
     doLast { 
         exec {
-            commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--diff', '--recursive', '--parallel',  '.'
+            // Exclude files that are generated
+            commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--diff', '--recursive', '--parallel', 
+            '--exclude', 'keanu/vertex/generated.py', '--exclude', 'keanu/vertex/__init__.py', '.'
         }
     }
 }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -1,4 +1,6 @@
-import static org.apache.tools.ant.taskdefs.condition.Os.*
+import static org.apache.tools.ant.taskdefs.condition.Os.isFamily;
+import static org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS;
+
 task installPipenv {
     doLast {
         exec {
@@ -105,8 +107,12 @@ task formatCheck {
     doLast { 
         exec {
             // Exclude files that are generated
-            def keanuVertexGeneratedPath = 'keanu' + File.separator + 'vertex' + File.separator + 'generated.py'
-            def keanuVertexInitPath = 'keanu' + File.separator + 'vertex' + File.separator + '__init__.py'
+            def keanuVetexPath = 'keanu/vertex/'
+            if(isFamily(FAMILY_WINDOWS)) {
+                keanuVetexPath = '.\\keanu\\vertex\\'
+            }
+            def keanuVertexGeneratedPath = keanuVetexPath + 'generated.py'
+            def keanuVertexInitPath = keanuVetexPath + '__init__.py'
             commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--diff', '--recursive', '--parallel', 
             '--exclude', keanuVertexGeneratedPath, '--exclude', keanuVertexInitPath, '.'
         }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -1,3 +1,4 @@
+import static org.apache.tools.ant.taskdefs.condition.Os.*
 task installPipenv {
     doLast {
         exec {
@@ -104,8 +105,10 @@ task formatCheck {
     doLast { 
         exec {
             // Exclude files that are generated
+            def keanuVertexGeneratedPath = 'keanu' + File.separator + 'vertex' + File.separator + 'generated.py'
+            def keanuVertexInitPath = 'keanu' + File.separator + 'vertex' + File.separator + '__init__.py'
             commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--diff', '--recursive', '--parallel', 
-            '--exclude', 'keanu/vertex/generated.py', '--exclude', 'keanu/vertex/__init__.py', '.'
+            '--exclude', keanuVertexGeneratedPath, '--exclude', keanuVertexInitPath, '.'
         }
     }
 }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -81,6 +81,22 @@ task generateDocumentation {
         }
     }
 }
+task applyFormat {
+    doLast {
+        exec {
+            commandLine 'yapf', '--in-place', '--recursive', '--parallel', '.'
+        }
+    }
+}
+
+task checkFormat {
+    doLast { 
+        exec {
+            commandLine 'yapf', '--diff', '--recursive', '--parallel',  '.'
+        }
+    }
+}
+
 
 pythonVersionInfo.mustRunAfter(installPipenv)
 installDependencies.mustRunAfter(pythonVersionInfo)

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -97,7 +97,7 @@ task formatApply {
     dependsOn("preparePythonEnvironment")
     doLast {
         exec {
-            commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--in-place', '--recursive', '--parallel', '.'
+            commandLine 'pipenv', 'run', 'yapf', '--in-place', '--recursive', '--parallel', '.'
         }
     }
 }
@@ -113,7 +113,7 @@ task formatCheck {
             }
             def keanuVertexGeneratedPath = keanuVetexPath + 'generated.py'
             def keanuVertexInitPath = keanuVetexPath + '__init__.py'
-            commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--diff', '--recursive', '--parallel', 
+            commandLine 'pipenv', 'run', 'yapf', '--diff', '--recursive', '--parallel',
             '--exclude', keanuVertexGeneratedPath, '--exclude', keanuVertexInitPath, '.'
         }
     }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -82,7 +82,16 @@ task generateDocumentation {
     }
 }
 
+task preparePythonEnvironment {
+    dependsOn(installPipenv)
+    dependsOn(pythonVersionInfo)
+    dependsOn(installDependencies)
+    dependsOn(":keanu-project:preparePythonClasspath")
+    dependsOn(":codegen:runCodeGeneration")
+}
+
 task formatApply {
+    dependsOn("preparePythonEnvironment")
     doLast {
         exec {
             commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--in-place', '--recursive', '--parallel', '.'
@@ -91,6 +100,7 @@ task formatApply {
 }
 
 task formatCheck {
+    dependsOn("preparePythonEnvironment")
     doLast { 
         exec {
             commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--diff', '--recursive', '--parallel',  '.'
@@ -101,15 +111,8 @@ task formatCheck {
 
 pythonVersionInfo.mustRunAfter(installPipenv)
 installDependencies.mustRunAfter(pythonVersionInfo)
-
-task preparePythonEnvironment {
-    dependsOn(installPipenv)
-    dependsOn(pythonVersionInfo)
-    dependsOn(installDependencies)
-    dependsOn(":keanu-project:preparePythonClasspath")
-    dependsOn(":codegen:runCodeGeneration")
-}
-
 generateDocumentation.dependsOn(preparePythonEnvironment)
 pytest.dependsOn(preparePythonEnvironment)
+test.dependsOn(formatCheck)
 test.dependsOn(pytest)
+

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -1,5 +1,7 @@
-import static org.apache.tools.ant.taskdefs.condition.Os.isFamily;
-import static org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS;
+import java.nio.file.Paths
+
+import static org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS
+import static org.apache.tools.ant.taskdefs.condition.Os.isFamily
 
 task installPipenv {
     doLast {
@@ -107,12 +109,12 @@ task formatCheck {
     doLast { 
         exec {
             // Exclude files that are generated
-            def keanuVertexPath = 'keanu/vertex/'
+            def keanuVertexPath = Paths.get("keanu", "vertex")
             if(isFamily(FAMILY_WINDOWS)) {
-                keanuVertexPath = '.\\keanu\\vertex\\'
+                keanuVertexPath = Paths.get(".").resolve(keanuVertexPath)
             }
-            def keanuVertexGeneratedPath = keanuVertexPath + 'generated.py'
-            def keanuVertexInitPath = keanuVertexPath + '__init__.py'
+            def keanuVertexGeneratedPath = keanuVertexPath.resolve("generated.py")
+            def keanuVertexInitPath = keanuVertexPath.resolve("__init__.py")
             commandLine 'pipenv', 'run', 'yapf', '--diff', '--recursive', '--parallel',
             '--exclude', keanuVertexGeneratedPath, '--exclude', keanuVertexInitPath, '.'
         }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -81,7 +81,7 @@ task generateDocumentation {
         }
     }
 }
-task applyFormat {
+task formatApply {
     doLast {
         exec {
             commandLine 'yapf', '--in-place', '--recursive', '--parallel', '.'
@@ -89,7 +89,7 @@ task applyFormat {
     }
 }
 
-task checkFormat {
+task formatCheck {
     doLast { 
         exec {
             commandLine 'yapf', '--diff', '--recursive', '--parallel',  '.'

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -107,12 +107,12 @@ task formatCheck {
     doLast { 
         exec {
             // Exclude files that are generated
-            def keanuVetexPath = 'keanu/vertex/'
+            def keanuVertexPath = 'keanu/vertex/'
             if(isFamily(FAMILY_WINDOWS)) {
-                keanuVetexPath = '.\\keanu\\vertex\\'
+                keanuVertexPath = '.\\keanu\\vertex\\'
             }
-            def keanuVertexGeneratedPath = keanuVetexPath + 'generated.py'
-            def keanuVertexInitPath = keanuVetexPath + '__init__.py'
+            def keanuVertexGeneratedPath = keanuVertexPath + 'generated.py'
+            def keanuVertexInitPath = keanuVertexPath + '__init__.py'
             commandLine 'pipenv', 'run', 'yapf', '--diff', '--recursive', '--parallel',
             '--exclude', keanuVertexGeneratedPath, '--exclude', keanuVertexInitPath, '.'
         }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -81,10 +81,11 @@ task generateDocumentation {
         }
     }
 }
+
 task formatApply {
     doLast {
         exec {
-            commandLine 'yapf', '--in-place', '--recursive', '--parallel', '.'
+            commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--in-place', '--recursive', '--parallel', '.'
         }
     }
 }
@@ -92,7 +93,7 @@ task formatApply {
 task formatCheck {
     doLast { 
         exec {
-            commandLine 'yapf', '--diff', '--recursive', '--parallel',  '.'
+            commandLine 'pipenv', 'run', 'yapf', '--style', 'google', '--diff', '--recursive', '--parallel',  '.'
         }
     }
 }

--- a/keanu-python/docs/conf.py
+++ b/keanu-python/docs/conf.py
@@ -126,8 +126,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'keanu.tex', u'keanu Documentation', u'Improbable Research',
-     'manual'),
+    (master_doc, 'keanu.tex', u'keanu Documentation', u'Improbable Research', 'manual'),
 ]
 
 # -- Options for manual page output ------------------------------------------
@@ -142,8 +141,7 @@ man_pages = [(master_doc, 'keanu', u'keanu Documentation', [author], 1)]
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'keanu', u'keanu Documentation', author, 'keanu',
-     'One line description of project.', 'Miscellaneous'),
+    (master_doc, 'keanu', u'keanu Documentation', author, 'keanu', 'One line description of project.', 'Miscellaneous'),
 ]
 
 # -- Options for Epub output -------------------------------------------------

--- a/keanu-python/docs/conf.py
+++ b/keanu-python/docs/conf.py
@@ -16,7 +16,6 @@ import os
 import sys
 sys.path.insert(0, u'../')
 
-
 # -- Project information -----------------------------------------------------
 
 project = u'keanu'
@@ -27,7 +26,6 @@ author = u'Improbable'
 version = u'0.0.15'
 # The full version, including alpha/beta/rc tags
 release = u'0.0.15'
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -71,7 +69,6 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -100,12 +97,10 @@ html_static_path = []
 #
 # html_sidebars = {}
 
-
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'keanudoc'
-
 
 # -- Options for LaTeX output ------------------------------------------------
 
@@ -131,20 +126,15 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'keanu.tex', u'keanu Documentation',
-     u'Improbable Research', 'manual'),
+    (master_doc, 'keanu.tex', u'keanu Documentation', u'Improbable Research',
+     'manual'),
 ]
-
 
 # -- Options for manual page output ------------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'keanu', u'keanu Documentation',
-     [author], 1)
-]
-
+man_pages = [(master_doc, 'keanu', u'keanu Documentation', [author], 1)]
 
 # -- Options for Texinfo output ----------------------------------------------
 
@@ -152,11 +142,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'keanu', u'keanu Documentation',
-     author, 'keanu', 'One line description of project.',
-     'Miscellaneous'),
+    (master_doc, 'keanu', u'keanu Documentation', author, 'keanu',
+     'One line description of project.', 'Miscellaneous'),
 ]
-
 
 # -- Options for Epub output -------------------------------------------------
 
@@ -174,7 +162,6 @@ epub_title = project
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
-
 
 # -- Extension configuration -------------------------------------------------
 

--- a/keanu-python/docs/remove_underscores.py
+++ b/keanu-python/docs/remove_underscores.py
@@ -24,4 +24,6 @@ for directory, subdirectories, files in os.walk(root_dir):
         except:
             pass
 
-print("Finished renaming all directories and mentions of directories with underscores")
+print(
+    "Finished renaming all directories and mentions of directories with underscores"
+)

--- a/keanu-python/docs/remove_underscores.py
+++ b/keanu-python/docs/remove_underscores.py
@@ -24,6 +24,4 @@ for directory, subdirectories, files in os.walk(root_dir):
         except:
             pass
 
-print(
-    "Finished renaming all directories and mentions of directories with underscores"
-)
+print("Finished renaming all directories and mentions of directories with underscores")

--- a/keanu-python/examples/coal_mining.py
+++ b/keanu-python/examples/coal_mining.py
@@ -3,11 +3,13 @@ import numpy as np
 from keanu.vertex import UniformInt, Exponential, DoubleIf, Poisson
 from keanu import Model
 
+
 class CoalMining():
     __fname = "data/coal-mining-disaster-data.csv"
 
     def __init__(self):
-        self._data = pd.read_csv(CoalMining.__fname, names=["year", "count"]).set_index("year")
+        self._data = pd.read_csv(
+            CoalMining.__fname, names=["year", "count"]).set_index("year")
 
     def model(self):
         start_year, end_year = (self._data.index.min(), self._data.index.max())
@@ -19,7 +21,8 @@ class CoalMining():
             m.late_rate = Exponential(1.0)
 
             m.years = np.array(self._data.index)
-            m.rates = DoubleIf((1, 1), m.switchpoint > m.years, m.early_rate, m.late_rate)
+            m.rates = DoubleIf((1, 1), m.switchpoint > m.years, m.early_rate,
+                               m.late_rate)
             m.disasters = Poisson(m.rates)
 
         return m

--- a/keanu-python/examples/coal_mining.py
+++ b/keanu-python/examples/coal_mining.py
@@ -8,8 +8,7 @@ class CoalMining():
     __fname = "data/coal-mining-disaster-data.csv"
 
     def __init__(self):
-        self._data = pd.read_csv(
-            CoalMining.__fname, names=["year", "count"]).set_index("year")
+        self._data = pd.read_csv(CoalMining.__fname, names=["year", "count"]).set_index("year")
 
     def model(self):
         start_year, end_year = (self._data.index.min(), self._data.index.max())
@@ -21,8 +20,7 @@ class CoalMining():
             m.late_rate = Exponential(1.0)
 
             m.years = np.array(self._data.index)
-            m.rates = DoubleIf((1, 1), m.switchpoint > m.years, m.early_rate,
-                               m.late_rate)
+            m.rates = DoubleIf((1, 1), m.switchpoint > m.years, m.early_rate, m.late_rate)
             m.disasters = Poisson(m.rates)
 
         return m

--- a/keanu-python/examples/lorenz_model.py
+++ b/keanu-python/examples/lorenz_model.py
@@ -19,10 +19,7 @@ class LorenzModel:
             yield position
 
     def __get_next_position(self, current: Coordinates) -> Coordinates:
-        nextX = current.x + self.time_step * (self.sigma *
-                                              (current.y - current.x))
-        nextY = current.y + self.time_step * (
-            current.x * (self.rho - current.z) - current.y)
-        nextZ = current.z + self.time_step * (
-            current.x * current.y - self.beta * current.z)
+        nextX = current.x + self.time_step * (self.sigma * (current.y - current.x))
+        nextY = current.y + self.time_step * (current.x * (self.rho - current.z) - current.y)
+        nextZ = current.z + self.time_step * (current.x * current.y - self.beta * current.z)
         return Coordinates(nextX, nextY, nextZ)

--- a/keanu-python/examples/lorenz_model.py
+++ b/keanu-python/examples/lorenz_model.py
@@ -1,10 +1,10 @@
 from collections import namedtuple
 
-
 Coordinates = namedtuple('Coordinates', 'x y z')
 
 
-class LorenzModel: 
+class LorenzModel:
+
     def __init__(self, sigma, beta, rho, time_step):
         self.sigma = sigma
         self.beta = beta
@@ -17,10 +17,12 @@ class LorenzModel:
         for _ in range(num_time_steps):
             position = self.__get_next_position(position)
             yield position
-        
-    def __get_next_position(self, current : Coordinates) -> Coordinates :
-        nextX = current.x + self.time_step * (self.sigma * (current.y - current.x))
-        nextY = current.y + self.time_step * (current.x * (self.rho - current.z) - current.y)
-        nextZ = current.z + self.time_step * (current.x * current.y - self.beta * current.z)
+
+    def __get_next_position(self, current: Coordinates) -> Coordinates:
+        nextX = current.x + self.time_step * (self.sigma *
+                                              (current.y - current.x))
+        nextY = current.y + self.time_step * (
+            current.x * (self.rho - current.z) - current.y)
+        nextZ = current.z + self.time_step * (
+            current.x * current.y - self.beta * current.z)
         return Coordinates(nextX, nextY, nextZ)
-    

--- a/keanu-python/examples/thermometers.py
+++ b/keanu-python/examples/thermometers.py
@@ -1,7 +1,9 @@
 from keanu import Model
 from keanu.vertex import Uniform, Gaussian
 
+
 class Thermometer:
+
     @staticmethod
     def model():
 

--- a/keanu-python/keanu/algorithm/__init__.py
+++ b/keanu-python/keanu/algorithm/__init__.py
@@ -1,5 +1,2 @@
-from .optimization import (
-    GradientOptimizer,
-    NonGradientOptimizer
-)
+from .optimization import (GradientOptimizer, NonGradientOptimizer)
 from .sampling import sample, generate_samples

--- a/keanu-python/keanu/algorithm/optimization.py
+++ b/keanu-python/keanu/algorithm/optimization.py
@@ -5,14 +5,8 @@ from keanu.vertex.base import Vertex
 
 k = KeanuContext()
 
-java_import(
-    k.jvm_view(),
-    "io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer"
-)
-java_import(
-    k.jvm_view(),
-    "io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer"
-)
+java_import(k.jvm_view(), "io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer")
+java_import(k.jvm_view(), "io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer")
 
 
 class Optimizer:
@@ -30,9 +24,7 @@ class Optimizer:
     @staticmethod
     def _build_bayes_net(builder, net):
         if not (isinstance(net, BayesNet) or isinstance(net, Vertex)):
-            raise TypeError(
-                "net must be a Vertex or a BayesNet. Was given {}".format(
-                    type(net)))
+            raise TypeError("net must be a Vertex or a BayesNet. Was given {}".format(type(net)))
         elif isinstance(net, Vertex):
             net = BayesNet(net.get_connected_graph())
         return builder.bayesianNetwork(net.unwrap()), net
@@ -40,11 +32,7 @@ class Optimizer:
 
 class GradientOptimizer(Optimizer):
 
-    def __init__(self,
-                 net,
-                 max_evaluations=None,
-                 relative_threshold=None,
-                 absolute_threshold=None):
+    def __init__(self, net, max_evaluations=None, relative_threshold=None, absolute_threshold=None):
         builder = k.jvm_view().GradientOptimizer.builder()
         builder, net = Optimizer._build_bayes_net(builder, net)
         if max_evaluations is not None:

--- a/keanu-python/keanu/algorithm/optimization.py
+++ b/keanu-python/keanu/algorithm/optimization.py
@@ -5,11 +5,18 @@ from keanu.vertex.base import Vertex
 
 k = KeanuContext()
 
-java_import(k.jvm_view(), "io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer")
-java_import(k.jvm_view(), "io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer")
+java_import(
+    k.jvm_view(),
+    "io.improbable.keanu.algorithms.variational.optimizer.gradient.GradientOptimizer"
+)
+java_import(
+    k.jvm_view(),
+    "io.improbable.keanu.algorithms.variational.optimizer.nongradient.NonGradientOptimizer"
+)
 
 
 class Optimizer:
+
     def __init__(self, optimizer, net):
         self.optimizer = optimizer
         self.net = net
@@ -23,14 +30,21 @@ class Optimizer:
     @staticmethod
     def _build_bayes_net(builder, net):
         if not (isinstance(net, BayesNet) or isinstance(net, Vertex)):
-            raise TypeError("net must be a Vertex or a BayesNet. Was given {}".format(type(net)))
+            raise TypeError(
+                "net must be a Vertex or a BayesNet. Was given {}".format(
+                    type(net)))
         elif isinstance(net, Vertex):
             net = BayesNet(net.get_connected_graph())
         return builder.bayesianNetwork(net.unwrap()), net
 
 
 class GradientOptimizer(Optimizer):
-    def __init__(self, net, max_evaluations=None, relative_threshold=None, absolute_threshold=None):
+
+    def __init__(self,
+                 net,
+                 max_evaluations=None,
+                 relative_threshold=None,
+                 absolute_threshold=None):
         builder = k.jvm_view().GradientOptimizer.builder()
         builder, net = Optimizer._build_bayes_net(builder, net)
         if max_evaluations is not None:
@@ -44,7 +58,13 @@ class GradientOptimizer(Optimizer):
 
 
 class NonGradientOptimizer(Optimizer):
-    def __init__(self, net, max_evaluations=None, bounds_range=None, initial_trust_region_radius=None, stopping_trust_region_radius=None):
+
+    def __init__(self,
+                 net,
+                 max_evaluations=None,
+                 bounds_range=None,
+                 initial_trust_region_radius=None,
+                 stopping_trust_region_radius=None):
         builder = k.jvm_view().NonGradientOptimizer.builder()
         builder, net = Optimizer._build_bayes_net(builder, net)
         if max_evaluations is not None:

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -5,8 +5,7 @@ from keanu.vertex.base import Vertex
 
 k = KeanuContext()
 
-java_import(k.jvm_view(),
-            "io.improbable.keanu.algorithms.mcmc.MetropolisHastings")
+java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.MetropolisHastings")
 java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.NUTS")
 java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.Hamiltonian")
 
@@ -17,38 +16,25 @@ algorithms = {
 }
 
 
-def sample(net,
-           sample_from,
-           algo='metropolis',
-           draws=500,
-           drop=0,
-           down_sample_interval=1):
+def sample(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_interval=1):
     vertices_unwrapped = k.to_java_object_list(sample_from)
 
     network_samples = algorithms[algo].withDefaultConfig().getPosteriorSamples(
-        net.unwrap(), vertices_unwrapped,
-        draws).drop(drop).downSample(down_sample_interval)
+        net.unwrap(), vertices_unwrapped, draws).drop(drop).downSample(down_sample_interval)
     vertex_samples = {
         Vertex._get_python_id(vertex_unwrapped): list(
             map(Tensor._to_ndarray,
-                network_samples.get(vertex_unwrapped).asList()))
-        for vertex_unwrapped in vertices_unwrapped
+                network_samples.get(vertex_unwrapped).asList())) for vertex_unwrapped in vertices_unwrapped
     }
 
     return vertex_samples
 
 
-def generate_samples(net,
-                     sample_from,
-                     algo='metropolis',
-                     drop=0,
-                     down_sample_interval=1):
+def generate_samples(net, sample_from, algo='metropolis', drop=0, down_sample_interval=1):
     vertices_unwrapped = k.to_java_object_list(sample_from)
 
-    sample_iterator = algorithms[algo].withDefaultConfig(
-    ).generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
-    sample_iterator = sample_iterator.dropCount(drop).downSampleInterval(
-        down_sample_interval)
+    sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
+    sample_iterator = sample_iterator.dropCount(drop).downSampleInterval(down_sample_interval)
     sample_iterator = sample_iterator.stream().iterator()
 
     return _samples_generator(sample_iterator, vertices_unwrapped)
@@ -58,8 +44,7 @@ def _samples_generator(sample_iterator, vertices_unwrapped):
     while (True):
         network_sample = sample_iterator.next()
         sample = {
-            Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(
-                network_sample.get(vertex_unwrapped))
+            Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(network_sample.get(vertex_unwrapped))
             for vertex_unwrapped in vertices_unwrapped
         }
         yield sample

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -5,33 +5,61 @@ from keanu.vertex.base import Vertex
 
 k = KeanuContext()
 
-java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.MetropolisHastings")
+java_import(k.jvm_view(),
+            "io.improbable.keanu.algorithms.mcmc.MetropolisHastings")
 java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.NUTS")
 java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.Hamiltonian")
 
-algorithms = {'metropolis': k.jvm_view().MetropolisHastings,
-              'NUTS': k.jvm_view().NUTS,
-              'hamiltonian': k.jvm_view().Hamiltonian}
+algorithms = {
+    'metropolis': k.jvm_view().MetropolisHastings,
+    'NUTS': k.jvm_view().NUTS,
+    'hamiltonian': k.jvm_view().Hamiltonian
+}
 
-def sample(net, sample_from, algo='metropolis', draws=500, drop=0, down_sample_interval=1):
+
+def sample(net,
+           sample_from,
+           algo='metropolis',
+           draws=500,
+           drop=0,
+           down_sample_interval=1):
     vertices_unwrapped = k.to_java_object_list(sample_from)
 
-    network_samples = algorithms[algo].withDefaultConfig().getPosteriorSamples(net.unwrap(), vertices_unwrapped, draws).drop(drop).downSample(down_sample_interval)
-    vertex_samples = {Vertex._get_python_id(vertex_unwrapped): list(map(Tensor._to_ndarray, network_samples.get(vertex_unwrapped).asList())) for vertex_unwrapped in vertices_unwrapped}
+    network_samples = algorithms[algo].withDefaultConfig().getPosteriorSamples(
+        net.unwrap(), vertices_unwrapped,
+        draws).drop(drop).downSample(down_sample_interval)
+    vertex_samples = {
+        Vertex._get_python_id(vertex_unwrapped): list(
+            map(Tensor._to_ndarray,
+                network_samples.get(vertex_unwrapped).asList()))
+        for vertex_unwrapped in vertices_unwrapped
+    }
 
     return vertex_samples
 
-def generate_samples(net, sample_from, algo='metropolis', drop=0, down_sample_interval=1):
-	vertices_unwrapped = k.to_java_object_list(sample_from)
 
-	sample_iterator = algorithms[algo].withDefaultConfig().generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
-	sample_iterator = sample_iterator.dropCount(drop).downSampleInterval(down_sample_interval)
-	sample_iterator = sample_iterator.stream().iterator()
-	
-	return _samples_generator(sample_iterator, vertices_unwrapped)
+def generate_samples(net,
+                     sample_from,
+                     algo='metropolis',
+                     drop=0,
+                     down_sample_interval=1):
+    vertices_unwrapped = k.to_java_object_list(sample_from)
+
+    sample_iterator = algorithms[algo].withDefaultConfig(
+    ).generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
+    sample_iterator = sample_iterator.dropCount(drop).downSampleInterval(
+        down_sample_interval)
+    sample_iterator = sample_iterator.stream().iterator()
+
+    return _samples_generator(sample_iterator, vertices_unwrapped)
+
 
 def _samples_generator(sample_iterator, vertices_unwrapped):
-	while (True):
-		network_sample = sample_iterator.next()
-		sample = {Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(network_sample.get(vertex_unwrapped)) for vertex_unwrapped in vertices_unwrapped}
-		yield sample
+    while (True):
+        network_sample = sample_iterator.next()
+        sample = {
+            Vertex._get_python_id(vertex_unwrapped): Tensor._to_ndarray(
+                network_sample.get(vertex_unwrapped))
+            for vertex_unwrapped in vertices_unwrapped
+        }
+        yield sample

--- a/keanu-python/keanu/base.py
+++ b/keanu-python/keanu/base.py
@@ -1,7 +1,9 @@
 import logging
 from .case_conversion import _to_camel_case_name, _to_snake_case_name
 
+
 class JavaObjectWrapper:
+
     def __init__(self, val):
         self._val = val
         self._class = self.unwrap().getClass().getSimpleName()
@@ -14,12 +16,17 @@ class JavaObjectWrapper:
 
         if k != python_name:
             if python_name in self.__class__.__dict__:
-                raise AttributeError("{} has no attribute {}. Did you mean {}?".format(self.__class__, k, python_name))
+                raise AttributeError(
+                    "{} has no attribute {}. Did you mean {}?".format(
+                        self.__class__, k, python_name))
 
-            raise AttributeError("{} has no attribute {}".format(self.__class__, k))
+            raise AttributeError("{} has no attribute {}".format(
+                self.__class__, k))
 
         java_name = _to_camel_case_name(k)
-        logging.warning("\"{}\" is not implemented so Java API \"{}\" was called directly instead".format(k, java_name))
+        logging.warning(
+            "\"{}\" is not implemented so Java API \"{}\" was called directly instead"
+            .format(k, java_name))
         return self.unwrap().__getattr__(java_name)
 
     def unwrap(self):

--- a/keanu-python/keanu/base.py
+++ b/keanu-python/keanu/base.py
@@ -16,17 +16,12 @@ class JavaObjectWrapper:
 
         if k != python_name:
             if python_name in self.__class__.__dict__:
-                raise AttributeError(
-                    "{} has no attribute {}. Did you mean {}?".format(
-                        self.__class__, k, python_name))
+                raise AttributeError("{} has no attribute {}. Did you mean {}?".format(self.__class__, k, python_name))
 
-            raise AttributeError("{} has no attribute {}".format(
-                self.__class__, k))
+            raise AttributeError("{} has no attribute {}".format(self.__class__, k))
 
         java_name = _to_camel_case_name(k)
-        logging.warning(
-            "\"{}\" is not implemented so Java API \"{}\" was called directly instead"
-            .format(k, java_name))
+        logging.warning("\"{}\" is not implemented so Java API \"{}\" was called directly instead".format(k, java_name))
         return self.unwrap().__getattr__(java_name)
 
     def unwrap(self):

--- a/keanu-python/keanu/case_conversion.py
+++ b/keanu-python/keanu/case_conversion.py
@@ -3,6 +3,7 @@ import re
 first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 all_cap_re = re.compile('([a-z0-9])([A-Z])')
 
+
 def _to_camel_case_name(name):
     """
     >>> _to_camel_case_name("snake_case_name")
@@ -12,6 +13,7 @@ def _to_camel_case_name(name):
     """
     first, *rest = name.split('_')
     return first + ''.join(word.capitalize() for word in rest)
+
 
 def _to_snake_case_name(name):
     """

--- a/keanu-python/keanu/context.py
+++ b/keanu-python/keanu/context.py
@@ -14,8 +14,7 @@ class Singleton(type):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(
-                *args, **kwargs)
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
 
 
@@ -25,14 +24,10 @@ class KeanuContext(metaclass=Singleton):
         stderr = self.__stderr_with_redirect_disabled_for_jupyter()
         classpath = self.__build_classpath()
 
-        logging.getLogger("keanu").debug(
-            "Initiating Py4J gateway with classpath %s" % classpath)
+        logging.getLogger("keanu").debug("Initiating Py4J gateway with classpath %s" % classpath)
 
         self._gateway = JavaGateway.launch_gateway(
-            classpath=classpath,
-            die_on_exit=True,
-            redirect_stdout=sys.stdout,
-            redirect_stderr=stderr)
+            classpath=classpath, die_on_exit=True, redirect_stdout=sys.stdout, redirect_stderr=stderr)
 
         self.__get_random_port_for_callback_server()
 
@@ -56,12 +51,10 @@ class KeanuContext(metaclass=Singleton):
     def __get_random_port_for_callback_server(self):
         # See: https://github.com/bartdag/py4j/issues/147
         self._gateway.start_callback_server(
-            CallbackServerParameters(
-                port=0, daemonize=True, daemonize_connections=True))
+            CallbackServerParameters(port=0, daemonize=True, daemonize_connections=True))
         jgws = JavaObject("GATEWAY_SERVER", self._gateway._gateway_client)
-        jgws.resetCallbackClient(
-            jgws.getCallbackClient().getAddress(),
-            self._gateway.get_callback_server().get_listening_port())
+        jgws.resetCallbackClient(jgws.getCallbackClient().getAddress(),
+                                 self._gateway.get_callback_server().get_listening_port())
 
     def jvm_view(self):
         return self.__jvm_view
@@ -99,5 +92,4 @@ class KeanuContext(metaclass=Singleton):
             return self._gateway.jvm.double
         else:
             raise NotImplementedError(
-                "Cannot infer class from array because it doesn't contain primitives. Was given {}"
-                .format(type(l[0])))
+                "Cannot infer class from array because it doesn't contain primitives. Was given {}".format(type(l[0])))

--- a/keanu-python/keanu/context.py
+++ b/keanu-python/keanu/context.py
@@ -7,29 +7,32 @@ from py4j.java_gateway import JavaGateway, JavaObject, CallbackServerParameters
 PATH = os.path.abspath(os.path.dirname(__file__))
 ND4J_CLASSPATH_ENVIRONMENT_VARIABLE = "KEANU_ND4J_CLASSPATH"
 
+
 # python singleton implementation https://stackoverflow.com/a/6798042/741789
 class Singleton(type):
     _instances = {}
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super(Singleton, cls).__call__(
+                *args, **kwargs)
         return cls._instances[cls]
 
 
 class KeanuContext(metaclass=Singleton):
+
     def __init__(self):
         stderr = self.__stderr_with_redirect_disabled_for_jupyter()
         classpath = self.__build_classpath()
 
-        logging.getLogger("keanu").debug("Initiating Py4J gateway with classpath %s" % classpath)
+        logging.getLogger("keanu").debug(
+            "Initiating Py4J gateway with classpath %s" % classpath)
 
         self._gateway = JavaGateway.launch_gateway(
             classpath=classpath,
             die_on_exit=True,
             redirect_stdout=sys.stdout,
-            redirect_stderr=stderr
-        )
+            redirect_stderr=stderr)
 
         self.__get_random_port_for_callback_server()
 
@@ -52,9 +55,13 @@ class KeanuContext(metaclass=Singleton):
 
     def __get_random_port_for_callback_server(self):
         # See: https://github.com/bartdag/py4j/issues/147
-        self._gateway.start_callback_server(CallbackServerParameters(port=0, daemonize=True, daemonize_connections=True))
+        self._gateway.start_callback_server(
+            CallbackServerParameters(
+                port=0, daemonize=True, daemonize_connections=True))
         jgws = JavaObject("GATEWAY_SERVER", self._gateway._gateway_client)
-        jgws.resetCallbackClient(jgws.getCallbackClient().getAddress(), self._gateway.get_callback_server().get_listening_port())
+        jgws.resetCallbackClient(
+            jgws.getCallbackClient().getAddress(),
+            self._gateway.get_callback_server().get_listening_port())
 
     def jvm_view(self):
         return self.__jvm_view
@@ -91,4 +98,6 @@ class KeanuContext(metaclass=Singleton):
         elif isinstance(l[0], float):
             return self._gateway.jvm.double
         else:
-            raise NotImplementedError("Cannot infer class from array because it doesn't contain primitives. Was given {}".format(type(l[0])))
+            raise NotImplementedError(
+                "Cannot infer class from array because it doesn't contain primitives. Was given {}"
+                .format(type(l[0])))

--- a/keanu-python/keanu/keanu_random.py
+++ b/keanu-python/keanu/keanu_random.py
@@ -8,6 +8,7 @@ java_import(k.jvm_view(), "io.improbable.keanu.vertices.dbl.KeanuRandom")
 
 
 class KeanuRandom(JavaObjectWrapper):
+
     def __init__(self, seed=None):
         if seed is None:
             super(KeanuRandom, self).__init__(k.jvm_view().KeanuRandom())
@@ -16,4 +17,4 @@ class KeanuRandom(JavaObjectWrapper):
 
     @staticmethod
     def set_default_random_seed(seed):
-    	k.jvm_view().KeanuRandom.setDefaultRandomSeed(seed)
+        k.jvm_view().KeanuRandom.setDefaultRandomSeed(seed)

--- a/keanu-python/keanu/model.py
+++ b/keanu-python/keanu/model.py
@@ -9,8 +9,7 @@ class Model:
         self.__dict__["_vertices"].update(vertices)
 
     def to_bayes_net(self):
-        return BayesNet((filter(lambda vertex: isinstance(vertex, Vertex),
-                                self._vertices.values())))
+        return BayesNet((filter(lambda vertex: isinstance(vertex, Vertex), self._vertices.values())))
 
     def __setattr__(self, k, v):
         if k in self.__dict__:

--- a/keanu-python/keanu/model.py
+++ b/keanu-python/keanu/model.py
@@ -1,13 +1,16 @@
 from .net import BayesNet
 from .vertex.base import Vertex
 
+
 class Model:
+
     def __init__(self, vertices={}):
         self.__dict__["_vertices"] = {}
         self.__dict__["_vertices"].update(vertices)
 
     def to_bayes_net(self):
-        return BayesNet((filter(lambda vertex: isinstance(vertex, Vertex), self._vertices.values())))
+        return BayesNet((filter(lambda vertex: isinstance(vertex, Vertex),
+                                self._vertices.values())))
 
     def __setattr__(self, k, v):
         if k in self.__dict__:

--- a/keanu-python/keanu/net.py
+++ b/keanu-python/keanu/net.py
@@ -7,11 +7,14 @@ k = KeanuContext()
 
 java_import(k.jvm_view(), "io.improbable.keanu.network.BayesianNetwork")
 
+
 class BayesNet(JavaObjectWrapper):
+
     def __init__(self, vertices):
         java_vertices = k.to_java_object_list(vertices)
 
-        super(BayesNet, self).__init__(k.jvm_view().BayesianNetwork(java_vertices))
+        super(BayesNet,
+              self).__init__(k.jvm_view().BayesianNetwork(java_vertices))
 
     def get_latent_or_observed_vertices(self):
         return Vertex._to_generator(self.unwrap().getLatentOrObservedVertices())

--- a/keanu-python/keanu/net.py
+++ b/keanu-python/keanu/net.py
@@ -13,8 +13,7 @@ class BayesNet(JavaObjectWrapper):
     def __init__(self, vertices):
         java_vertices = k.to_java_object_list(vertices)
 
-        super(BayesNet,
-              self).__init__(k.jvm_view().BayesianNetwork(java_vertices))
+        super(BayesNet, self).__init__(k.jvm_view().BayesianNetwork(java_vertices))
 
     def get_latent_or_observed_vertices(self):
         return Vertex._to_generator(self.unwrap().getLatentOrObservedVertices())

--- a/keanu-python/keanu/tensor.py
+++ b/keanu-python/keanu/tensor.py
@@ -18,14 +18,11 @@ class Tensor(JavaObjectWrapper):
         if isinstance(t, np.ndarray):
             super(Tensor, self).__init__(Tensor.__get_tensor_from_ndarray(t))
         elif isinstance(t, pandas_types):
-            super(Tensor, self).__init__(
-                Tensor.__get_tensor_from_ndarray(t.values))
+            super(Tensor, self).__init__(Tensor.__get_tensor_from_ndarray(t.values))
         elif isinstance(t, primitive_types):
             super(Tensor, self).__init__(Tensor.__get_tensor_from_scalar(t))
         else:
-            raise NotImplementedError(
-                "Generic types in an ndarray are not supported. Was given {}".
-                format(type(t)))
+            raise NotImplementedError("Generic types in an ndarray are not supported. Was given {}".format(type(t)))
 
     @staticmethod
     def __get_tensor_from_ndarray(ndarray):
@@ -56,9 +53,8 @@ class Tensor(JavaObjectWrapper):
         elif isinstance(ndarray.item(0), float_types):
             return k.jvm_view().DoubleTensor.create
         else:
-            raise NotImplementedError(
-                "Generic types in an ndarray are not supported. Was given {}".
-                format(type(ndarray.item(0))))
+            raise NotImplementedError("Generic types in an ndarray are not supported. Was given {}".format(
+                type(ndarray.item(0))))
 
     @staticmethod
     def __get_tensor_from_scalar(scalar):
@@ -69,9 +65,7 @@ class Tensor(JavaObjectWrapper):
         elif isinstance(scalar, float_types):
             return k.jvm_view().DoubleTensor.scalar(float(scalar))
         else:
-            raise NotImplementedError(
-                "Generic types in a ndarray are not supported. Was given {}".
-                format(type(scalar)))
+            raise NotImplementedError("Generic types in a ndarray are not supported. Was given {}".format(type(scalar)))
 
     @staticmethod
     def _to_ndarray(java_tensor):

--- a/keanu-python/keanu/tensor.py
+++ b/keanu-python/keanu/tensor.py
@@ -11,16 +11,21 @@ java_import(k.jvm_view(), "io.improbable.keanu.tensor.dbl.DoubleTensor")
 java_import(k.jvm_view(), "io.improbable.keanu.tensor.bool.BooleanTensor")
 java_import(k.jvm_view(), "io.improbable.keanu.tensor.intgr.IntegerTensor")
 
+
 class Tensor(JavaObjectWrapper):
+
     def __init__(self, t):
         if isinstance(t, np.ndarray):
             super(Tensor, self).__init__(Tensor.__get_tensor_from_ndarray(t))
         elif isinstance(t, pandas_types):
-            super(Tensor, self).__init__(Tensor.__get_tensor_from_ndarray(t.values))
+            super(Tensor, self).__init__(
+                Tensor.__get_tensor_from_ndarray(t.values))
         elif isinstance(t, primitive_types):
             super(Tensor, self).__init__(Tensor.__get_tensor_from_scalar(t))
         else:
-            raise NotImplementedError("Generic types in an ndarray are not supported. Was given {}".format(type(t)))
+            raise NotImplementedError(
+                "Generic types in an ndarray are not supported. Was given {}".
+                format(type(t)))
 
     @staticmethod
     def __get_tensor_from_ndarray(ndarray):
@@ -51,7 +56,9 @@ class Tensor(JavaObjectWrapper):
         elif isinstance(ndarray.item(0), float_types):
             return k.jvm_view().DoubleTensor.create
         else:
-            raise NotImplementedError("Generic types in an ndarray are not supported. Was given {}".format(type(ndarray.item(0))))
+            raise NotImplementedError(
+                "Generic types in an ndarray are not supported. Was given {}".
+                format(type(ndarray.item(0))))
 
     @staticmethod
     def __get_tensor_from_scalar(scalar):
@@ -62,7 +69,9 @@ class Tensor(JavaObjectWrapper):
         elif isinstance(scalar, float_types):
             return k.jvm_view().DoubleTensor.scalar(float(scalar))
         else:
-            raise NotImplementedError("Generic types in a ndarray are not supported. Was given {}".format(type(scalar)))
+            raise NotImplementedError(
+                "Generic types in a ndarray are not supported. Was given {}".
+                format(type(scalar)))
 
     @staticmethod
     def _to_ndarray(java_tensor):

--- a/keanu-python/keanu/vartypes.py
+++ b/keanu-python/keanu/vartypes.py
@@ -11,6 +11,6 @@ primitive_types = int_types + float_types + bool_types
 
 pandas_types = (pd.Series, pd.DataFrame)
 
-numpy_types = (np.ndarray, )
+numpy_types = (np.ndarray,)
 
 const_arg_types = numpy_types + pandas_types + primitive_types

--- a/keanu-python/keanu/vertex/__init__.py
+++ b/keanu-python/keanu/vertex/__init__.py
@@ -1,7 +1,12 @@
 ## This is a generated file. DO NOT EDIT.
 
 # This allows us to make these vertices visible externally so they can be picked up for our python docs
-__all__ = ["ConstantBool", "Equals", "GreaterThanOrEqual", "GreaterThan", "LessThanOrEqual", "LessThan", "NotEquals", "CastDouble", "ConstantDouble", "DoubleIf", "Addition", "Difference", "Division", "Multiplication", "Power", "Abs", "Ceil", "Floor", "Round", "Cauchy", "Exponential", "Gamma", "Gaussian", "Uniform", "ConstantInteger", "IntegerDivision", "Poisson", "UniformInt"]
+__all__ = [
+    "ConstantBool", "Equals", "GreaterThanOrEqual", "GreaterThan", "LessThanOrEqual", "LessThan", "NotEquals",
+    "CastDouble", "ConstantDouble", "DoubleIf", "Addition", "Difference", "Division", "Multiplication", "Power", "Abs",
+    "Ceil", "Floor", "Round", "Cauchy", "Exponential", "Gamma", "Gaussian", "Uniform", "ConstantInteger",
+    "IntegerDivision", "Poisson", "UniformInt"
+]
 
 from .generated import *
 from .const import Const

--- a/keanu-python/keanu/vertex/base.py
+++ b/keanu-python/keanu/vertex/base.py
@@ -17,29 +17,32 @@ class VertexOps:
     Without this the right operators would fail.
     See https://docs.scipy.org/doc/numpy-1.13.0/neps/ufunc-overrides.html
     """
+
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         methods = {
-            "equal" : VertexOps.__eq__,
-            "not_equal" : VertexOps.__ne__,
-            "add" : VertexOps.__radd__,
-            "subtract" : VertexOps.__rsub__,
-            "multiply" : VertexOps.__rmul__,
-            "power" : VertexOps.__rpow__,
-            "true_divide" : VertexOps.__rtruediv__,
-            "floor_divide" : VertexOps.__rfloordiv__,
-            "greater" : VertexOps.__lt__,
-            "greater_equal" : VertexOps.__le__,
-            "less" : VertexOps.__gt__,
-            "less_equal" : VertexOps.__ge__,
+            "equal": VertexOps.__eq__,
+            "not_equal": VertexOps.__ne__,
+            "add": VertexOps.__radd__,
+            "subtract": VertexOps.__rsub__,
+            "multiply": VertexOps.__rmul__,
+            "power": VertexOps.__rpow__,
+            "true_divide": VertexOps.__rtruediv__,
+            "floor_divide": VertexOps.__rfloordiv__,
+            "greater": VertexOps.__lt__,
+            "greater_equal": VertexOps.__le__,
+            "less": VertexOps.__gt__,
+            "less_equal": VertexOps.__ge__,
         }
         if method == "__call__":
             try:
                 dispatch_method = methods[ufunc.__name__]
                 return dispatch_method(inputs[1], inputs[0])
             except KeyError:
-                raise NotImplementedError("NumPy ufunc of type %s not implemented" % ufunc.__name__)
+                raise NotImplementedError(
+                    "NumPy ufunc of type %s not implemented" % ufunc.__name__)
         else:
-            raise NotImplementedError("NumPy ufunc method %s not implemented" % method)
+            raise NotImplementedError(
+                "NumPy ufunc method %s not implemented" % method)
 
     def __add__(self, other):
         return kn.vertex.generated.Addition(self, other)
@@ -115,6 +118,7 @@ class VertexOps:
 
 
 class Vertex(JavaObjectWrapper, VertexOps):
+
     def __init__(self, val, *args):
         if args:
             ctor = val
@@ -156,10 +160,12 @@ class Vertex(JavaObjectWrapper, VertexOps):
             return kn.vertex.const.Const(arg).unwrap()
         elif isinstance(arg, JavaObjectWrapper):
             return arg.unwrap()
-        elif isinstance(arg, collections.Iterable) and all(isinstance(x, primitive_types) for x in arg):
+        elif isinstance(arg, collections.Iterable) and all(
+                isinstance(x, primitive_types) for x in arg):
             return k.to_java_long_array(arg)
         else:
-            raise ValueError("Can't parse generic argument. Was given {}".format(type(arg)))
+            raise ValueError(
+                "Can't parse generic argument. Was given {}".format(type(arg)))
 
     @staticmethod
     def _to_generator(java_vertices):

--- a/keanu-python/keanu/vertex/base.py
+++ b/keanu-python/keanu/vertex/base.py
@@ -38,11 +38,9 @@ class VertexOps:
                 dispatch_method = methods[ufunc.__name__]
                 return dispatch_method(inputs[1], inputs[0])
             except KeyError:
-                raise NotImplementedError(
-                    "NumPy ufunc of type %s not implemented" % ufunc.__name__)
+                raise NotImplementedError("NumPy ufunc of type %s not implemented" % ufunc.__name__)
         else:
-            raise NotImplementedError(
-                "NumPy ufunc method %s not implemented" % method)
+            raise NotImplementedError("NumPy ufunc method %s not implemented" % method)
 
     def __add__(self, other):
         return kn.vertex.generated.Addition(self, other)
@@ -160,12 +158,10 @@ class Vertex(JavaObjectWrapper, VertexOps):
             return kn.vertex.const.Const(arg).unwrap()
         elif isinstance(arg, JavaObjectWrapper):
             return arg.unwrap()
-        elif isinstance(arg, collections.Iterable) and all(
-                isinstance(x, primitive_types) for x in arg):
+        elif isinstance(arg, collections.Iterable) and all(isinstance(x, primitive_types) for x in arg):
             return k.to_java_long_array(arg)
         else:
-            raise ValueError(
-                "Can't parse generic argument. Was given {}".format(type(arg)))
+            raise ValueError("Can't parse generic argument. Was given {}".format(type(arg)))
 
     @staticmethod
     def _to_generator(java_vertices):

--- a/keanu-python/keanu/vertex/const.py
+++ b/keanu-python/keanu/vertex/const.py
@@ -5,6 +5,7 @@ from .base import Vertex
 import numpy as np
 from keanu.vartypes import int_types, float_types, bool_types, primitive_types, pandas_types
 
+
 def Const(t) -> Vertex:
     if isinstance(t, np.ndarray):
         ctor = __infer_const_ctor_from_ndarray(t)
@@ -16,15 +17,19 @@ def Const(t) -> Vertex:
         ctor = __infer_const_ctor_from_scalar(t)
         val = np.array([[t]])
     else:
-        raise NotImplementedError("Argument t must be either an ndarray or an instance of numbers.Number. Was given {} instead".format(type(t)))
+        raise NotImplementedError(
+            "Argument t must be either an ndarray or an instance of numbers.Number. Was given {} instead"
+            .format(type(t)))
 
     return ctor(Tensor(val))
+
 
 def __infer_const_ctor_from_ndarray(ndarray):
     if len(ndarray) == 0:
         raise ValueError("Cannot infer type because the ndarray is empty")
 
     return __infer_const_ctor_from_scalar(ndarray.item(0))
+
 
 def __infer_const_ctor_from_scalar(scalar):
     if isinstance(scalar, bool_types):
@@ -34,4 +39,6 @@ def __infer_const_ctor_from_scalar(scalar):
     elif isinstance(scalar, float_types):
         return ConstantDouble
     else:
-        raise NotImplementedError("Generic types in an ndarray are not supported. Was given {}".format(type(scalar)))
+        raise NotImplementedError(
+            "Generic types in an ndarray are not supported. Was given {}".
+            format(type(scalar)))

--- a/keanu-python/keanu/vertex/const.py
+++ b/keanu-python/keanu/vertex/const.py
@@ -18,8 +18,8 @@ def Const(t) -> Vertex:
         val = np.array([[t]])
     else:
         raise NotImplementedError(
-            "Argument t must be either an ndarray or an instance of numbers.Number. Was given {} instead"
-            .format(type(t)))
+            "Argument t must be either an ndarray or an instance of numbers.Number. Was given {} instead".format(
+                type(t)))
 
     return ctor(Tensor(val))
 
@@ -39,6 +39,4 @@ def __infer_const_ctor_from_scalar(scalar):
     elif isinstance(scalar, float_types):
         return ConstantDouble
     else:
-        raise NotImplementedError(
-            "Generic types in an ndarray are not supported. Was given {}".
-            format(type(scalar)))
+        raise NotImplementedError("Generic types in an ndarray are not supported. Was given {}".format(type(scalar)))

--- a/keanu-python/keanu/vertex/generated.py
+++ b/keanu-python/keanu/vertex/generated.py
@@ -6,21 +6,27 @@ from .base import Vertex
 
 context = KeanuContext()
 
-
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.bool.nonprobabilistic.ConstantBoolVertex")
-java_import(context.jvm_view(), "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.EqualsVertex")
-java_import(context.jvm_view(), "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.GreaterThanOrEqualVertex")
-java_import(context.jvm_view(), "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.GreaterThanVertex")
-java_import(context.jvm_view(), "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.LessThanOrEqualVertex")
-java_import(context.jvm_view(), "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.LessThanVertex")
-java_import(context.jvm_view(), "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.NotEqualsVertex")
+java_import(context.jvm_view(),
+            "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.EqualsVertex")
+java_import(context.jvm_view(),
+            "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.GreaterThanOrEqualVertex")
+java_import(context.jvm_view(),
+            "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.GreaterThanVertex")
+java_import(context.jvm_view(),
+            "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.LessThanOrEqualVertex")
+java_import(context.jvm_view(),
+            "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.LessThanVertex")
+java_import(context.jvm_view(),
+            "io.improbable.keanu.vertices.bool.nonprobabilistic.operators.binary.compare.NotEqualsVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.CastDoubleVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.DoubleIfVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.AdditionVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DifferenceVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.DivisionVertex")
-java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex")
+java_import(context.jvm_view(),
+            "io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.PowerVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.AbsVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.CeilVertex")
@@ -32,7 +38,8 @@ java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.probabilistic.
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.intgr.nonprobabilistic.ConstantIntegerVertex")
-java_import(context.jvm_view(), "io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerDivisionVertex")
+java_import(context.jvm_view(),
+            "io.improbable.keanu.vertices.intgr.nonprobabilistic.operators.binary.IntegerDivisionVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.intgr.probabilistic.PoissonVertex")
 java_import(context.jvm_view(), "io.improbable.keanu.vertices.intgr.probabilistic.UniformIntVertex")
 

--- a/keanu-python/setup.py
+++ b/keanu-python/setup.py
@@ -10,8 +10,7 @@ def readme():
 version_string = '0.0.15.dev1'
 
 # If you don't remove the old directories, it tends to put the excluded module "examples" into the bdist
-for dir_name in ("keanu-%s.dist-info" % version_string, "keanu.egg-info",
-                 "build", "dist"):
+for dir_name in ("keanu-%s.dist-info" % version_string, "keanu.egg-info", "build", "dist"):
     shutil.rmtree(dir_name, ignore_errors=True)
 
 setup(
@@ -27,8 +26,7 @@ setup(
     include_package_data=True,
     install_requires=['py4j', 'numpy', 'pandas'],
     classifiers=[
-        'Development Status :: 1 - Planning',
-        'License :: OSI Approved :: MIT License',
+        'Development Status :: 1 - Planning', 'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6'
     ],
     zip_safe=False)

--- a/keanu-python/setup.py
+++ b/keanu-python/setup.py
@@ -1,34 +1,34 @@
 from setuptools import setup, find_packages
 import shutil
 
+
 def readme():
     with open('README.rst', "r") as f:
         return f.read()
 
+
 version_string = '0.0.15.dev1'
 
 # If you don't remove the old directories, it tends to put the excluded module "examples" into the bdist
-for dir_name in ("keanu-%s.dist-info" % version_string, "keanu.egg-info", "build", "dist"):
+for dir_name in ("keanu-%s.dist-info" % version_string, "keanu.egg-info",
+                 "build", "dist"):
     shutil.rmtree(dir_name, ignore_errors=True)
 
-setup(name='keanu',
-      description='A probabilistic approach from an Improbabilistic company',
-      long_description=readme(),
-      version=version_string,
-      author='Improbable Worlds',
-      author_email='keanu-engineering@improbable.io',
-      url='https://improbable-research.github.io/keanu/python',
-      license='MIT',
-      packages=find_packages(exclude=["examples"]),
-      include_package_data=True,
-      install_requires=[
-          'py4j',
-          'numpy',
-          'pandas'
-      ],
-      classifiers=[
-          'Development Status :: 1 - Planning',
-          'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 3.6'
-      ],
-      zip_safe=False)
+setup(
+    name='keanu',
+    description='A probabilistic approach from an Improbabilistic company',
+    long_description=readme(),
+    version=version_string,
+    author='Improbable Worlds',
+    author_email='keanu-engineering@improbable.io',
+    url='https://improbable-research.github.io/keanu/python',
+    license='MIT',
+    packages=find_packages(exclude=["examples"]),
+    include_package_data=True,
+    install_requires=['py4j', 'numpy', 'pandas'],
+    classifiers=[
+        'Development Status :: 1 - Planning',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.6'
+    ],
+    zip_safe=False)

--- a/keanu-python/tests/test_base.py
+++ b/keanu-python/tests/test_base.py
@@ -21,33 +21,25 @@ def java_list_wrapper():
     return JavaListWrapper([1, 2, 3])
 
 
-def test_java_object_wrapper_cant_call_java_api_with_no_python_impl_if_camel_case(
-        java_list_wrapper):
+def test_java_object_wrapper_cant_call_java_api_with_no_python_impl_if_camel_case(java_list_wrapper):
     with pytest.raises(AttributeError) as excinfo:
         java_list_wrapper.isEmpty()
 
-    assert str(excinfo.value) == "{} has no attribute isEmpty".format(
-        type(java_list_wrapper))
+    assert str(excinfo.value) == "{} has no attribute isEmpty".format(type(java_list_wrapper))
 
 
-def test_java_object_wrapper_cant_call_java_api_with_python_impl_if_camel_case(
-        java_list_wrapper):
+def test_java_object_wrapper_cant_call_java_api_with_python_impl_if_camel_case(java_list_wrapper):
     with pytest.raises(AttributeError) as excinfo:
         java_list_wrapper.indexOf(1)
 
-    assert str(
-        excinfo.
-        value) == "{} has no attribute indexOf. Did you mean index_of?".format(
-            type(java_list_wrapper))
+    assert str(excinfo.value) == "{} has no attribute indexOf. Did you mean index_of?".format(type(java_list_wrapper))
 
 
-def test_java_object_wrapper_can_call_java_api_with_no_python_impl_if_snake_case(
-        java_list_wrapper):
+def test_java_object_wrapper_can_call_java_api_with_no_python_impl_if_snake_case(java_list_wrapper):
     assert not java_list_wrapper.is_empty()
 
 
-def test_java_object_wrapper_can_call_java_api_with_no_python_impl_if_both_camel_case_and_snake_case(
-        java_list_wrapper):
+def test_java_object_wrapper_can_call_java_api_with_no_python_impl_if_both_camel_case_and_snake_case(java_list_wrapper):
     assert java_list_wrapper.get(0) == 1
 
 

--- a/keanu-python/tests/test_base.py
+++ b/keanu-python/tests/test_base.py
@@ -2,9 +2,12 @@ from keanu.base import JavaObjectWrapper
 from keanu.context import KeanuContext
 import pytest
 
+
 @pytest.fixture
 def java_list_wrapper():
+
     class JavaListWrapper(JavaObjectWrapper):
+
         def __init__(self, numbers):
             lst = KeanuContext()._gateway.jvm.java.util.ArrayList()
             for number in numbers:
@@ -17,23 +20,36 @@ def java_list_wrapper():
 
     return JavaListWrapper([1, 2, 3])
 
-def test_java_object_wrapper_cant_call_java_api_with_no_python_impl_if_camel_case(java_list_wrapper):
+
+def test_java_object_wrapper_cant_call_java_api_with_no_python_impl_if_camel_case(
+        java_list_wrapper):
     with pytest.raises(AttributeError) as excinfo:
         java_list_wrapper.isEmpty()
 
-    assert str(excinfo.value) == "{} has no attribute isEmpty".format(type(java_list_wrapper))
+    assert str(excinfo.value) == "{} has no attribute isEmpty".format(
+        type(java_list_wrapper))
 
-def test_java_object_wrapper_cant_call_java_api_with_python_impl_if_camel_case(java_list_wrapper):
+
+def test_java_object_wrapper_cant_call_java_api_with_python_impl_if_camel_case(
+        java_list_wrapper):
     with pytest.raises(AttributeError) as excinfo:
         java_list_wrapper.indexOf(1)
 
-    assert str(excinfo.value) == "{} has no attribute indexOf. Did you mean index_of?".format(type(java_list_wrapper))
+    assert str(
+        excinfo.
+        value) == "{} has no attribute indexOf. Did you mean index_of?".format(
+            type(java_list_wrapper))
 
-def test_java_object_wrapper_can_call_java_api_with_no_python_impl_if_snake_case(java_list_wrapper):
+
+def test_java_object_wrapper_can_call_java_api_with_no_python_impl_if_snake_case(
+        java_list_wrapper):
     assert not java_list_wrapper.is_empty()
 
-def test_java_object_wrapper_can_call_java_api_with_no_python_impl_if_both_camel_case_and_snake_case(java_list_wrapper):
+
+def test_java_object_wrapper_can_call_java_api_with_no_python_impl_if_both_camel_case_and_snake_case(
+        java_list_wrapper):
     assert java_list_wrapper.get(0) == 1
+
 
 def test_java_object_wrapper_can_call_python_api(java_list_wrapper):
     assert java_list_wrapper.index_of(1) == 100

--- a/keanu-python/tests/test_coal_mining.py
+++ b/keanu-python/tests/test_coal_mining.py
@@ -3,6 +3,7 @@ from examples import CoalMining
 from keanu import BayesNet
 from keanu.algorithm import sample
 
+
 def test_coalmining():
     coal_mining = CoalMining()
     model = coal_mining.model()
@@ -10,7 +11,12 @@ def test_coalmining():
     model.disasters.observe(coal_mining.training_data())
 
     net = BayesNet(model.switchpoint.get_connected_graph())
-    samples = sample(net=net, sample_from=net.get_latent_vertices(), draws=50000, drop=10000, down_sample_interval=5)
+    samples = sample(
+        net=net,
+        sample_from=net.get_latent_vertices(),
+        draws=50000,
+        drop=10000,
+        down_sample_interval=5)
 
     vertex_samples = samples[model.switchpoint.get_id()]
     scalar_values = np.concatenate(vertex_samples, axis=0).flatten()

--- a/keanu-python/tests/test_coal_mining.py
+++ b/keanu-python/tests/test_coal_mining.py
@@ -11,12 +11,7 @@ def test_coalmining():
     model.disasters.observe(coal_mining.training_data())
 
     net = BayesNet(model.switchpoint.get_connected_graph())
-    samples = sample(
-        net=net,
-        sample_from=net.get_latent_vertices(),
-        draws=50000,
-        drop=10000,
-        down_sample_interval=5)
+    samples = sample(net=net, sample_from=net.get_latent_vertices(), draws=50000, drop=10000, down_sample_interval=5)
 
     vertex_samples = samples[model.switchpoint.get_id()]
     scalar_values = np.concatenate(vertex_samples, axis=0).flatten()

--- a/keanu-python/tests/test_const.py
+++ b/keanu-python/tests/test_const.py
@@ -8,11 +8,12 @@ from keanu.vertex import Const
 def generic():
     pass
 
-@pytest.mark.parametrize("arr, expected_java_class", [
-    ([[1, 2], [3, 4]], "ConstantIntegerVertex"),
-    ([[1., 2.], [3., 4.]], "ConstantDoubleVertex"),
-    ([[True, False], [False, True]], "ConstantBoolVertex")
-])
+
+@pytest.mark.parametrize(
+    "arr, expected_java_class",
+    [([[1, 2], [3, 4]], "ConstantIntegerVertex"),
+     ([[1., 2.], [3., 4.]], "ConstantDoubleVertex"),
+     ([[True, False], [False, True]], "ConstantBoolVertex")])
 def test_const_takes_ndarray(arr, expected_java_class):
     ndarray = np.array(arr)
     v = Const(ndarray)
@@ -21,11 +22,10 @@ def test_const_takes_ndarray(arr, expected_java_class):
     assert np.array_equal(v.get_value(), ndarray)
 
 
-@pytest.mark.parametrize("data, expected_java_class", [
-    ([1, 2], "ConstantIntegerVertex"),
-    ([1., 2.], "ConstantDoubleVertex"),
-    ([True, False], "ConstantBoolVertex")
-])
+@pytest.mark.parametrize("data, expected_java_class",
+                         [([1, 2], "ConstantIntegerVertex"),
+                          ([1., 2.], "ConstantDoubleVertex"),
+                          ([True, False], "ConstantBoolVertex")])
 def test_const_takes_panda_series(data, expected_java_class):
     series = pd.Series(data)
     v = Const(series)
@@ -37,16 +37,16 @@ def test_const_takes_panda_series(data, expected_java_class):
 
     assert len(vertex_value) == len(series_value)
     assert vertex_value.shape == (2, 1)
-    assert series_value.shape == (2,  )
+    assert series_value.shape == (2,)
 
     assert np.array_equal(vertex_value.flatten(), series_value.flatten())
 
 
-@pytest.mark.parametrize("data, expected_java_class", [
-    ([[1, 2], [3, 4]], "ConstantIntegerVertex"),
-    ([[1., 2.], [3., 4.]], "ConstantDoubleVertex"),
-    ([[True, False], [True, False]], "ConstantBoolVertex")
-])
+@pytest.mark.parametrize(
+    "data, expected_java_class",
+    [([[1, 2], [3, 4]], "ConstantIntegerVertex"),
+     ([[1., 2.], [3., 4.]], "ConstantDoubleVertex"),
+     ([[True, False], [True, False]], "ConstantBoolVertex")])
 def test_const_takes_panda_dataframe(data, expected_java_class):
     dataframe = pd.DataFrame(columns=['A', 'B'], data=data)
     v = Const(dataframe)
@@ -59,14 +59,13 @@ def test_const_takes_panda_dataframe(data, expected_java_class):
     assert np.array_equal(vertex_value, dataframe_value)
 
 
-@pytest.mark.parametrize("num, expected_java_class", [
-    (3, "ConstantIntegerVertex"),
-    (np.array([3])[0], "ConstantIntegerVertex"),
-    (3.4, "ConstantDoubleVertex"),
-    (np.array([3.4])[0], "ConstantDoubleVertex"),
-    (True, "ConstantBoolVertex"),
-    (np.array([True])[0], "ConstantBoolVertex")
-])
+@pytest.mark.parametrize("num, expected_java_class",
+                         [(3, "ConstantIntegerVertex"),
+                          (np.array([3])[0], "ConstantIntegerVertex"),
+                          (3.4, "ConstantDoubleVertex"),
+                          (np.array([3.4])[0], "ConstantDoubleVertex"),
+                          (True, "ConstantBoolVertex"),
+                          (np.array([True])[0], "ConstantBoolVertex")])
 def test_const_takes_num(num, expected_java_class):
     v = Const(num)
 
@@ -79,14 +78,20 @@ def test_const_does_not_take_generic_ndarray(generic):
     with pytest.raises(NotImplementedError) as excinfo:
         Const(ndarray)
 
-    assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given {}".format(type(generic))
+    assert str(
+        excinfo.value
+    ) == "Generic types in an ndarray are not supported. Was given {}".format(
+        type(generic))
 
 
 def test_const_does_not_take_generic(generic):
     with pytest.raises(NotImplementedError) as excinfo:
         Const(generic)
 
-    assert str(excinfo.value) == "Argument t must be either an ndarray or an instance of numbers.Number. Was given {} instead".format(type(generic))
+    assert str(
+        excinfo.value
+    ) == "Argument t must be either an ndarray or an instance of numbers.Number. Was given {} instead".format(
+        type(generic))
 
 
 def test_const_does_not_take_empty_ndarray():
@@ -94,18 +99,20 @@ def test_const_does_not_take_empty_ndarray():
     with pytest.raises(ValueError) as excinfo:
         Const(ndarray)
 
-    assert str(excinfo.value) == "Cannot infer type because the ndarray is empty"
+    assert str(
+        excinfo.value) == "Cannot infer type because the ndarray is empty"
 
 
 def test_const_takes_ndarray_of_rank_one():
-    ndarray = np.array([1 ,2])
+    ndarray = np.array([1, 2])
     v = Const(ndarray)
 
-    assert ndarray.shape == (2, )
+    assert ndarray.shape == (2,)
     assert v.get_value().shape == (2, 1)
 
     assert np.array_equal(v.get_value().flatten(), ndarray.flatten())
 
 
 def assert_java_class(java_object_wrapper, java_class_str):
-    assert java_object_wrapper.unwrap().getClass().getSimpleName() == java_class_str
+    assert java_object_wrapper.unwrap().getClass().getSimpleName(
+    ) == java_class_str

--- a/keanu-python/tests/test_const.py
+++ b/keanu-python/tests/test_const.py
@@ -9,11 +9,9 @@ def generic():
     pass
 
 
-@pytest.mark.parametrize(
-    "arr, expected_java_class",
-    [([[1, 2], [3, 4]], "ConstantIntegerVertex"),
-     ([[1., 2.], [3., 4.]], "ConstantDoubleVertex"),
-     ([[True, False], [False, True]], "ConstantBoolVertex")])
+@pytest.mark.parametrize("arr, expected_java_class", [([[1, 2], [3, 4]], "ConstantIntegerVertex"),
+                                                      ([[1., 2.], [3., 4.]], "ConstantDoubleVertex"),
+                                                      ([[True, False], [False, True]], "ConstantBoolVertex")])
 def test_const_takes_ndarray(arr, expected_java_class):
     ndarray = np.array(arr)
     v = Const(ndarray)
@@ -22,10 +20,9 @@ def test_const_takes_ndarray(arr, expected_java_class):
     assert np.array_equal(v.get_value(), ndarray)
 
 
-@pytest.mark.parametrize("data, expected_java_class",
-                         [([1, 2], "ConstantIntegerVertex"),
-                          ([1., 2.], "ConstantDoubleVertex"),
-                          ([True, False], "ConstantBoolVertex")])
+@pytest.mark.parametrize("data, expected_java_class", [([1, 2], "ConstantIntegerVertex"),
+                                                       ([1., 2.], "ConstantDoubleVertex"),
+                                                       ([True, False], "ConstantBoolVertex")])
 def test_const_takes_panda_series(data, expected_java_class):
     series = pd.Series(data)
     v = Const(series)
@@ -42,11 +39,9 @@ def test_const_takes_panda_series(data, expected_java_class):
     assert np.array_equal(vertex_value.flatten(), series_value.flatten())
 
 
-@pytest.mark.parametrize(
-    "data, expected_java_class",
-    [([[1, 2], [3, 4]], "ConstantIntegerVertex"),
-     ([[1., 2.], [3., 4.]], "ConstantDoubleVertex"),
-     ([[True, False], [True, False]], "ConstantBoolVertex")])
+@pytest.mark.parametrize("data, expected_java_class", [([[1, 2], [3, 4]], "ConstantIntegerVertex"),
+                                                       ([[1., 2.], [3., 4.]], "ConstantDoubleVertex"),
+                                                       ([[True, False], [True, False]], "ConstantBoolVertex")])
 def test_const_takes_panda_dataframe(data, expected_java_class):
     dataframe = pd.DataFrame(columns=['A', 'B'], data=data)
     v = Const(dataframe)
@@ -59,13 +54,12 @@ def test_const_takes_panda_dataframe(data, expected_java_class):
     assert np.array_equal(vertex_value, dataframe_value)
 
 
-@pytest.mark.parametrize("num, expected_java_class",
-                         [(3, "ConstantIntegerVertex"),
-                          (np.array([3])[0], "ConstantIntegerVertex"),
-                          (3.4, "ConstantDoubleVertex"),
-                          (np.array([3.4])[0], "ConstantDoubleVertex"),
-                          (True, "ConstantBoolVertex"),
-                          (np.array([True])[0], "ConstantBoolVertex")])
+@pytest.mark.parametrize("num, expected_java_class", [(3, "ConstantIntegerVertex"),
+                                                      (np.array([3])[0], "ConstantIntegerVertex"),
+                                                      (3.4, "ConstantDoubleVertex"),
+                                                      (np.array([3.4])[0], "ConstantDoubleVertex"),
+                                                      (True, "ConstantBoolVertex"),
+                                                      (np.array([True])[0], "ConstantBoolVertex")])
 def test_const_takes_num(num, expected_java_class):
     v = Const(num)
 
@@ -78,10 +72,7 @@ def test_const_does_not_take_generic_ndarray(generic):
     with pytest.raises(NotImplementedError) as excinfo:
         Const(ndarray)
 
-    assert str(
-        excinfo.value
-    ) == "Generic types in an ndarray are not supported. Was given {}".format(
-        type(generic))
+    assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given {}".format(type(generic))
 
 
 def test_const_does_not_take_generic(generic):
@@ -89,9 +80,9 @@ def test_const_does_not_take_generic(generic):
         Const(generic)
 
     assert str(
-        excinfo.value
-    ) == "Argument t must be either an ndarray or an instance of numbers.Number. Was given {} instead".format(
-        type(generic))
+        excinfo.
+        value) == "Argument t must be either an ndarray or an instance of numbers.Number. Was given {} instead".format(
+            type(generic))
 
 
 def test_const_does_not_take_empty_ndarray():
@@ -99,8 +90,7 @@ def test_const_does_not_take_empty_ndarray():
     with pytest.raises(ValueError) as excinfo:
         Const(ndarray)
 
-    assert str(
-        excinfo.value) == "Cannot infer type because the ndarray is empty"
+    assert str(excinfo.value) == "Cannot infer type because the ndarray is empty"
 
 
 def test_const_takes_ndarray_of_rank_one():
@@ -114,5 +104,4 @@ def test_const_takes_ndarray_of_rank_one():
 
 
 def assert_java_class(java_object_wrapper, java_class_str):
-    assert java_object_wrapper.unwrap().getClass().getSimpleName(
-    ) == java_class_str
+    assert java_object_wrapper.unwrap().getClass().getSimpleName() == java_class_str

--- a/keanu-python/tests/test_context.py
+++ b/keanu-python/tests/test_context.py
@@ -1,15 +1,18 @@
 from keanu.context import KeanuContext
 import py4j
 
+
 def test_the_context_is_a_singleton():
     context1 = KeanuContext()
     context2 = KeanuContext()
     assert context1 == context2
 
+
 def test_there_is_only_one_jvm_view():
     view1 = KeanuContext().jvm_view()
     view2 = KeanuContext().jvm_view()
     assert view1 == view2
+
 
 def test_you_can_convert_a_numpy_array_to_a_java_array():
     python_list = [1., 2., 3.]

--- a/keanu-python/tests/test_gradient_optimization.py
+++ b/keanu-python/tests/test_gradient_optimization.py
@@ -4,6 +4,7 @@ from py4j.protocol import Py4JJavaError
 from keanu import KeanuRandom, BayesNet
 from keanu.algorithm import GradientOptimizer
 
+
 @pytest.fixture
 def model():
     KeanuRandom.set_default_random_seed(1)
@@ -44,7 +45,7 @@ def test_thermometers_map_gradient(model):
     assert logProb < 0.
 
     temperature = model.temperature.get_value()
-    assert 20.995 < temperature <  21.005
+    assert 20.995 < temperature < 21.005
 
 
 def test_thermometers_max_likelihood_gradient(model):
@@ -54,4 +55,4 @@ def test_thermometers_max_likelihood_gradient(model):
     assert logProb < 0.
 
     temperature = model.temperature.get_value()
-    assert 20.995 < temperature <  21.005
+    assert 20.995 < temperature < 21.005

--- a/keanu-python/tests/test_keanu_random.py
+++ b/keanu-python/tests/test_keanu_random.py
@@ -1,11 +1,13 @@
 from keanu import KeanuRandom
 
+
 def test_default_keanu_random():
     keanu_random = KeanuRandom()
     random = keanu_random.next_double()
 
     assert type(random) == float
     assert 0 <= random < 1
+
 
 def test_seeded_keanu_random():
     keanu_random = KeanuRandom(1)

--- a/keanu-python/tests/test_lorenz.py
+++ b/keanu-python/tests/test_lorenz.py
@@ -38,8 +38,7 @@ def test_lorenz():
         post_t = (window + 1) * (window_size - 1)
         actual_at_post_t = observed[post_t]
 
-        error = math.sqrt((actual_at_post_t.x - posterior[0])**2 +
-                          (actual_at_post_t.y - posterior[1])**2 +
+        error = math.sqrt((actual_at_post_t.x - posterior[0])**2 + (actual_at_post_t.y - posterior[1])**2 +
                           (actual_at_post_t.z - posterior[2])**2)
         prior_mu = (posterior[0], posterior[1], posterior[2])
         window += 1
@@ -51,10 +50,8 @@ def add_time(current):
     rho_v = Const(rho)
     (xt, yt, zt) = current
 
-    x_tplus1 = xt * Const(1. - time_step * sigma) + (
-        yt * Const(time_step * sigma))
-    y_tplus1 = yt * Const(1. - time_step) + (xt *
-                                             (rho_v - zt) * Const(time_step))
+    x_tplus1 = xt * Const(1. - time_step * sigma) + (yt * Const(time_step * sigma))
+    y_tplus1 = yt * Const(1. - time_step) + (xt * (rho_v - zt) * Const(time_step))
     z_tplus1 = zt * Const(1. - time_step * beta) + (xt * yt * Const(time_step))
     return (x_tplus1, y_tplus1, z_tplus1)
 

--- a/keanu-python/tests/test_lorenz.py
+++ b/keanu-python/tests/test_lorenz.py
@@ -3,7 +3,6 @@ from keanu.vertex import Const, Gaussian
 from keanu.algorithm import GradientOptimizer
 from examples import LorenzModel
 
-
 converged_error = 0.01
 window_size = 8
 max_windows = 100
@@ -17,7 +16,7 @@ time_step = 0.01
 def test_lorenz():
     error = math.inf
     window = 0
-    prior_mu = (3. ,3. ,3.)
+    prior_mu = (3., 3., 3.)
 
     model = LorenzModel(sigma, beta, rho, time_step)
     observed = list(model.run_model(window_size * max_windows))
@@ -39,24 +38,26 @@ def test_lorenz():
         post_t = (window + 1) * (window_size - 1)
         actual_at_post_t = observed[post_t]
 
-        error = math.sqrt(
-                    (actual_at_post_t.x - posterior[0]) ** 2 +
-                    (actual_at_post_t.y - posterior[1]) ** 2 +
-                    (actual_at_post_t.z - posterior[2]) ** 2
-                )
+        error = math.sqrt((actual_at_post_t.x - posterior[0])**2 +
+                          (actual_at_post_t.y - posterior[1])**2 +
+                          (actual_at_post_t.z - posterior[2])**2)
         prior_mu = (posterior[0], posterior[1], posterior[2])
         window += 1
 
     assert error <= converged_error
 
+
 def add_time(current):
     rho_v = Const(rho)
     (xt, yt, zt) = current
 
-    x_tplus1 = xt * Const(1. - time_step * sigma) + (yt * Const(time_step * sigma))
-    y_tplus1 = yt * Const(1. - time_step) + (xt * (rho_v - zt) * Const(time_step))
+    x_tplus1 = xt * Const(1. - time_step * sigma) + (
+        yt * Const(time_step * sigma))
+    y_tplus1 = yt * Const(1. - time_step) + (xt *
+                                             (rho_v - zt) * Const(time_step))
     z_tplus1 = zt * Const(1. - time_step * beta) + (xt * yt * Const(time_step))
-    return (x_tplus1, y_tplus1, z_tplus1) 
+    return (x_tplus1, y_tplus1, z_tplus1)
+
 
 def build_graph(initial):
     (x, y, z) = initial
@@ -64,7 +65,8 @@ def build_graph(initial):
     for _ in range(window_size):
         (x, y, z) = add_time((x, y, z))
         yield (x, y, z)
-    
+
+
 def apply_observations(graph_time_steps, window, observed):
     for (idx, time_slice) in enumerate(graph_time_steps):
         t = window * (window_size - 1) + idx
@@ -72,6 +74,7 @@ def apply_observations(graph_time_steps, window, observed):
         observed_xt = Gaussian(xt, 1.0)
         observed_xt.observe(observed[t].x)
 
+
 def get_time_slice_values(time_steps, time):
     time_slice = time_steps[time]
-    return list(map(lambda v : v.get_value(), time_slice))
+    return list(map(lambda v: v.get_value(), time_slice))

--- a/keanu-python/tests/test_lorenz.py
+++ b/keanu-python/tests/test_lorenz.py
@@ -38,8 +38,8 @@ def test_lorenz():
         post_t = (window + 1) * (window_size - 1)
         actual_at_post_t = observed[post_t]
 
-        error = math.sqrt((actual_at_post_t.x - posterior[0])**2 + (actual_at_post_t.y - posterior[1])**2 +
-                          (actual_at_post_t.z - posterior[2])**2)
+        error = math.sqrt((actual_at_post_t.x - posterior[0]) ** 2 + (actual_at_post_t.y - posterior[1]) ** 2 +
+                          (actual_at_post_t.z - posterior[2]) ** 2)
         prior_mu = (posterior[0], posterior[1], posterior[2])
         window += 1
 

--- a/keanu-python/tests/test_model.py
+++ b/keanu-python/tests/test_model.py
@@ -1,6 +1,7 @@
 from keanu import Model, BayesNet
 from keanu.vertex import Exponential, Gamma, Gaussian
 
+
 def test_to_bayes_net():
     with Model() as m:
         m.mu = Exponential(1.)
@@ -12,7 +13,9 @@ def test_to_bayes_net():
 
     assert isinstance(net, BayesNet)
 
-    net_vertex_ids = [vertex.get_id() for vertex in net.get_latent_or_observed_vertices()]
+    net_vertex_ids = [
+        vertex.get_id() for vertex in net.get_latent_or_observed_vertices()
+    ]
 
     assert len(net_vertex_ids) == 3
     assert m.mu.get_id() in net_vertex_ids
@@ -29,7 +32,9 @@ def test_to_bayes_net_excludes_non_vertices():
 
     assert isinstance(net, BayesNet)
 
-    net_vertex_ids = [vertex.get_id() for vertex in net.get_latent_or_observed_vertices()]
+    net_vertex_ids = [
+        vertex.get_id() for vertex in net.get_latent_or_observed_vertices()
+    ]
 
     assert len(net_vertex_ids) == 1
     assert m.vertex.get_id() in net_vertex_ids

--- a/keanu-python/tests/test_model.py
+++ b/keanu-python/tests/test_model.py
@@ -13,9 +13,7 @@ def test_to_bayes_net():
 
     assert isinstance(net, BayesNet)
 
-    net_vertex_ids = [
-        vertex.get_id() for vertex in net.get_latent_or_observed_vertices()
-    ]
+    net_vertex_ids = [vertex.get_id() for vertex in net.get_latent_or_observed_vertices()]
 
     assert len(net_vertex_ids) == 3
     assert m.mu.get_id() in net_vertex_ids
@@ -32,9 +30,7 @@ def test_to_bayes_net_excludes_non_vertices():
 
     assert isinstance(net, BayesNet)
 
-    net_vertex_ids = [
-        vertex.get_id() for vertex in net.get_latent_or_observed_vertices()
-    ]
+    net_vertex_ids = [vertex.get_id() for vertex in net.get_latent_or_observed_vertices()]
 
     assert len(net_vertex_ids) == 1
     assert m.vertex.get_id() in net_vertex_ids

--- a/keanu-python/tests/test_net.py
+++ b/keanu-python/tests/test_net.py
@@ -2,6 +2,7 @@ from keanu.vertex import UniformInt, Gamma, Poisson, Cauchy
 from keanu import BayesNet, KeanuRandom
 import pytest
 
+
 def test_construct_bayes_net():
     uniform = UniformInt(0, 1)
     graph = set(uniform.get_connected_graph())
@@ -11,19 +12,23 @@ def test_construct_bayes_net():
     assert uniform.get_id() in vertex_ids
 
     net = BayesNet(graph)
-    latent_vertex_ids = [vertex.get_id() for vertex in net.get_latent_vertices()]
+    latent_vertex_ids = [
+        vertex.get_id() for vertex in net.get_latent_vertices()
+    ]
 
     assert len(latent_vertex_ids) == 1
     assert uniform.get_id() in latent_vertex_ids
 
-@pytest.mark.parametrize("get_method, latent, observed, continuous, discrete", [
-    ("get_latent_or_observed_vertices", True, True, True, True),
-    ("get_latent_vertices", True, False, True, True),
-    ("get_observed_vertices", False, True, True, True),
-    ("get_continuous_latent_vertices", True, False, True, False),
-    ("get_discrete_latent_vertices", True, False, False, True)
-])
-def test_can_get_vertices_from_bayes_net(get_method, latent, observed, continuous, discrete):
+
+@pytest.mark.parametrize(
+    "get_method, latent, observed, continuous, discrete",
+    [("get_latent_or_observed_vertices", True, True, True, True),
+     ("get_latent_vertices", True, False, True, True),
+     ("get_observed_vertices", False, True, True, True),
+     ("get_continuous_latent_vertices", True, False, True, False),
+     ("get_discrete_latent_vertices", True, False, False, True)])
+def test_can_get_vertices_from_bayes_net(get_method, latent, observed,
+                                         continuous, discrete):
     gamma = Gamma(1., 1.)
     gamma.observe(0.5)
 
@@ -44,7 +49,9 @@ def test_can_get_vertices_from_bayes_net(get_method, latent, observed, continuou
     if latent and continuous:
         assert cauchy.get_id() in vertex_ids
 
-    assert len(vertex_ids) == (observed and continuous) + (latent and discrete) + (latent and continuous)
+    assert len(vertex_ids) == (observed and continuous) + (
+        latent and discrete) + (latent and continuous)
+
 
 def test_probe_for_non_zero_probability_from_bayes_net():
     gamma = Gamma(1., 1.)
@@ -59,4 +66,3 @@ def test_probe_for_non_zero_probability_from_bayes_net():
 
     assert gamma.has_value()
     assert poisson.has_value()
-

--- a/keanu-python/tests/test_net.py
+++ b/keanu-python/tests/test_net.py
@@ -12,23 +12,19 @@ def test_construct_bayes_net():
     assert uniform.get_id() in vertex_ids
 
     net = BayesNet(graph)
-    latent_vertex_ids = [
-        vertex.get_id() for vertex in net.get_latent_vertices()
-    ]
+    latent_vertex_ids = [vertex.get_id() for vertex in net.get_latent_vertices()]
 
     assert len(latent_vertex_ids) == 1
     assert uniform.get_id() in latent_vertex_ids
 
 
-@pytest.mark.parametrize(
-    "get_method, latent, observed, continuous, discrete",
-    [("get_latent_or_observed_vertices", True, True, True, True),
-     ("get_latent_vertices", True, False, True, True),
-     ("get_observed_vertices", False, True, True, True),
-     ("get_continuous_latent_vertices", True, False, True, False),
-     ("get_discrete_latent_vertices", True, False, False, True)])
-def test_can_get_vertices_from_bayes_net(get_method, latent, observed,
-                                         continuous, discrete):
+@pytest.mark.parametrize("get_method, latent, observed, continuous, discrete",
+                         [("get_latent_or_observed_vertices", True, True, True, True),
+                          ("get_latent_vertices", True, False, True, True),
+                          ("get_observed_vertices", False, True, True, True),
+                          ("get_continuous_latent_vertices", True, False, True, False),
+                          ("get_discrete_latent_vertices", True, False, False, True)])
+def test_can_get_vertices_from_bayes_net(get_method, latent, observed, continuous, discrete):
     gamma = Gamma(1., 1.)
     gamma.observe(0.5)
 
@@ -49,8 +45,7 @@ def test_can_get_vertices_from_bayes_net(get_method, latent, observed,
     if latent and continuous:
         assert cauchy.get_id() in vertex_ids
 
-    assert len(vertex_ids) == (observed and continuous) + (
-        latent and discrete) + (latent and continuous)
+    assert len(vertex_ids) == (observed and continuous) + (latent and discrete) + (latent and continuous)
 
 
 def test_probe_for_non_zero_probability_from_bayes_net():

--- a/keanu-python/tests/test_non_gradient_optimization.py
+++ b/keanu-python/tests/test_non_gradient_optimization.py
@@ -4,6 +4,7 @@ from keanu import KeanuRandom, Model, BayesNet
 from keanu.vertex import Gaussian
 from keanu.algorithm import NonGradientOptimizer
 
+
 @pytest.fixture
 def model():
     KeanuRandom.set_default_random_seed(1)

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -20,8 +20,7 @@ def net():
 
 
 @pytest.mark.parametrize("algo", [("metropolis"), ("NUTS"), ("hamiltonian")])
-def test_sampling_returns_dict_of_list_of_ndarrays_for_vertices_in_sample_from(
-        algo, net):
+def test_sampling_returns_dict_of_list_of_ndarrays_for_vertices_in_sample_from(algo, net):
     draws = 5
     sample_from = list(net.get_latent_vertices())
     vertex_ids = [vertex.get_id() for vertex in sample_from]
@@ -43,13 +42,10 @@ def test_dropping_samples(net):
     draws = 10
     drop = 3
 
-    samples = sample(
-        net=net, sample_from=net.get_latent_vertices(), draws=draws, drop=drop)
+    samples = sample(net=net, sample_from=net.get_latent_vertices(), draws=draws, drop=drop)
 
     expected_num_samples = draws - drop
-    assert all(
-        len(vertex_samples) == expected_num_samples
-        for vertex_id, vertex_samples in samples.items())
+    assert all(len(vertex_samples) == expected_num_samples for vertex_id, vertex_samples in samples.items())
 
 
 def test_down_sample_interval(net):
@@ -57,25 +53,16 @@ def test_down_sample_interval(net):
     down_sample_interval = 2
 
     samples = sample(
-        net=net,
-        sample_from=net.get_latent_vertices(),
-        draws=draws,
-        down_sample_interval=down_sample_interval)
+        net=net, sample_from=net.get_latent_vertices(), draws=draws, down_sample_interval=down_sample_interval)
 
     expected_num_samples = draws / down_sample_interval
-    assert all(
-        len(vertex_samples) == expected_num_samples
-        for vertex_id, vertex_samples in samples.items())
+    assert all(len(vertex_samples) == expected_num_samples for vertex_id, vertex_samples in samples.items())
 
 
 @pytest.mark.parametrize("algo", [("metropolis"), ("hamiltonian")])
 def test_can_iter_through_samples(algo, net):
     draws = 10
-    samples = generate_samples(
-        net=net,
-        sample_from=net.get_latent_vertices(),
-        algo=algo,
-        down_sample_interval=1)
+    samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, down_sample_interval=1)
     count = 0
     for sample in islice(samples, draws):
         count += 1
@@ -88,21 +75,15 @@ def test_iter_returns_same_result_as_sample(algo):
     model = Thermometer.model()
     net = BayesNet(model.temperature.get_connected_graph())
     set_starting_state(model)
-    samples = sample(
-        net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
+    samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     set_starting_state(model)
-    iter_samples = generate_samples(
-        net=net, sample_from=net.get_latent_vertices(), algo=algo)
+    iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo)
 
     samples_dataframe = pd.DataFrame()
-    [
-        samples_dataframe.append(pd.DataFrame(list(next_sample.items())))
-        for next_sample in islice(iter_samples, draws)
-    ]
+    [samples_dataframe.append(pd.DataFrame(list(next_sample.items()))) for next_sample in islice(iter_samples, draws)]
 
     for vertex_id in samples_dataframe:
-        np.testing.assert_almost_equal(dataframe[vertex_id].mean(),
-                                       np.average(samples[vertex_id]))
+        np.testing.assert_almost_equal(dataframe[vertex_id].mean(), np.average(samples[vertex_id]))
 
 
 def set_starting_state(model):

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -9,6 +9,7 @@ from keanu import BayesNet, KeanuRandom
 from collections import defaultdict
 from itertools import islice
 
+
 @pytest.fixture
 def net():
     gamma = Gamma(1., 1.)
@@ -18,12 +19,9 @@ def net():
     return BayesNet(cauchy.get_connected_graph())
 
 
-@pytest.mark.parametrize("algo", [
-    ("metropolis"),
-    ("NUTS"),
-    ("hamiltonian")
-])
-def test_sampling_returns_dict_of_list_of_ndarrays_for_vertices_in_sample_from(algo, net):
+@pytest.mark.parametrize("algo", [("metropolis"), ("NUTS"), ("hamiltonian")])
+def test_sampling_returns_dict_of_list_of_ndarrays_for_vertices_in_sample_from(
+        algo, net):
     draws = 5
     sample_from = list(net.get_latent_vertices())
     vertex_ids = [vertex.get_id() for vertex in sample_from]
@@ -45,53 +43,66 @@ def test_dropping_samples(net):
     draws = 10
     drop = 3
 
-    samples = sample(net=net, sample_from=net.get_latent_vertices(), draws=draws, drop=drop)
+    samples = sample(
+        net=net, sample_from=net.get_latent_vertices(), draws=draws, drop=drop)
 
     expected_num_samples = draws - drop
-    assert all(len(vertex_samples) == expected_num_samples for vertex_id, vertex_samples in samples.items())
+    assert all(
+        len(vertex_samples) == expected_num_samples
+        for vertex_id, vertex_samples in samples.items())
 
 
 def test_down_sample_interval(net):
     draws = 10
     down_sample_interval = 2
 
-    samples = sample(net=net, sample_from=net.get_latent_vertices(), draws=draws, down_sample_interval=down_sample_interval)
+    samples = sample(
+        net=net,
+        sample_from=net.get_latent_vertices(),
+        draws=draws,
+        down_sample_interval=down_sample_interval)
 
     expected_num_samples = draws / down_sample_interval
-    assert all(len(vertex_samples) == expected_num_samples for vertex_id, vertex_samples in samples.items())
+    assert all(
+        len(vertex_samples) == expected_num_samples
+        for vertex_id, vertex_samples in samples.items())
 
 
-@pytest.mark.parametrize("algo", [
-    ("metropolis"),
-    ("hamiltonian")
-])
+@pytest.mark.parametrize("algo", [("metropolis"), ("hamiltonian")])
 def test_can_iter_through_samples(algo, net):
     draws = 10
-    samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, down_sample_interval=1)
+    samples = generate_samples(
+        net=net,
+        sample_from=net.get_latent_vertices(),
+        algo=algo,
+        down_sample_interval=1)
     count = 0
     for sample in islice(samples, draws):
         count += 1
     assert count == draws
 
 
-@pytest.mark.parametrize("algo", [
-    ("metropolis"),
-    ("hamiltonian")
-])
+@pytest.mark.parametrize("algo", [("metropolis"), ("hamiltonian")])
 def test_iter_returns_same_result_as_sample(algo):
     draws = 100
     model = Thermometer.model()
     net = BayesNet(model.temperature.get_connected_graph())
     set_starting_state(model)
-    samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
+    samples = sample(
+        net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
     set_starting_state(model)
-    iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo)
+    iter_samples = generate_samples(
+        net=net, sample_from=net.get_latent_vertices(), algo=algo)
 
     samples_dataframe = pd.DataFrame()
-    [samples_dataframe.append(pd.DataFrame(list(next_sample.items()))) for next_sample in islice(iter_samples, draws)]
+    [
+        samples_dataframe.append(pd.DataFrame(list(next_sample.items())))
+        for next_sample in islice(iter_samples, draws)
+    ]
 
     for vertex_id in samples_dataframe:
-        np.testing.assert_almost_equal(dataframe[vertex_id].mean(), np.average(samples[vertex_id]))
+        np.testing.assert_almost_equal(dataframe[vertex_id].mean(),
+                                       np.average(samples[vertex_id]))
 
 
 def set_starting_state(model):

--- a/keanu-python/tests/test_tensor.py
+++ b/keanu-python/tests/test_tensor.py
@@ -8,14 +8,14 @@ from keanu.tensor import Tensor
 def generic():
     pass
 
-@pytest.mark.parametrize("num, expected_java_class", [
-    (1, "ScalarIntegerTensor"),
-    (np.array([1])[0], "ScalarIntegerTensor"),
-    (1.3, "ScalarDoubleTensor"),
-    (np.array([1.3])[0], "ScalarDoubleTensor"),
-    (True, "SimpleBooleanTensor"),
-    (np.array([True])[0], "SimpleBooleanTensor")
-])
+
+@pytest.mark.parametrize("num, expected_java_class",
+                         [(1, "ScalarIntegerTensor"),
+                          (np.array([1])[0], "ScalarIntegerTensor"),
+                          (1.3, "ScalarDoubleTensor"),
+                          (np.array([1.3])[0], "ScalarDoubleTensor"),
+                          (True, "SimpleBooleanTensor"),
+                          (np.array([True])[0], "SimpleBooleanTensor")])
 def test_num_passed_to_Tensor_creates_scalar_tensor(num, expected_java_class):
     t = Tensor(num)
     assert_java_class(t, expected_java_class)
@@ -23,11 +23,11 @@ def test_num_passed_to_Tensor_creates_scalar_tensor(num, expected_java_class):
     assert t.scalar() == num
 
 
-@pytest.mark.parametrize("data, expected_java_class", [
-    ([[1, 2], [3, 4]], "Nd4jIntegerTensor"),
-    ([[1., 2.], [3., 4.]], "Nd4jDoubleTensor"),
-    ([[True, False], [True, False]], "SimpleBooleanTensor")
-])
+@pytest.mark.parametrize(
+    "data, expected_java_class",
+    [([[1, 2], [3, 4]], "Nd4jIntegerTensor"),
+     ([[1., 2.], [3., 4.]], "Nd4jDoubleTensor"),
+     ([[True, False], [True, False]], "SimpleBooleanTensor")])
 def test_dataframe_passed_to_Tensor_creates_tensor(data, expected_java_class):
     dataframe = pd.DataFrame(columns=['A', 'B'], data=data)
     t = Tensor(dataframe)
@@ -40,14 +40,13 @@ def test_dataframe_passed_to_Tensor_creates_tensor(data, expected_java_class):
     assert np.array_equal(tensor_value, dataframe_value)
 
 
-@pytest.mark.parametrize("data, expected_java_class", [
-    ([1, 2], "Nd4jIntegerTensor"),
-    ([1], "ScalarIntegerTensor"),
-    ([1., 2.], "Nd4jDoubleTensor"),
-    ([1.], "ScalarDoubleTensor"),
-    ([True, False], "SimpleBooleanTensor"),
-    ([True], "SimpleBooleanTensor")
-])
+@pytest.mark.parametrize("data, expected_java_class",
+                         [([1, 2], "Nd4jIntegerTensor"),
+                          ([1], "ScalarIntegerTensor"),
+                          ([1., 2.], "Nd4jDoubleTensor"),
+                          ([1.], "ScalarDoubleTensor"),
+                          ([True, False], "SimpleBooleanTensor"),
+                          ([True], "SimpleBooleanTensor")])
 def test_series_passed_to_Tensor_creates_tensor(data, expected_java_class):
     series = pd.Series(data)
     t = Tensor(series)
@@ -59,7 +58,7 @@ def test_series_passed_to_Tensor_creates_tensor(data, expected_java_class):
 
     assert len(tensor_value) == len(series_value)
     assert tensor_value.shape == (len(series_value), 1)
-    assert series_value.shape == (len(series_value),  )
+    assert series_value.shape == (len(series_value),)
 
     assert np.array_equal(tensor_value.flatten(), series_value.flatten())
 
@@ -68,15 +67,18 @@ def test_cannot_pass_generic_to_Tensor(generic):
     with pytest.raises(NotImplementedError) as excinfo:
         Tensor(generic)
 
-    assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given {}".format(type(generic))
+    assert str(
+        excinfo.value
+    ) == "Generic types in an ndarray are not supported. Was given {}".format(
+        type(generic))
 
 
-@pytest.mark.parametrize("arr, expected_java_class", [
-    ([1, 2], "Nd4jIntegerTensor"),
-    ([3.4, 2.], "Nd4jDoubleTensor"),
-    ([True, False], "SimpleBooleanTensor")
-])
-def test_ndarray_passed_to_Tensor_creates_nonscalar_tensor(arr, expected_java_class):
+@pytest.mark.parametrize("arr, expected_java_class",
+                         [([1, 2], "Nd4jIntegerTensor"),
+                          ([3.4, 2.], "Nd4jDoubleTensor"),
+                          ([True, False], "SimpleBooleanTensor")])
+def test_ndarray_passed_to_Tensor_creates_nonscalar_tensor(
+        arr, expected_java_class):
     ndarray = np.array(arr)
     t = Tensor(ndarray)
     assert_java_class(t, expected_java_class)
@@ -87,26 +89,28 @@ def test_cannot_pass_generic_ndarray_to_Tensor(generic):
     with pytest.raises(NotImplementedError) as excinfo:
         Tensor(np.array([generic, generic]))
 
-    assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given {}".format(type(generic))
+    assert str(
+        excinfo.value
+    ) == "Generic types in an ndarray are not supported. Was given {}".format(
+        type(generic))
 
 
 def test_cannot_pass_empty_ndarray_to_Tensor():
     with pytest.raises(ValueError) as excinfo:
         Tensor(np.array([]))
 
-    assert str(excinfo.value) == "Cannot infer type because the ndarray is empty"
+    assert str(
+        excinfo.value) == "Cannot infer type because the ndarray is empty"
 
 
-@pytest.mark.parametrize("value", [
-    (np.array([[1, 2], [3, 4]])),
-    (3)
-])
+@pytest.mark.parametrize("value", [(np.array([[1, 2], [3, 4]])), (3)])
 def test_convert_java_tensor_to_ndarray(value):
     t = Tensor(value)
     ndarray = Tensor._to_ndarray(t.unwrap())
 
     assert type(ndarray) == np.ndarray
     assert (value == ndarray).all()
+
 
 def assert_java_class(java_object_wrapper, java_class_str):
     assert java_object_wrapper.get_class().getSimpleName() == java_class_str

--- a/keanu-python/tests/test_tensor.py
+++ b/keanu-python/tests/test_tensor.py
@@ -9,13 +9,12 @@ def generic():
     pass
 
 
-@pytest.mark.parametrize("num, expected_java_class",
-                         [(1, "ScalarIntegerTensor"),
-                          (np.array([1])[0], "ScalarIntegerTensor"),
-                          (1.3, "ScalarDoubleTensor"),
-                          (np.array([1.3])[0], "ScalarDoubleTensor"),
-                          (True, "SimpleBooleanTensor"),
-                          (np.array([True])[0], "SimpleBooleanTensor")])
+@pytest.mark.parametrize("num, expected_java_class", [(1, "ScalarIntegerTensor"),
+                                                      (np.array([1])[0], "ScalarIntegerTensor"),
+                                                      (1.3, "ScalarDoubleTensor"),
+                                                      (np.array([1.3])[0], "ScalarDoubleTensor"),
+                                                      (True, "SimpleBooleanTensor"),
+                                                      (np.array([True])[0], "SimpleBooleanTensor")])
 def test_num_passed_to_Tensor_creates_scalar_tensor(num, expected_java_class):
     t = Tensor(num)
     assert_java_class(t, expected_java_class)
@@ -23,11 +22,9 @@ def test_num_passed_to_Tensor_creates_scalar_tensor(num, expected_java_class):
     assert t.scalar() == num
 
 
-@pytest.mark.parametrize(
-    "data, expected_java_class",
-    [([[1, 2], [3, 4]], "Nd4jIntegerTensor"),
-     ([[1., 2.], [3., 4.]], "Nd4jDoubleTensor"),
-     ([[True, False], [True, False]], "SimpleBooleanTensor")])
+@pytest.mark.parametrize("data, expected_java_class", [([[1, 2], [3, 4]], "Nd4jIntegerTensor"),
+                                                       ([[1., 2.], [3., 4.]], "Nd4jDoubleTensor"),
+                                                       ([[True, False], [True, False]], "SimpleBooleanTensor")])
 def test_dataframe_passed_to_Tensor_creates_tensor(data, expected_java_class):
     dataframe = pd.DataFrame(columns=['A', 'B'], data=data)
     t = Tensor(dataframe)
@@ -40,13 +37,10 @@ def test_dataframe_passed_to_Tensor_creates_tensor(data, expected_java_class):
     assert np.array_equal(tensor_value, dataframe_value)
 
 
-@pytest.mark.parametrize("data, expected_java_class",
-                         [([1, 2], "Nd4jIntegerTensor"),
-                          ([1], "ScalarIntegerTensor"),
-                          ([1., 2.], "Nd4jDoubleTensor"),
-                          ([1.], "ScalarDoubleTensor"),
-                          ([True, False], "SimpleBooleanTensor"),
-                          ([True], "SimpleBooleanTensor")])
+@pytest.mark.parametrize("data, expected_java_class", [([1, 2], "Nd4jIntegerTensor"), ([1], "ScalarIntegerTensor"),
+                                                       ([1., 2.], "Nd4jDoubleTensor"), ([1.], "ScalarDoubleTensor"),
+                                                       ([True, False], "SimpleBooleanTensor"),
+                                                       ([True], "SimpleBooleanTensor")])
 def test_series_passed_to_Tensor_creates_tensor(data, expected_java_class):
     series = pd.Series(data)
     t = Tensor(series)
@@ -67,18 +61,12 @@ def test_cannot_pass_generic_to_Tensor(generic):
     with pytest.raises(NotImplementedError) as excinfo:
         Tensor(generic)
 
-    assert str(
-        excinfo.value
-    ) == "Generic types in an ndarray are not supported. Was given {}".format(
-        type(generic))
+    assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given {}".format(type(generic))
 
 
-@pytest.mark.parametrize("arr, expected_java_class",
-                         [([1, 2], "Nd4jIntegerTensor"),
-                          ([3.4, 2.], "Nd4jDoubleTensor"),
-                          ([True, False], "SimpleBooleanTensor")])
-def test_ndarray_passed_to_Tensor_creates_nonscalar_tensor(
-        arr, expected_java_class):
+@pytest.mark.parametrize("arr, expected_java_class", [([1, 2], "Nd4jIntegerTensor"), ([3.4, 2.], "Nd4jDoubleTensor"),
+                                                      ([True, False], "SimpleBooleanTensor")])
+def test_ndarray_passed_to_Tensor_creates_nonscalar_tensor(arr, expected_java_class):
     ndarray = np.array(arr)
     t = Tensor(ndarray)
     assert_java_class(t, expected_java_class)
@@ -89,18 +77,14 @@ def test_cannot_pass_generic_ndarray_to_Tensor(generic):
     with pytest.raises(NotImplementedError) as excinfo:
         Tensor(np.array([generic, generic]))
 
-    assert str(
-        excinfo.value
-    ) == "Generic types in an ndarray are not supported. Was given {}".format(
-        type(generic))
+    assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given {}".format(type(generic))
 
 
 def test_cannot_pass_empty_ndarray_to_Tensor():
     with pytest.raises(ValueError) as excinfo:
         Tensor(np.array([]))
 
-    assert str(
-        excinfo.value) == "Cannot infer type because the ndarray is empty"
+    assert str(excinfo.value) == "Cannot infer type because the ndarray is empty"
 
 
 @pytest.mark.parametrize("value", [(np.array([[1, 2], [3, 4]])), (3)])

--- a/keanu-python/tests/test_vertex.py
+++ b/keanu-python/tests/test_vertex.py
@@ -4,11 +4,14 @@ from keanu.vertex.base import Vertex
 from keanu.context import KeanuContext
 from keanu.vertex import Gaussian, Const
 
+
 @pytest.fixture
 def jvm_view():
     from py4j.java_gateway import java_import
     jvm_view = KeanuContext().jvm_view()
-    java_import(jvm_view, "io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex")
+    java_import(
+        jvm_view,
+        "io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex")
     return jvm_view
 
 
@@ -20,7 +23,8 @@ def test_can_pass_scalar_to_vertex(jvm_view):
 
 
 def test_can_pass_ndarray_to_vertex(jvm_view):
-    gaussian = Vertex(jvm_view.GaussianVertex, np.array([[0.1, 0.4]]), np.array([[0.4, 0.5]]))
+    gaussian = Vertex(jvm_view.GaussianVertex, np.array([[0.1, 0.4]]),
+                      np.array([[0.4, 0.5]]))
     sample = gaussian.sample()
 
     assert sample.shape == (1, 2)
@@ -42,13 +46,17 @@ def test_can_pass_array_to_vertex(jvm_view):
 
 
 def test_cannot_pass_generic_to_vertex(jvm_view):
+
     class GenericExampleClass:
         pass
 
     with pytest.raises(ValueError) as excinfo:
-        Vertex(jvm_view.GaussianVertex, GenericExampleClass(), GenericExampleClass())
+        Vertex(jvm_view.GaussianVertex, GenericExampleClass(),
+               GenericExampleClass())
 
-    assert str(excinfo.value) == "Can't parse generic argument. Was given {}".format(GenericExampleClass)
+    assert str(
+        excinfo.value) == "Can't parse generic argument. Was given {}".format(
+            GenericExampleClass)
 
 
 def test_you_can_set_and_get_a_value(jvm_view):
@@ -77,7 +85,7 @@ def test_vertex_can_observe_scalar(jvm_view):
 def test_vertex_can_observe_ndarray(jvm_view):
     gaussian = Vertex(jvm_view.GaussianVertex, 0., 1.)
 
-    ndarray = np.array([[1.,2.]])
+    ndarray = np.array([[1., 2.]])
     gaussian.observe(ndarray)
 
     assert type(gaussian.get_value()) == np.ndarray
@@ -92,6 +100,7 @@ def test_int_vertex_value_is_a_numpy_array():
     assert value.dtype == np.int64 or value.dtype == np.int32
     assert (value == ndarray).all()
 
+
 def test_float_vertex_value_is_a_numpy_array():
     ndarray = np.array([[1., 2.], [3., 4.]])
     vertex = Const(ndarray)
@@ -100,6 +109,7 @@ def test_float_vertex_value_is_a_numpy_array():
     assert value.dtype == np.float64
     assert (value == ndarray).all()
 
+
 def test_boolean_vertex_value_is_a_numpy_array():
     ndarray = np.array([[True, True], [False, True]])
     vertex = Const(ndarray)
@@ -107,6 +117,7 @@ def test_boolean_vertex_value_is_a_numpy_array():
     assert type(value) == np.ndarray
     assert value.dtype == np.bool
     assert (value == ndarray).all()
+
 
 def test_scalar_vertex_value_is_a_numpy_array():
     scalar = 1.
@@ -117,6 +128,7 @@ def test_scalar_vertex_value_is_a_numpy_array():
     assert value.shape == (1, 1)
     assert value == scalar
     assert (value == scalar).all()
+
 
 def test_vertex_sample_is_a_numpy_array():
     mu = np.array([[1., 2.], [3., 4.]])
@@ -162,10 +174,14 @@ def test_java_collections_to_generator(jvm_view):
     java_collections = gaussian.unwrap().getConnectedGraph()
     python_list = list(Vertex._to_generator(java_collections))
 
-    java_vertex_ids = [Vertex._get_python_id(java_vertex) for java_vertex in java_collections]
+    java_vertex_ids = [
+        Vertex._get_python_id(java_vertex) for java_vertex in java_collections
+    ]
 
     assert java_collections.size() == len(python_list)
-    assert all(type(element) == Vertex and element.get_id() in java_vertex_ids for element in python_list)
+    assert all(
+        type(element) == Vertex and element.get_id() in java_vertex_ids
+        for element in python_list)
 
 
 def test_get_vertex_id(jvm_view):

--- a/keanu-python/tests/test_vertex.py
+++ b/keanu-python/tests/test_vertex.py
@@ -9,9 +9,7 @@ from keanu.vertex import Gaussian, Const
 def jvm_view():
     from py4j.java_gateway import java_import
     jvm_view = KeanuContext().jvm_view()
-    java_import(
-        jvm_view,
-        "io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex")
+    java_import(jvm_view, "io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex")
     return jvm_view
 
 
@@ -23,8 +21,7 @@ def test_can_pass_scalar_to_vertex(jvm_view):
 
 
 def test_can_pass_ndarray_to_vertex(jvm_view):
-    gaussian = Vertex(jvm_view.GaussianVertex, np.array([[0.1, 0.4]]),
-                      np.array([[0.4, 0.5]]))
+    gaussian = Vertex(jvm_view.GaussianVertex, np.array([[0.1, 0.4]]), np.array([[0.4, 0.5]]))
     sample = gaussian.sample()
 
     assert sample.shape == (1, 2)
@@ -51,12 +48,9 @@ def test_cannot_pass_generic_to_vertex(jvm_view):
         pass
 
     with pytest.raises(ValueError) as excinfo:
-        Vertex(jvm_view.GaussianVertex, GenericExampleClass(),
-               GenericExampleClass())
+        Vertex(jvm_view.GaussianVertex, GenericExampleClass(), GenericExampleClass())
 
-    assert str(
-        excinfo.value) == "Can't parse generic argument. Was given {}".format(
-            GenericExampleClass)
+    assert str(excinfo.value) == "Can't parse generic argument. Was given {}".format(GenericExampleClass)
 
 
 def test_you_can_set_and_get_a_value(jvm_view):
@@ -174,14 +168,10 @@ def test_java_collections_to_generator(jvm_view):
     java_collections = gaussian.unwrap().getConnectedGraph()
     python_list = list(Vertex._to_generator(java_collections))
 
-    java_vertex_ids = [
-        Vertex._get_python_id(java_vertex) for java_vertex in java_collections
-    ]
+    java_vertex_ids = [Vertex._get_python_id(java_vertex) for java_vertex in java_collections]
 
     assert java_collections.size() == len(python_list)
-    assert all(
-        type(element) == Vertex and element.get_id() in java_vertex_ids
-        for element in python_list)
+    assert all(type(element) == Vertex and element.get_id() in java_vertex_ids for element in python_list)
 
 
 def test_get_vertex_id(jvm_view):

--- a/keanu-python/tests/test_vertex_operations.py
+++ b/keanu-python/tests/test_vertex_operations.py
@@ -167,7 +167,7 @@ def test_can_do_integer_division(lhs, rhs, expected_result):
     (3., Const(np.array([2., 0.5])), np.array([[9], [1.7320508075688772]])),
 ])
 def test_can_do_pow(lhs, rhs, expected_result):
-    result = lhs**rhs
+    result = lhs ** rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 

--- a/keanu-python/tests/test_vertex_operations.py
+++ b/keanu-python/tests/test_vertex_operations.py
@@ -7,42 +7,32 @@ from keanu.vertex.base import Vertex
 ### Comparisons
 
 
-@pytest.mark.parametrize(
-    "lhs, rhs, expected_result", [
-        (Const(np.array([1., 2.])), Const(np.array([1., -1.])),
-         np.array([[True], [False]])),
-        (Const(np.array([1., 2.])), np.array([1., -1.]),
-         np.array([[True], [False]])),
-        (np.array([1., 2.]), Const(np.array([1., -1.])),
-         np.array([[True], [False]])),
-        (Const(np.array([1.])), 1., np.array([[True]])),
-        (Const(np.array([2.])), 1., np.array([[False]])),
-        (1., Const(np.array([1.])), np.array([[True]])),
-        (1., Const(np.array([-1.])), np.array([[False]])),
-        (Const(np.array([1., 2.])), Const(np.array([1.])),
-         np.array([[True], [False]])),
-        (Const(np.array([1.])), Const(np.array([1., 2.])),
-         np.array([[True], [False]])),
-    ])
+@pytest.mark.parametrize("lhs, rhs, expected_result", [
+    (Const(np.array([1., 2.])), Const(np.array([1., -1.])), np.array([[True], [False]])),
+    (Const(np.array([1., 2.])), np.array([1., -1.]), np.array([[True], [False]])),
+    (np.array([1., 2.]), Const(np.array([1., -1.])), np.array([[True], [False]])),
+    (Const(np.array([1.])), 1., np.array([[True]])),
+    (Const(np.array([2.])), 1., np.array([[False]])),
+    (1., Const(np.array([1.])), np.array([[True]])),
+    (1., Const(np.array([-1.])), np.array([[False]])),
+    (Const(np.array([1., 2.])), Const(np.array([1.])), np.array([[True], [False]])),
+    (Const(np.array([1.])), Const(np.array([1., 2.])), np.array([[True], [False]])),
+])
 def test_can_do_equal_to(lhs, rhs, expected_result):
     result = lhs == rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
-@pytest.mark.parametrize(
-    "lhs, rhs, expected_result", [
-        (Const(np.array([1., 2.])), Const(np.array([1., -1.])),
-         np.array([[False], [True]])),
-        (Const(np.array([1., 2.])), np.array([1., -1.]),
-         np.array([[False], [True]])),
-        (np.array([1., 2.]), Const(np.array([1., -1.])),
-         np.array([[False], [True]])),
-        (Const(np.array([1.])), 1., np.array([[False]])),
-        (Const(np.array([2.])), 1., np.array([[True]])),
-        (1., Const(np.array([1.])), np.array([[False]])),
-        (1., Const(np.array([-1.])), np.array([[True]])),
-    ])
+@pytest.mark.parametrize("lhs, rhs, expected_result", [
+    (Const(np.array([1., 2.])), Const(np.array([1., -1.])), np.array([[False], [True]])),
+    (Const(np.array([1., 2.])), np.array([1., -1.]), np.array([[False], [True]])),
+    (np.array([1., 2.]), Const(np.array([1., -1.])), np.array([[False], [True]])),
+    (Const(np.array([1.])), 1., np.array([[False]])),
+    (Const(np.array([2.])), 1., np.array([[True]])),
+    (1., Const(np.array([1.])), np.array([[False]])),
+    (1., Const(np.array([-1.])), np.array([[True]])),
+])
 def test_can_do_not_equal_to(lhs, rhs, expected_result):
     result = lhs != rhs
     assert type(result) == Vertex
@@ -50,12 +40,9 @@ def test_can_do_not_equal_to(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 20.])), Const(np.array([15., 15.])),
-     np.array([[False], [True]])),
-    (Const(np.array([10., 20.])), np.array([15., 15.]),
-     np.array([[False], [True]])),
-    (np.array([10., 20.]), Const(np.array([15., 15.])),
-     np.array([[False], [True]])),
+    (Const(np.array([10., 20.])), Const(np.array([15., 15.])), np.array([[False], [True]])),
+    (Const(np.array([10., 20.])), np.array([15., 15.]), np.array([[False], [True]])),
+    (np.array([10., 20.]), Const(np.array([15., 15.])), np.array([[False], [True]])),
     (Const(np.array([10., 20.])), 15., np.array([[False], [True]])),
     (10., Const(np.array([15., 5.])), np.array([[False], [True]])),
 ])
@@ -66,12 +53,9 @@ def test_can_do_greater_than(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 20.])), Const(np.array([15., 15.])),
-     np.array([[True], [False]])),
-    (Const(np.array([10., 20.])), np.array([15., 15.]),
-     np.array([[True], [False]])),
-    (np.array([10., 20.]), Const(np.array([15., 15.])),
-     np.array([[True], [False]])),
+    (Const(np.array([10., 20.])), Const(np.array([15., 15.])), np.array([[True], [False]])),
+    (Const(np.array([10., 20.])), np.array([15., 15.]), np.array([[True], [False]])),
+    (np.array([10., 20.]), Const(np.array([15., 15.])), np.array([[True], [False]])),
     (Const(np.array([10., 20.])), 15., np.array([[True], [False]])),
     (10., Const(np.array([15., 5.])), np.array([[True], [False]])),
 ])
@@ -82,14 +66,10 @@ def test_can_do_less_than(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])),
-     np.array([[False], [True], [True]])),
-    (Const(np.array([10., 15., 20.])), np.array([15., 15., 15.]),
-     np.array([[False], [True], [True]])),
-    (np.array([10., 15., 20.]), Const(np.array([15., 15., 15.])),
-     np.array([[False], [True], [True]])),
-    (Const(np.array([10., 15., 20.])), 15., np.array([[False], [True], [True]
-                                                     ])),
+    (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])), np.array([[False], [True], [True]])),
+    (Const(np.array([10., 15., 20.])), np.array([15., 15., 15.]), np.array([[False], [True], [True]])),
+    (np.array([10., 15., 20.]), Const(np.array([15., 15., 15.])), np.array([[False], [True], [True]])),
+    (Const(np.array([10., 15., 20.])), 15., np.array([[False], [True], [True]])),
     (10., Const(np.array([15., 10., 5.])), np.array([[False], [True], [True]])),
 ])
 def test_can_do_greater_than_or_equal_to(lhs, rhs, expected_result):
@@ -99,14 +79,10 @@ def test_can_do_greater_than_or_equal_to(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])),
-     np.array([[True], [True], [False]])),
-    (Const(np.array([10., 15., 20.])), np.array([15., 15., 15.]),
-     np.array([[True], [True], [False]])),
-    (np.array([10., 15., 20.]), Const(np.array([15., 15., 15.])),
-     np.array([[True], [True], [False]])),
-    (Const(np.array([10., 15., 20.])), 15., np.array([[True], [True], [False]
-                                                     ])),
+    (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])), np.array([[True], [True], [False]])),
+    (Const(np.array([10., 15., 20.])), np.array([15., 15., 15.]), np.array([[True], [True], [False]])),
+    (np.array([10., 15., 20.]), Const(np.array([15., 15., 15.])), np.array([[True], [True], [False]])),
+    (Const(np.array([10., 15., 20.])), 15., np.array([[True], [True], [False]])),
     (10., Const(np.array([15., 10., 5.])), np.array([[True], [True], [False]])),
 ])
 def test_can_do_less_than_or_equal_to(lhs, rhs, expected_result):
@@ -119,8 +95,7 @@ def test_can_do_less_than_or_equal_to(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 20.])), Const(np.array([1., 2.])),
-     np.array([[11], [22]])),
+    (Const(np.array([10., 20.])), Const(np.array([1., 2.])), np.array([[11], [22]])),
     (Const(np.array([10., 20.])), np.array([1., 2.]), np.array([[11], [22]])),
     (np.array([10., 20.]), Const(np.array([1., 2.])), np.array([[11], [22]])),
     (Const(np.array([10., 20.])), 2., np.array([[12], [22]])),
@@ -133,8 +108,7 @@ def test_can_do_addition(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 20.])), Const(np.array([1., 2.])),
-     np.array([[9], [18]])),
+    (Const(np.array([10., 20.])), Const(np.array([1., 2.])), np.array([[9], [18]])),
     (Const(np.array([10., 20.])), np.array([1., 2.]), np.array([[9], [18]])),
     (np.array([10., 20.]), Const(np.array([1., 2.])), np.array([[9], [18]])),
     (Const(np.array([10., 20.])), 2., np.array([[8], [18]])),
@@ -147,8 +121,7 @@ def test_can_do_subtraction(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([3., 2.])), Const(np.array([5., 7.])), np.array([[15], [14]
-                                                                    ])),
+    (Const(np.array([3., 2.])), Const(np.array([5., 7.])), np.array([[15], [14]])),
     (Const(np.array([3., 2.])), np.array([5., 7.]), np.array([[15], [14]])),
     (np.array([3., 2.]), Const(np.array([5., 7.])), np.array([[15], [14]])),
     (Const(np.array([3., 2.])), 5., np.array([[15], [10]])),
@@ -161,8 +134,7 @@ def test_can_do_multiplication(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([15., 10.])), Const(np.array([2., 4.])),
-     np.array([[7.5], [2.5]])),
+    (Const(np.array([15., 10.])), Const(np.array([2., 4.])), np.array([[7.5], [2.5]])),
     (Const(np.array([15., 10.])), np.array([2., 4.]), np.array([[7.5], [2.5]])),
     (np.array([15., 10.]), Const(np.array([2., 4.])), np.array([[7.5], [2.5]])),
     (Const(np.array([15., 10.])), 2., np.array([[7.5], [5.]])),
@@ -188,12 +160,9 @@ def test_can_do_integer_division(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([3., 2.])), Const(np.array([2., 0.5])),
-     np.array([[9], [1.4142135623730951]])),
-    (Const(np.array([3., 2.])), np.array([2., 0.5]),
-     np.array([[9], [1.4142135623730951]])),
-    (np.array([3., 2.]), Const(np.array([2., 0.5])),
-     np.array([[9], [1.4142135623730951]])),
+    (Const(np.array([3., 2.])), Const(np.array([2., 0.5])), np.array([[9], [1.4142135623730951]])),
+    (Const(np.array([3., 2.])), np.array([2., 0.5]), np.array([[9], [1.4142135623730951]])),
+    (np.array([3., 2.]), Const(np.array([2., 0.5])), np.array([[9], [1.4142135623730951]])),
     (Const(np.array([3., 2.])), 2., np.array([[9], [4]])),
     (3., Const(np.array([2., 0.5])), np.array([[9], [1.7320508075688772]])),
 ])
@@ -209,8 +178,7 @@ def test_can_do_compound_operations():
     v3 = 23.
 
     result = v1 * v2 - v2 / v1 + v3 * v2
-    assert (result.get_value() == np.array([[269.5, 333.6666666666667],
-                                            [472.6, 567.2857142857142]])).all()
+    assert (result.get_value() == np.array([[269.5, 333.6666666666667], [472.6, 567.2857142857142]])).all()
 
 
 ### Unary

--- a/keanu-python/tests/test_vertex_operations.py
+++ b/keanu-python/tests/test_vertex_operations.py
@@ -7,84 +7,96 @@ from keanu.vertex.base import Vertex
 ### Comparisons
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([1., 2.])), Const(np.array([1., -1.])), np.array([[True], [False]])),
-    (Const(np.array([1., 2.])), np.array([1., -1.]), np.array([[True], [False]])),
-    (np.array([1., 2.]), Const(np.array([1., -1.])), np.array([[True], [False]])),
-    (Const(np.array([1.])), 1., np.array([[True]])),
-    (Const(np.array([2.])), 1., np.array([[False]])),
-    (1., Const(np.array([1.])), np.array([[True]])),
-    (1., Const(np.array([-1.])), np.array([[False]])),
-    (Const(np.array([1., 2.])), Const(np.array([1.])), np.array([[True], [False]])),
-    (Const(np.array([1.])), Const(np.array([1., 2.])), np.array([[True], [False]])),
+    (Const(np.array([1., 2.])),    Const(np.array([1., -1.])), np.array([[True], [False]])),
+    (Const(np.array([1., 2.])),          np.array([1., -1.]) , np.array([[True], [False]])),
+    (      np.array([1., 2.]) ,    Const(np.array([1., -1.])), np.array([[True], [False]])),
+    (Const(np.array([1.    ])),                    1.        , np.array([[True]         ])),
+    (Const(np.array([    2.])),                    1.        , np.array([        [False]])),
+    (                    1.   ,    Const(np.array([1.     ])), np.array([[True]         ])),
+    (                    1.   ,    Const(np.array([    -1.])), np.array([        [False]])),
+    (Const(np.array([1., 2.])),    Const(np.array([1.     ])), np.array([[True], [False]])),
+    (Const(np.array([1.    ])),    Const(np.array([1.,  2.])), np.array([[True], [False]])),
 ])
+# yapf: enable
 def test_can_do_equal_to(lhs, rhs, expected_result):
     result = lhs == rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([1., 2.])), Const(np.array([1., -1.])), np.array([[False], [True]])),
-    (Const(np.array([1., 2.])), np.array([1., -1.]), np.array([[False], [True]])),
-    (np.array([1., 2.]), Const(np.array([1., -1.])), np.array([[False], [True]])),
-    (Const(np.array([1.])), 1., np.array([[False]])),
-    (Const(np.array([2.])), 1., np.array([[True]])),
-    (1., Const(np.array([1.])), np.array([[False]])),
-    (1., Const(np.array([-1.])), np.array([[True]])),
+    (Const(np.array([1., 2.])),       np.array([1., -1.]) , np.array([[False], [True]])),
+    (      np.array([1., 2.]) , Const(np.array([1., -1.])), np.array([[False], [True]])),
+    (Const(np.array([1.    ])),                 1.        , np.array([[False]        ])),
+    (Const(np.array([    2.])),                 1.        , np.array([         [True]])),
+    (                1.       , Const(np.array([1.     ])), np.array([[False]        ])),
+    (                1.       , Const(np.array([    -1.])), np.array([         [True]])),
 ])
+# yapf: enable
 def test_can_do_not_equal_to(lhs, rhs, expected_result):
     result = lhs != rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([10., 20.])), Const(np.array([15., 15.])), np.array([[False], [True]])),
-    (Const(np.array([10., 20.])), np.array([15., 15.]), np.array([[False], [True]])),
-    (np.array([10., 20.]), Const(np.array([15., 15.])), np.array([[False], [True]])),
-    (Const(np.array([10., 20.])), 15., np.array([[False], [True]])),
-    (10., Const(np.array([15., 5.])), np.array([[False], [True]])),
+    (Const(np.array([10., 20.])),       np.array([15., 15.]) , np.array([[False], [True]])),
+    (      np.array([10., 20.]) , Const(np.array([15., 15.])), np.array([[False], [True]])),
+    (Const(np.array([10., 20.])),                      15.   , np.array([[False], [True]])),
+    (                10.        , Const(np.array([15.,  5.])), np.array([[False], [True]])),
 ])
+# yapf: enable
 def test_can_do_greater_than(lhs, rhs, expected_result):
     result = lhs > rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([10., 20.])), Const(np.array([15., 15.])), np.array([[True], [False]])),
-    (Const(np.array([10., 20.])), np.array([15., 15.]), np.array([[True], [False]])),
-    (np.array([10., 20.]), Const(np.array([15., 15.])), np.array([[True], [False]])),
-    (Const(np.array([10., 20.])), 15., np.array([[True], [False]])),
-    (10., Const(np.array([15., 5.])), np.array([[True], [False]])),
+    (Const(np.array([10., 20.])),       np.array([15., 15.]) , np.array([[True], [False]])),
+    (      np.array([10., 20.]) , Const(np.array([15., 15.])), np.array([[True], [False]])),
+    (Const(np.array([10., 20.])),                      15.   , np.array([[True], [False]])),
+    (                10.        , Const(np.array([15.,  5.])), np.array([[True], [False]])),
 ])
+# yapf: enable
 def test_can_do_less_than(lhs, rhs, expected_result):
     result = lhs < rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])), np.array([[False], [True], [True]])),
-    (Const(np.array([10., 15., 20.])), np.array([15., 15., 15.]), np.array([[False], [True], [True]])),
-    (np.array([10., 15., 20.]), Const(np.array([15., 15., 15.])), np.array([[False], [True], [True]])),
-    (Const(np.array([10., 15., 20.])), 15., np.array([[False], [True], [True]])),
-    (10., Const(np.array([15., 10., 5.])), np.array([[False], [True], [True]])),
+    (Const(np.array([10., 15., 20.])),       np.array([15., 15., 15.]) , np.array([[False], [True], [True]])),
+    (      np.array([10., 15., 20.]) , Const(np.array([15., 15., 15.])), np.array([[False], [True], [True]])),
+    (Const(np.array([10., 15., 20.])),                           15.   , np.array([[False], [True], [True]])),
+    (                10.             , Const(np.array([15., 10.,  5.])), np.array([[False], [True], [True]])),
 ])
+# yapf: enable
 def test_can_do_greater_than_or_equal_to(lhs, rhs, expected_result):
     result = lhs >= rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])), np.array([[True], [True], [False]])),
-    (Const(np.array([10., 15., 20.])), np.array([15., 15., 15.]), np.array([[True], [True], [False]])),
-    (np.array([10., 15., 20.]), Const(np.array([15., 15., 15.])), np.array([[True], [True], [False]])),
-    (Const(np.array([10., 15., 20.])), 15., np.array([[True], [True], [False]])),
-    (10., Const(np.array([15., 10., 5.])), np.array([[True], [True], [False]])),
+    (Const(np.array([10., 15., 20.])),       np.array([15., 15., 15.]) , np.array([[True], [True], [False]])),
+    (      np.array([10., 15., 20.]) , Const(np.array([15., 15., 15.])), np.array([[True], [True], [False]])),
+    (Const(np.array([10., 15., 20.])),                           15.   , np.array([[True], [True], [False]])),
+    (                10.             , Const(np.array([15., 10.,  5.])), np.array([[True], [True], [False]])),
 ])
+# yapf: enable
 def test_can_do_less_than_or_equal_to(lhs, rhs, expected_result):
     result = lhs <= rhs
     assert type(result) == Vertex
@@ -94,78 +106,90 @@ def test_can_do_less_than_or_equal_to(lhs, rhs, expected_result):
 ### Arithmetic
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([10., 20.])), Const(np.array([1., 2.])), np.array([[11], [22]])),
-    (Const(np.array([10., 20.])), np.array([1., 2.]), np.array([[11], [22]])),
-    (np.array([10., 20.]), Const(np.array([1., 2.])), np.array([[11], [22]])),
-    (Const(np.array([10., 20.])), 2., np.array([[12], [22]])),
-    (10., Const(np.array([1., 2.])), np.array([[11], [12]])),
+    (Const(np.array([10., 20.])),       np.array([1., 2.]) , np.array([[11], [22]])),
+    (      np.array([10., 20.]) , Const(np.array([1., 2.])), np.array([[11], [22]])),
+    (Const(np.array([10., 20.])),                     2.   , np.array([[12], [22]])),
+    (                10.        , Const(np.array([1., 2.])), np.array([[11], [12]])),
 ])
+# yapf: enable
 def test_can_do_addition(lhs, rhs, expected_result):
     result = lhs + rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([10., 20.])), Const(np.array([1., 2.])), np.array([[9], [18]])),
-    (Const(np.array([10., 20.])), np.array([1., 2.]), np.array([[9], [18]])),
-    (np.array([10., 20.]), Const(np.array([1., 2.])), np.array([[9], [18]])),
-    (Const(np.array([10., 20.])), 2., np.array([[8], [18]])),
-    (10., Const(np.array([1., 2.])), np.array([[9], [8]])),
+    (Const(np.array([10., 20.])),       np.array([1., 2.]) , np.array([[9], [18]])),
+    (      np.array([10., 20.]) , Const(np.array([1., 2.])), np.array([[9], [18]])),
+    (Const(np.array([10., 20.])),                     2.   , np.array([[8], [18]])),
+    (                10.        , Const(np.array([1., 2.])), np.array([[9], [ 8]])),
 ])
+# yapf: enable
 def test_can_do_subtraction(lhs, rhs, expected_result):
     result = lhs - rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([3., 2.])), Const(np.array([5., 7.])), np.array([[15], [14]])),
-    (Const(np.array([3., 2.])), np.array([5., 7.]), np.array([[15], [14]])),
-    (np.array([3., 2.]), Const(np.array([5., 7.])), np.array([[15], [14]])),
-    (Const(np.array([3., 2.])), 5., np.array([[15], [10]])),
-    (3., Const(np.array([5., 7.])), np.array([[15], [21]])),
+    (Const(np.array([3., 2.])),       np.array([5., 7.]) , np.array([[15], [14]])),
+    (      np.array([3., 2.]) , Const(np.array([5., 7.])), np.array([[15], [14]])),
+    (Const(np.array([3., 2.])),                 5.       , np.array([[15], [10]])),
+    (                3.       , Const(np.array([5., 7.])), np.array([[15], [21]])),
 ])
+# yapf: enable
 def test_can_do_multiplication(lhs, rhs, expected_result):
     result = lhs * rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([15., 10.])), Const(np.array([2., 4.])), np.array([[7.5], [2.5]])),
-    (Const(np.array([15., 10.])), np.array([2., 4.]), np.array([[7.5], [2.5]])),
-    (np.array([15., 10.]), Const(np.array([2., 4.])), np.array([[7.5], [2.5]])),
-    (Const(np.array([15., 10.])), 2., np.array([[7.5], [5.]])),
-    (15., Const(np.array([2., 4.])), np.array([[7.5], [3.75]])),
+    (Const(np.array([15., 10.])), Const(np.array([2., 4.])), np.array([[7.5], [2.5 ]])),
+    (Const(np.array([15., 10.])),          np.array([2., 4.]) , np.array([[7.5], [2.5 ]])),
+    (      np.array([15., 10.]) , Const(np.array([2., 4.])), np.array([[7.5], [2.5 ]])),
+    (Const(np.array([15., 10.])),                 2.       , np.array([[7.5], [5.  ]])),
+    (                15.,         Const(np.array([2., 4.])), np.array([[7.5], [3.75]])),
 ])
+# yapf: enable
 def test_can_do_division(lhs, rhs, expected_result):
     result = lhs / rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([15, 10])), Const(np.array([2, 4])), np.array([[7], [2]])),
-    (Const(np.array([15, 10])), np.array([2, 4]), np.array([[7], [2]])),
-    (np.array([15, 10]), Const(np.array([2, 4])), np.array([[7], [2]])),
-    (Const(np.array([15, 10])), 2, np.array([[7], [5]])),
-    (15, Const(np.array([2, 4])), np.array([[7], [3]])),
+    (Const(np.array([15, 10])),       np.array([2, 4]) , np.array([[7], [2]])),
+    (      np.array([15, 10]) , Const(np.array([2, 4])), np.array([[7], [2]])),
+    (Const(np.array([15, 10])),                 2      , np.array([[7], [5]])),
+    (                15,        Const(np.array([2, 4])), np.array([[7], [3]])),
 ])
+# yapf: enable
 def test_can_do_integer_division(lhs, rhs, expected_result):
     result = lhs // rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
 
+# yapf: disable
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([3., 2.])), Const(np.array([2., 0.5])), np.array([[9], [1.4142135623730951]])),
-    (Const(np.array([3., 2.])), np.array([2., 0.5]), np.array([[9], [1.4142135623730951]])),
-    (np.array([3., 2.]), Const(np.array([2., 0.5])), np.array([[9], [1.4142135623730951]])),
-    (Const(np.array([3., 2.])), 2., np.array([[9], [4]])),
-    (3., Const(np.array([2., 0.5])), np.array([[9], [1.7320508075688772]])),
+    (Const(np.array([3., 2.])),       np.array([2., 0.5]) , np.array([[9], [1.4142135623730951]])),
+    (      np.array([3., 2.]) , Const(np.array([2., 0.5])), np.array([[9], [1.4142135623730951]])),
+    (Const(np.array([3., 2.])),                 2.        , np.array([[9], [4                 ]])),
+    (                3.,        Const(np.array([2., 0.5])), np.array([[9], [1.7320508075688772]])),
 ])
+# yapf: enable
 def test_can_do_pow(lhs, rhs, expected_result):
     result = lhs ** rhs
     assert type(result) == Vertex

--- a/keanu-python/tests/test_vertex_operations.py
+++ b/keanu-python/tests/test_vertex_operations.py
@@ -6,42 +6,58 @@ from keanu.vertex.base import Vertex
 
 ### Comparisons
 
-@pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([1., 2.])),    Const(np.array([1., -1.])), np.array([[True], [False]])),
-    (Const(np.array([1., 2.])),          np.array([1., -1.]) , np.array([[True], [False]])),
-    (      np.array([1., 2.]) ,    Const(np.array([1., -1.])), np.array([[True], [False]])),
-    (Const(np.array([1.    ])),                    1.        , np.array([[True]         ])),
-    (Const(np.array([    2.])),                    1.        , np.array([        [False]])),
-    (                    1.   ,    Const(np.array([1.     ])), np.array([[True]         ])),
-    (                    1.   ,    Const(np.array([    -1.])), np.array([        [False]])),
-    (Const(np.array([1., 2.])),    Const(np.array([1.     ])), np.array([[True], [False]])),
-    (Const(np.array([1.    ])),    Const(np.array([1.,  2.])), np.array([[True], [False]])),
-])
+
+@pytest.mark.parametrize(
+    "lhs, rhs, expected_result", [
+        (Const(np.array([1., 2.])), Const(np.array([1., -1.])),
+         np.array([[True], [False]])),
+        (Const(np.array([1., 2.])), np.array([1., -1.]),
+         np.array([[True], [False]])),
+        (np.array([1., 2.]), Const(np.array([1., -1.])),
+         np.array([[True], [False]])),
+        (Const(np.array([1.])), 1., np.array([[True]])),
+        (Const(np.array([2.])), 1., np.array([[False]])),
+        (1., Const(np.array([1.])), np.array([[True]])),
+        (1., Const(np.array([-1.])), np.array([[False]])),
+        (Const(np.array([1., 2.])), Const(np.array([1.])),
+         np.array([[True], [False]])),
+        (Const(np.array([1.])), Const(np.array([1., 2.])),
+         np.array([[True], [False]])),
+    ])
 def test_can_do_equal_to(lhs, rhs, expected_result):
     result = lhs == rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
-@pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([1., 2.])), Const(np.array([1., -1.])), np.array([[False], [True]])),
-    (Const(np.array([1., 2.])),       np.array([1., -1.]) , np.array([[False], [True]])),
-    (      np.array([1., 2.]) , Const(np.array([1., -1.])), np.array([[False], [True]])),
-    (Const(np.array([1.    ])),                 1.        , np.array([[False]        ])),
-    (Const(np.array([    2.])),                 1.        , np.array([         [True]])),
-    (                1.       , Const(np.array([1.     ])), np.array([[False]        ])),
-    (                1.       , Const(np.array([    -1.])), np.array([         [True]])),
-])
+
+@pytest.mark.parametrize(
+    "lhs, rhs, expected_result", [
+        (Const(np.array([1., 2.])), Const(np.array([1., -1.])),
+         np.array([[False], [True]])),
+        (Const(np.array([1., 2.])), np.array([1., -1.]),
+         np.array([[False], [True]])),
+        (np.array([1., 2.]), Const(np.array([1., -1.])),
+         np.array([[False], [True]])),
+        (Const(np.array([1.])), 1., np.array([[False]])),
+        (Const(np.array([2.])), 1., np.array([[True]])),
+        (1., Const(np.array([1.])), np.array([[False]])),
+        (1., Const(np.array([-1.])), np.array([[True]])),
+    ])
 def test_can_do_not_equal_to(lhs, rhs, expected_result):
     result = lhs != rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
+
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 20.])), Const(np.array([15., 15.])), np.array([[False], [True]])),
-    (Const(np.array([10., 20.])),       np.array([15., 15.]) , np.array([[False], [True]])),
-    (      np.array([10., 20.]) , Const(np.array([15., 15.])), np.array([[False], [True]])),
-    (Const(np.array([10., 20.])),                      15.   , np.array([[False], [True]])),
-    (                10.        , Const(np.array([15.,  5.])), np.array([[False], [True]])),
+    (Const(np.array([10., 20.])), Const(np.array([15., 15.])),
+     np.array([[False], [True]])),
+    (Const(np.array([10., 20.])), np.array([15., 15.]),
+     np.array([[False], [True]])),
+    (np.array([10., 20.]), Const(np.array([15., 15.])),
+     np.array([[False], [True]])),
+    (Const(np.array([10., 20.])), 15., np.array([[False], [True]])),
+    (10., Const(np.array([15., 5.])), np.array([[False], [True]])),
 ])
 def test_can_do_greater_than(lhs, rhs, expected_result):
     result = lhs > rhs
@@ -50,143 +66,160 @@ def test_can_do_greater_than(lhs, rhs, expected_result):
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 20.])), Const(np.array([15., 15.])), np.array([[True], [False]])),
-    (Const(np.array([10., 20.])),       np.array([15., 15.]) , np.array([[True], [False]])),
-    (      np.array([10., 20.]) , Const(np.array([15., 15.])), np.array([[True], [False]])),
-    (Const(np.array([10., 20.])),                      15.   , np.array([[True], [False]])),
-    (                10.        , Const(np.array([15.,  5.])), np.array([[True], [False]])),
+    (Const(np.array([10., 20.])), Const(np.array([15., 15.])),
+     np.array([[True], [False]])),
+    (Const(np.array([10., 20.])), np.array([15., 15.]),
+     np.array([[True], [False]])),
+    (np.array([10., 20.]), Const(np.array([15., 15.])),
+     np.array([[True], [False]])),
+    (Const(np.array([10., 20.])), 15., np.array([[True], [False]])),
+    (10., Const(np.array([15., 5.])), np.array([[True], [False]])),
 ])
 def test_can_do_less_than(lhs, rhs, expected_result):
     result = lhs < rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
+
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])), np.array([[False], [True], [True]])),
-    (Const(np.array([10., 15., 20.])),       np.array([15., 15., 15.]) , np.array([[False], [True], [True]])),
-    (      np.array([10., 15., 20.]) , Const(np.array([15., 15., 15.])), np.array([[False], [True], [True]])),
-    (Const(np.array([10., 15., 20.])),                           15.   , np.array([[False], [True], [True]])),
-    (                10.             , Const(np.array([15., 10.,  5.])), np.array([[False], [True], [True]])),
+    (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])),
+     np.array([[False], [True], [True]])),
+    (Const(np.array([10., 15., 20.])), np.array([15., 15., 15.]),
+     np.array([[False], [True], [True]])),
+    (np.array([10., 15., 20.]), Const(np.array([15., 15., 15.])),
+     np.array([[False], [True], [True]])),
+    (Const(np.array([10., 15., 20.])), 15., np.array([[False], [True], [True]
+                                                     ])),
+    (10., Const(np.array([15., 10., 5.])), np.array([[False], [True], [True]])),
 ])
 def test_can_do_greater_than_or_equal_to(lhs, rhs, expected_result):
     result = lhs >= rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
+
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])), np.array([[True], [True], [False]])),
-    (Const(np.array([10., 15., 20.])),       np.array([15., 15., 15.]) , np.array([[True], [True], [False]])),
-    (      np.array([10., 15., 20.]) , Const(np.array([15., 15., 15.])), np.array([[True], [True], [False]])),
-    (Const(np.array([10., 15., 20.])),                           15.   , np.array([[True], [True], [False]])),
-    (                10.             , Const(np.array([15., 10.,  5.])), np.array([[True], [True], [False]])),
+    (Const(np.array([10., 15., 20.])), Const(np.array([15., 15., 15.])),
+     np.array([[True], [True], [False]])),
+    (Const(np.array([10., 15., 20.])), np.array([15., 15., 15.]),
+     np.array([[True], [True], [False]])),
+    (np.array([10., 15., 20.]), Const(np.array([15., 15., 15.])),
+     np.array([[True], [True], [False]])),
+    (Const(np.array([10., 15., 20.])), 15., np.array([[True], [True], [False]
+                                                     ])),
+    (10., Const(np.array([15., 10., 5.])), np.array([[True], [True], [False]])),
 ])
 def test_can_do_less_than_or_equal_to(lhs, rhs, expected_result):
     result = lhs <= rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
+
 ### Arithmetic
 
+
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 20.])), Const(np.array([1., 2.])), np.array([[11], [22]])),
-    (Const(np.array([10., 20.])),       np.array([1., 2.]) , np.array([[11], [22]])),
-    (      np.array([10., 20.]) , Const(np.array([1., 2.])), np.array([[11], [22]])),
-    (Const(np.array([10., 20.])),                     2.   , np.array([[12], [22]])),
-    (                10.        , Const(np.array([1., 2.])), np.array([[11], [12]])),
+    (Const(np.array([10., 20.])), Const(np.array([1., 2.])),
+     np.array([[11], [22]])),
+    (Const(np.array([10., 20.])), np.array([1., 2.]), np.array([[11], [22]])),
+    (np.array([10., 20.]), Const(np.array([1., 2.])), np.array([[11], [22]])),
+    (Const(np.array([10., 20.])), 2., np.array([[12], [22]])),
+    (10., Const(np.array([1., 2.])), np.array([[11], [12]])),
 ])
 def test_can_do_addition(lhs, rhs, expected_result):
     result = lhs + rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
+
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([10., 20.])), Const(np.array([1., 2.])), np.array([[9], [18]])),
-    (Const(np.array([10., 20.])),       np.array([1., 2.]) , np.array([[9], [18]])),
-    (      np.array([10., 20.]) , Const(np.array([1., 2.])), np.array([[9], [18]])),
-    (Const(np.array([10., 20.])),                     2.   , np.array([[8], [18]])),
-    (                10.        , Const(np.array([1., 2.])), np.array([[9], [ 8]])),
+    (Const(np.array([10., 20.])), Const(np.array([1., 2.])),
+     np.array([[9], [18]])),
+    (Const(np.array([10., 20.])), np.array([1., 2.]), np.array([[9], [18]])),
+    (np.array([10., 20.]), Const(np.array([1., 2.])), np.array([[9], [18]])),
+    (Const(np.array([10., 20.])), 2., np.array([[8], [18]])),
+    (10., Const(np.array([1., 2.])), np.array([[9], [8]])),
 ])
 def test_can_do_subtraction(lhs, rhs, expected_result):
     result = lhs - rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
+
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([3., 2.])), Const(np.array([5., 7.])), np.array([[15], [14]])),
-    (Const(np.array([3., 2.])),       np.array([5., 7.]) , np.array([[15], [14]])),
-    (      np.array([3., 2.]) , Const(np.array([5., 7.])), np.array([[15], [14]])),
-    (Const(np.array([3., 2.])),                 5.       , np.array([[15], [10]])),
-    (                3.       , Const(np.array([5., 7.])), np.array([[15], [21]])),
+    (Const(np.array([3., 2.])), Const(np.array([5., 7.])), np.array([[15], [14]
+                                                                    ])),
+    (Const(np.array([3., 2.])), np.array([5., 7.]), np.array([[15], [14]])),
+    (np.array([3., 2.]), Const(np.array([5., 7.])), np.array([[15], [14]])),
+    (Const(np.array([3., 2.])), 5., np.array([[15], [10]])),
+    (3., Const(np.array([5., 7.])), np.array([[15], [21]])),
 ])
 def test_can_do_multiplication(lhs, rhs, expected_result):
     result = lhs * rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
+
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([15., 10.])), Const(np.array([2., 4.])), np.array([[7.5], [2.5 ]])),
-    (Const(np.array([15., 10.])),          np.array([2., 4.]) , np.array([[7.5], [2.5 ]])),
-    (      np.array([15., 10.]) , Const(np.array([2., 4.])), np.array([[7.5], [2.5 ]])),
-    (Const(np.array([15., 10.])),                 2.       , np.array([[7.5], [5.  ]])),
-    (                15.,         Const(np.array([2., 4.])), np.array([[7.5], [3.75]])),
+    (Const(np.array([15., 10.])), Const(np.array([2., 4.])),
+     np.array([[7.5], [2.5]])),
+    (Const(np.array([15., 10.])), np.array([2., 4.]), np.array([[7.5], [2.5]])),
+    (np.array([15., 10.]), Const(np.array([2., 4.])), np.array([[7.5], [2.5]])),
+    (Const(np.array([15., 10.])), 2., np.array([[7.5], [5.]])),
+    (15., Const(np.array([2., 4.])), np.array([[7.5], [3.75]])),
 ])
 def test_can_do_division(lhs, rhs, expected_result):
     result = lhs / rhs
     assert type(result) == Vertex
-    assert (result.get_value() == expected_result).all()    
+    assert (result.get_value() == expected_result).all()
+
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
     (Const(np.array([15, 10])), Const(np.array([2, 4])), np.array([[7], [2]])),
-    (Const(np.array([15, 10])),       np.array([2, 4]) , np.array([[7], [2]])),
-    (      np.array([15, 10]) , Const(np.array([2, 4])), np.array([[7], [2]])),
-    (Const(np.array([15, 10])),                 2      , np.array([[7], [5]])),
-    (                15,        Const(np.array([2, 4])), np.array([[7], [3]])),
+    (Const(np.array([15, 10])), np.array([2, 4]), np.array([[7], [2]])),
+    (np.array([15, 10]), Const(np.array([2, 4])), np.array([[7], [2]])),
+    (Const(np.array([15, 10])), 2, np.array([[7], [5]])),
+    (15, Const(np.array([2, 4])), np.array([[7], [3]])),
 ])
 def test_can_do_integer_division(lhs, rhs, expected_result):
     result = lhs // rhs
     assert type(result) == Vertex
-    assert (result.get_value() == expected_result).all()    
+    assert (result.get_value() == expected_result).all()
 
 
 @pytest.mark.parametrize("lhs, rhs, expected_result", [
-    (Const(np.array([3., 2.])), Const(np.array([2., 0.5])), np.array([[9], [1.4142135623730951]])),
-    (Const(np.array([3., 2.])),       np.array([2., 0.5]) , np.array([[9], [1.4142135623730951]])),
-    (      np.array([3., 2.]) , Const(np.array([2., 0.5])), np.array([[9], [1.4142135623730951]])),
-    (Const(np.array([3., 2.])),                 2.        , np.array([[9], [4                 ]])),
-    (                3.,        Const(np.array([2., 0.5])), np.array([[9], [1.7320508075688772]])),
+    (Const(np.array([3., 2.])), Const(np.array([2., 0.5])),
+     np.array([[9], [1.4142135623730951]])),
+    (Const(np.array([3., 2.])), np.array([2., 0.5]),
+     np.array([[9], [1.4142135623730951]])),
+    (np.array([3., 2.]), Const(np.array([2., 0.5])),
+     np.array([[9], [1.4142135623730951]])),
+    (Const(np.array([3., 2.])), 2., np.array([[9], [4]])),
+    (3., Const(np.array([2., 0.5])), np.array([[9], [1.7320508075688772]])),
 ])
 def test_can_do_pow(lhs, rhs, expected_result):
-    result = lhs ** rhs
+    result = lhs**rhs
     assert type(result) == Vertex
     assert (result.get_value() == expected_result).all()
 
+
 def test_can_do_compound_operations():
-    v1 = Const(np.array([
-        [2., 3.], 
-        [5., 7.]
-        ]))
-    v2 = np.array([
-        [11., 13.], 
-        [17., 19.]]
-        )
+    v1 = Const(np.array([[2., 3.], [5., 7.]]))
+    v2 = np.array([[11., 13.], [17., 19.]])
     v3 = 23.
 
     result = v1 * v2 - v2 / v1 + v3 * v2
-    assert (result.get_value() == np.array([[269.5, 333.6666666666667], [472.6, 567.2857142857142]])).all()
+    assert (result.get_value() == np.array([[269.5, 333.6666666666667],
+                                            [472.6, 567.2857142857142]])).all()
 
 
 ### Unary
 
-def test_can_do_abs():
-    v = Const(np.array([
-        [ 2., -3.], 
-        [-5.,  7.]
-        ]))
 
-    expected = np.array([
-        [ 2.,  3.], 
-        [ 5.,  7.]
-        ])
+def test_can_do_abs():
+    v = Const(np.array([[2., -3.], [-5., 7.]]))
+
+    expected = np.array([[2., 3.], [5., 7.]])
 
     result = abs(v)
     assert type(result) == Vertex
@@ -194,15 +227,9 @@ def test_can_do_abs():
 
 
 def test_can_do_round():
-    v = Const(np.array([
-        [ 4.4, 4.5,   5.5,  6.6], 
-        [-4.4, -4.5, -5.5, -6.6]
-        ]))
+    v = Const(np.array([[4.4, 4.5, 5.5, 6.6], [-4.4, -4.5, -5.5, -6.6]]))
 
-    expected = np.array([
-        [ 4.,  5.,  6.,  7.], 
-        [-4., -5., -6., -7.]
-        ])
+    expected = np.array([[4., 5., 6., 7.], [-4., -5., -6., -7.]])
 
     result = round(v)
     assert type(result) == Vertex
@@ -210,15 +237,9 @@ def test_can_do_round():
 
 
 def test_can_do_floor():
-    v = Const(np.array([
-        [ 4.4, 4.5,   5.5,  6.6], 
-        [-4.4, -4.5, -5.5, -6.6]
-        ]))
+    v = Const(np.array([[4.4, 4.5, 5.5, 6.6], [-4.4, -4.5, -5.5, -6.6]]))
 
-    expected = np.array([
-        [ 4.,  4.,  5.,  6.], 
-        [-5., -5., -6., -7.]
-        ])
+    expected = np.array([[4., 4., 5., 6.], [-5., -5., -6., -7.]])
 
     result = math.floor(v)
     assert type(result) == Vertex
@@ -226,16 +247,10 @@ def test_can_do_floor():
 
 
 def test_can_do_ceil():
-    v = Const(np.array([
-        [ 4.4, 4.5,   5.5,  6.6], 
-        [-4.4, -4.5, -5.5, -6.6]
-        ]))
+    v = Const(np.array([[4.4, 4.5, 5.5, 6.6], [-4.4, -4.5, -5.5, -6.6]]))
 
-    expected = np.array([
-        [ 5.,  5.,  6.,  7.], 
-        [-4., -4., -5., -6.]
-        ])
+    expected = np.array([[5., 5., 6., 7.], [-4., -4., -5., -6.]])
 
     result = math.ceil(v)
     assert type(result) == Vertex
-    assert (result.get_value() == expected).all()        
+    assert (result.get_value() == expected).all()


### PR DESCRIPTION
Added a build step to run [yapf](https://github.com/google/yapf) to enforce a python style. 

- Format check runs prior to tests so that builds fail as early as possible.
- Added task `formatApply` to automatically fix any formatting issues.

Have chosen to use the `google` style. However, this can be changed and customised to select a project preferred style.