### PR TITLE
Codegen javadoc to json classpath

### DIFF
--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -19,15 +19,14 @@ dependencies {
 }
 
 task saveJavadocStringsToFile(type: Javadoc) {
-    source = fileTree(dir:'../keanu-project', includes:["**/*.java"])
+    source = project(':keanu-project').sourceSets.main.allJava
 
     def docletClasspath = rootProject.compileJava.classpath.files.toList()
     docletClasspath.add(new File(layout.projectDirectory.get().path + "/build/classes/java/main"))
     options.setDocletpath(docletClasspath)
     options.setDoclet("io.improbable.keanu.codegen.python.KeanuProjectDoclet")
 
-    def mainClasspath = fileTree(dir:'../keanu-project').files.toList()
-    options.setClasspath(mainClasspath)
+    classpath = project(':keanu-project').sourceSets.main.runtimeClasspath
 }
 
 task runCodeGeneration (type: JavaExec) {

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -27,6 +27,7 @@ task saveJavadocStringsToFile(type: Javadoc) {
     options.setDoclet("io.improbable.keanu.codegen.python.KeanuProjectDoclet")
 
     classpath = project(':keanu-project').sourceSets.main.runtimeClasspath
+    classpath += project(':keanu-project').sourceSets.main.compileClasspath
 }
 
 task runCodeGeneration (type: JavaExec) {


### PR DESCRIPTION
This was causing the problem where `error: package com.google.protobuf does not exist` was reported from the `codegen` project.

## Cause
The task `saveJavadocStringsToFile` analysed the source. However, it would generate warnings whenever an unknown dependency was encountered. The dependencies on the `keanu-project` classpath were not being correctly included in this task. The warnings were capped to 100, therefore only showing the protobuf issues.

## Solution
- Stop processing generated and test sources. These are not used in the docs, so no need to process. Removes the need for including the compile classpath.
- Set the classpath for javadoc task to the runtime classpath of `keanu-project`.
- Include the compile class path of `keanu-project` in order to support Lombok.