### PR TITLE
Numeric stability NUTS bug

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTSSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTSSampler.java
@@ -100,7 +100,7 @@ public class NUTSSampler implements SamplingAlgorithm {
 
         double logOfMasterPMinusMomentumBeforeLeapfrog = tree.logOfMasterPAtAcceptedPosition - 0.5 * dotProduct(tree.momentumForward);
 
-        double u = random.nextDouble() * Math.exp(logOfMasterPMinusMomentumBeforeLeapfrog);
+        double logU = Math.log(random.nextDouble()) + logOfMasterPMinusMomentumBeforeLeapfrog;
 
         int treeHeight = 0;
         tree.shouldContinueFlag = true;
@@ -117,7 +117,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                 probabilisticVertices,
                 logProbGradientCalculator,
                 sampleFromVertices,
-                u,
+                logU,
                 buildDirection,
                 treeHeight,
                 stepSize,
@@ -167,7 +167,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                                                   List<Vertex> probabilisticVertices,
                                                   LogProbGradientCalculator logProbGradientCalculator,
                                                   final List<? extends Vertex> sampleFromVertices,
-                                                  double u,
+                                                  double logU,
                                                   int buildDirection,
                                                   int treeHeight,
                                                   double epsilon,
@@ -186,7 +186,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                 currentTree.positionBackward,
                 currentTree.gradientBackward,
                 currentTree.momentumBackward,
-                u,
+                logU,
                 buildDirection,
                 treeHeight,
                 epsilon,
@@ -208,7 +208,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                 currentTree.positionForward,
                 currentTree.gradientForward,
                 currentTree.momentumForward,
-                u,
+                logU,
                 buildDirection,
                 treeHeight,
                 epsilon,
@@ -231,7 +231,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                                        Map<VertexId, DoubleTensor> position,
                                        Map<VertexId, DoubleTensor> gradient,
                                        Map<VertexId, DoubleTensor> momentum,
-                                       double u,
+                                       double logU,
                                        int buildDirection,
                                        int treeHeight,
                                        double epsilon,
@@ -248,7 +248,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                 position,
                 gradient,
                 momentum,
-                u,
+                logU,
                 buildDirection,
                 epsilon,
                 logOfMasterPMinusMomentumBeforeLeapfrog
@@ -265,7 +265,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                 position,
                 gradient,
                 momentum,
-                u,
+                logU,
                 buildDirection,
                 treeHeight - 1,
                 epsilon,
@@ -282,7 +282,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                     probabilisticVertices,
                     logProbGradientCalculator,
                     sampleFromVertices,
-                    u,
+                    logU,
                     buildDirection,
                     treeHeight - 1,
                     epsilon,
@@ -322,7 +322,7 @@ public class NUTSSampler implements SamplingAlgorithm {
                                                Map<VertexId, DoubleTensor> position,
                                                Map<VertexId, DoubleTensor> gradient,
                                                Map<VertexId, DoubleTensor> momentum,
-                                               double u,
+                                               double logU,
                                                int buildDirection,
                                                double epsilon,
                                                double logOfMasterPMinusMomentumBeforeLeapfrog) {
@@ -339,8 +339,8 @@ public class NUTSSampler implements SamplingAlgorithm {
         final double logOfMasterPAfterLeapfrog = ProbabilityCalculator.calculateLogProbFor(probabilisticVertices);
 
         final double logOfMasterPMinusMomentum = logOfMasterPAfterLeapfrog - 0.5 * dotProduct(leapfrog.momentum);
-        final int acceptedLeapfrogCount = u <= Math.exp(logOfMasterPMinusMomentum) ? 1 : 0;
-        final boolean shouldContinueFlag = u < Math.exp(DELTA_MAX + logOfMasterPMinusMomentum);
+        final int acceptedLeapfrogCount = logU <= logOfMasterPMinusMomentum ? 1 : 0;
+        final boolean shouldContinueFlag = logU < DELTA_MAX + logOfMasterPMinusMomentum;
 
         final Map<VertexId, ?> sampleAtAcceptedPosition = takeSample(sampleFromVertices);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/HamiltonianTest.java
@@ -33,17 +33,18 @@ public class HamiltonianTest {
     public void samplesGaussian() {
         double mu = 0.0;
         double sigma = 1.0;
-        BayesianNetwork simpleGaussian = MCMCTestDistributions.createSimpleGaussian(mu, sigma, KeanuRandom.getDefaultRandom());
+        KeanuRandom random = KeanuRandom.getDefaultRandom();
+        BayesianNetwork simpleGaussian = MCMCTestDistributions.createSimpleGaussian(mu, sigma, random.nextGaussian(0, 1), random);
 
         Hamiltonian hmc = Hamiltonian.builder()
-            .leapFrogCount(10)
-            .stepSize(0.4)
+            .leapFrogCount(20)
+            .stepSize(0.05)
             .build();
 
         NetworkSamples posteriorSamples = hmc.getPosteriorSamples(
             simpleGaussian,
             simpleGaussian.getLatentVertices(),
-            1000
+            2000
         );
 
         Vertex<DoubleTensor> vertex = simpleGaussian.getContinuousLatentVertices().get(0);

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MCMCTestDistributions.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/MCMCTestDistributions.java
@@ -14,9 +14,9 @@ import static org.junit.Assert.assertTrue;
 
 public class MCMCTestDistributions {
 
-    public static BayesianNetwork createSimpleGaussian(double mu, double sigma, KeanuRandom random) {
+    public static BayesianNetwork createSimpleGaussian(double mu, double sigma, double initialValue, KeanuRandom random) {
         GaussianVertex A = new GaussianVertex(new long[]{2, 1}, mu, sigma);
-        A.setAndCascade(A.sample(random));
+        A.setAndCascade(initialValue);
         return new BayesianNetwork(A.getConnectedGraph());
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NUTSTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NUTSTest.java
@@ -30,17 +30,17 @@ public class NUTSTest {
     public void samplesGaussian() {
         double mu = 0.0;
         double sigma = 1.0;
-        BayesianNetwork simpleGaussian = MCMCTestDistributions.createSimpleGaussian(mu, sigma, random);
+        BayesianNetwork simpleGaussian = MCMCTestDistributions.createSimpleGaussian(mu, sigma, 3, random);
 
         NUTS nuts = NUTS.builder()
-            .adaptCount(50)
+            .adaptCount(2000)
             .random(random)
             .build();
 
         NetworkSamples posteriorSamples = nuts.getPosteriorSamples(
             simpleGaussian,
             simpleGaussian.getLatentVertices(),
-            1000
+            2000
         );
 
         Vertex<DoubleTensor> vertex = simpleGaussian.getContinuousLatentVertices().get(0);
@@ -51,19 +51,20 @@ public class NUTSTest {
     @Test
     public void samplesContinuousPrior() {
 
-        BayesianNetwork bayesNet = MCMCTestDistributions.createSumOfGaussianDistribution(20.0, 1.0, 46., 20.0);
+        BayesianNetwork bayesNet = MCMCTestDistributions.createSumOfGaussianDistribution(20.0, 1.0, 46., 15.0);
 
+        int sampleCount = 6000;
         NUTS nuts = NUTS.builder()
-            .adaptCount(0)
-            .maxTreeHeight(8)
+            .adaptCount(sampleCount)
+            .maxTreeHeight(4)
             .random(random)
             .build();
 
         NetworkSamples posteriorSamples = nuts.getPosteriorSamples(
             bayesNet,
             bayesNet.getLatentVertices(),
-            3000
-        );
+            sampleCount
+        ).drop((int) (sampleCount * 0.25));
 
         Vertex<DoubleTensor> A = bayesNet.getContinuousLatentVertices().get(0);
         Vertex<DoubleTensor> B = bayesNet.getContinuousLatentVertices().get(1);
@@ -77,7 +78,7 @@ public class NUTSTest {
         BayesianNetwork donutBayesNet = MCMCTestDistributions.create2DDonutDistribution();
 
         NUTS nuts = NUTS.builder()
-            .adaptCount(100)
+            .adaptCount(1000)
             .random(random)
             .build();
 


### PR DESCRIPTION
We are converting a potentially very negative value from log space into normal space. This can cause it to go to zero and wreck the algorithm. This PR keeps the number in log space and therefore avoids the going to zero problem.