### PR TITLE
added a task to delete the python classpath before populating it

### DIFF
--- a/keanu-project/build.gradle
+++ b/keanu-project/build.gradle
@@ -149,8 +149,12 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
+task deletePythonClasspath(type: Delete) {
+    delete fileTree("../keanu-python/keanu/classpath/")
+}
 task copyJarsIntoPythonClasspath(type: Copy) {
     dependsOn(build)
+    dependsOn(deletePythonClasspath)
     into "$rootDir/keanu-python/keanu/classpath/"
     from jar
     from configurations.compile

--- a/keanu-project/build.gradle
+++ b/keanu-project/build.gradle
@@ -152,6 +152,7 @@ task sourcesJar(type: Jar) {
 task deletePythonClasspath(type: Delete) {
     delete fileTree("../keanu-python/keanu/classpath/")
 }
+
 task copyJarsIntoPythonClasspath(type: Copy) {
     dependsOn(build)
     dependsOn(deletePythonClasspath)


### PR DESCRIPTION
Just a little change because the python classpath was getting populated with multiple versions of the `keanu` jar which was a bad thing.