### PR TITLE
fix return type of Tensor._to_ndarray

### DIFF
--- a/keanu-python/keanu/tensor.py
+++ b/keanu-python/keanu/tensor.py
@@ -38,14 +38,11 @@ class Tensor(JavaObjectWrapper):
 
     @staticmethod
     def __infer_tensor_ctor_from_ndarray(ndarray: numpy_types) -> Any:
-        if len(ndarray) == 0:
-            raise ValueError("Cannot infer type because the ndarray is empty")
-
-        if isinstance(ndarray.item(0), runtime_bool_types):
+        if ndarray.dtype in runtime_bool_types:
             return k.jvm_view().BooleanTensor.create
-        elif isinstance(ndarray.item(0), runtime_int_types):
+        elif ndarray.dtype in runtime_int_types:
             return k.jvm_view().IntegerTensor.create
-        elif isinstance(ndarray.item(0), runtime_float_types):
+        elif ndarray.dtype in runtime_float_types:
             return k.jvm_view().DoubleTensor.create
         else:
             raise NotImplementedError("Generic types in an ndarray are not supported. Was given {}".format(
@@ -65,6 +62,6 @@ class Tensor(JavaObjectWrapper):
     @staticmethod
     def _to_ndarray(java_tensor: Any) -> numpy_types:
         if java_tensor.getRank() == 0:
-            return java_tensor.scalar()
+            return np.array(java_tensor.scalar())
         else:
             return np.array(list(java_tensor.asFlatArray())).reshape(java_tensor.getShape())

--- a/keanu-python/keanu/vertex/const.py
+++ b/keanu-python/keanu/vertex/const.py
@@ -28,10 +28,14 @@ def Const(t: tensor_arg_types) -> Vertex:
 
 
 def __infer_const_ctor_from_ndarray(ndarray: numpy_types) -> Callable:
-    if len(ndarray) == 0:
-        raise ValueError("Cannot infer type because the ndarray is empty")
-
-    return __infer_const_ctor_from_scalar(ndarray.item(0))
+    if ndarray.dtype in runtime_bool_types:
+        return ConstantBool
+    elif ndarray.dtype in runtime_int_types:
+        return ConstantInteger
+    elif ndarray.dtype in runtime_float_types:
+        return ConstantDouble
+    else:
+        raise NotImplementedError("Generic types in an ndarray are not supported. Was given {}".format(ndarray.dtype))
 
 
 def __infer_const_ctor_from_scalar(scalar: np.generic) -> Callable:

--- a/keanu-python/tests/test_const.py
+++ b/keanu-python/tests/test_const.py
@@ -72,7 +72,7 @@ def test_const_does_not_take_generic_ndarray(generic):
     with pytest.raises(NotImplementedError) as excinfo:
         Const(ndarray)
 
-    assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given {}".format(type(generic))
+    assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given object"
 
 
 def test_const_does_not_take_generic(generic):
@@ -90,7 +90,7 @@ def test_const_does_not_take_empty_ndarray():
     with pytest.raises(ValueError) as excinfo:
         Const(ndarray)
 
-    assert str(excinfo.value) == "Cannot infer type because the ndarray is empty"
+    assert str(excinfo.value) == "Cannot infer type because array is empty"
 
 
 def test_const_takes_ndarray_of_rank_one():

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -35,7 +35,9 @@ def test_sampling_returns_dict_of_list_of_ndarrays_for_vertices_in_sample_from(a
 
         assert len(vertex_samples) == draws
         assert type(vertex_samples) == list
-        assert all(type(sample) == float for sample in vertex_samples)
+        assert all(type(sample) == np.ndarray for sample in vertex_samples)
+        assert all(sample.dtype == float for sample in vertex_samples)
+        assert all(sample.shape == () for sample in vertex_samples)
 
 
 def test_dropping_samples(net: BayesNet) -> None:

--- a/keanu-python/tests/test_tensor.py
+++ b/keanu-python/tests/test_tensor.py
@@ -81,11 +81,11 @@ def test_cannot_pass_generic_ndarray_to_Tensor(generic):
     assert str(excinfo.value) == "Generic types in an ndarray are not supported. Was given {}".format(type(generic))
 
 
-def test_cannot_pass_empty_ndarray_to_Tensor():
+def test_can_pass_empty_ndarray_to_Tensor():
     with pytest.raises(ValueError) as excinfo:
         Tensor(np.array([]))
 
-    assert str(excinfo.value) == "Cannot infer type because the ndarray is empty"
+    assert str(excinfo.value) == "Cannot infer type because array is empty"
 
 
 @pytest.mark.parametrize("value", [(np.array([[1, 2], [3, 4]])), np.array([3])])

--- a/keanu-python/tests/test_vertex.py
+++ b/keanu-python/tests/test_vertex.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from keanu.context import KeanuContext
+from keanu.vartypes import numpy_types
 from keanu.vertex import Gaussian, Const, UniformInt, Bernoulli
 from keanu.vertex.base import Vertex
 
@@ -18,7 +19,9 @@ def jvm_view():
 def assert_vertex_value_equals_scalar(vertex, expected_type, scalar):
     vertex_value = vertex.get_value()
     assert vertex_value == scalar
-    assert type(vertex_value) == expected_type
+    assert type(vertex_value) == numpy_types
+    assert vertex_value.shape == ()
+    assert vertex_value.dtype == expected_type
 
 
 def assert_vertex_value_equals_ndarray(vertex, expected_type, ndarray):
@@ -39,7 +42,9 @@ def test_can_pass_scalar_to_vertex(jvm_view):
     gaussian = Vertex(jvm_view.GaussianVertex, 0., 1.)
     sample = gaussian.sample()
 
-    assert type(sample) == float
+    assert type(sample) == numpy_types
+    assert sample.shape == ()
+    assert sample.dtype == float
 
 
 def test_can_pass_ndarray_to_vertex(jvm_view):
@@ -68,7 +73,9 @@ def test_can_pass_vertex_to_vertex(jvm_view):
     gaussian = Vertex(jvm_view.GaussianVertex, mu, 1.)
     sample = gaussian.sample()
 
-    assert isinstance(sample, float)
+    assert type(sample) == numpy_types
+    assert sample.shape == ()
+    assert sample.dtype == float
 
 
 def test_can_pass_array_to_vertex(jvm_view):
@@ -120,7 +127,9 @@ def test_scalar_vertex_value_is_a_numpy_array():
     scalar = 1.
     vertex = Const(scalar)
     value = vertex.get_value()
-    assert type(value) == float
+    assert type(value) == numpy_types
+    assert value.shape == ()
+    assert value.dtype == float
     assert value == scalar
 
 


### PR DESCRIPTION
fixed bug: Tensor._to_ndarray was returning a primitive type if the java tensor was rank 0