### PR TITLE
Seed random for python coal mining test

### DIFF
--- a/keanu-python/tests/test_coal_mining.py
+++ b/keanu-python/tests/test_coal_mining.py
@@ -1,10 +1,11 @@
 import numpy as np
 from examples import CoalMining
-from keanu import BayesNet
+from keanu import BayesNet, KeanuRandom
 from keanu.algorithm import sample
 
 
 def test_coalmining():
+    KeanuRandom.set_default_random_seed(1)
     coal_mining = CoalMining()
     model = coal_mining.model()
 


### PR DESCRIPTION
Sometimes the python coal mining test fails. This ensures that the random is seeded for this test so that it produces deterministic results.