### PR TITLE
Feature/spotless python rules

### DIFF
--- a/docs/bin/snippet_writer.py
+++ b/docs/bin/snippet_writer.py
@@ -18,12 +18,12 @@ import logging
 error_code = 0
 
 def record_error(output_str):
-    logging.error(output_str)
+    logging.getLogger("keanu").error(output_str)
     global error_code
     error_code = 1
 
 def printd(debug_str):
-    logging.debug(debug_str)
+    logging.getLogger("keanu").debug(debug_str)
 
 def read_file_snippets(file, snippet_store):
     """Parse a file and add all snippets to the snippet_store dictionary"""

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -11,5 +11,6 @@ spotless {
         target '**/*.py'
 
         replaceRegex 'loggers may not use root context', /logging.(debug|info|warning|error|critical|exception|log)/, 'logging.getLogger("keanu").$1'
+        replaceRegex 'all tests must be type annotated', /def test_([a-z_]+)\(\):/, 'def test_$1() -> None:'
     }
 }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -6,4 +6,10 @@ spotless {
         removeUnusedImports()
         importOrder '', 'javax', 'java', 'static '
     }
+
+    format 'python', {
+        target '**/*.py'
+
+        replaceRegex 'loggers may not use root context', /logging.warning/, 'logging.getLogger("keanu").warning'
+    }
 }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -10,6 +10,6 @@ spotless {
     format 'python', {
         target '**/*.py'
 
-        replaceRegex 'loggers may not use root context', /logging.warning/, 'logging.getLogger("keanu").warning'
+        replaceRegex 'loggers may not use root context', /logging.(debug|info|warning|error|critical|exception|log)/, 'logging.getLogger("keanu").$1'
     }
 }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -115,6 +115,7 @@ task populateExclusionPaths {
 
 task formatApply {
     mustRunAfter preparePythonEnvironment // this is a dependency but only needs to be run once
+    mustRunAfter ':spotlessPythonApply'   // spotless does some checks of the python code too
     dependsOn populateExclusionPaths
 
     doLast {
@@ -127,6 +128,7 @@ task formatApply {
 
 task formatCheck {
     mustRunAfter preparePythonEnvironment // this is a dependency but only needs to be run once
+    mustRunAfter ':spotlessPythonCheck'   // spotless does some checks of the python code too
     dependsOn populateExclusionPaths
 
     doLast {

--- a/keanu-python/keanu/base.py
+++ b/keanu-python/keanu/base.py
@@ -23,7 +23,8 @@ class JavaObjectWrapper:
             raise AttributeError("{} has no attribute {}".format(self.__class__, k))
 
         java_name = _to_camel_case_name(k)
-        logging.warning("\"{}\" is not implemented so Java API \"{}\" was called directly instead".format(k, java_name))
+        logging.getLogger("keanu").warning(
+            "\"{}\" is not implemented so Java API \"{}\" was called directly instead".format(k, java_name))
         return self.unwrap().__getattr__(java_name)
 
     def unwrap(self) -> JavaObject:

--- a/keanu-python/tests/test_proposal_distributions.py
+++ b/keanu-python/tests/test_proposal_distributions.py
@@ -4,29 +4,29 @@ import pytest
 from keanu.algorithm._proposal_distribution import ProposalDistribution
 
 
-def test_you_can_create_a_prior_proposal_distribution():
+def test_you_can_create_a_prior_proposal_distribution() -> None:
     ProposalDistribution("prior")
 
 
-def test_you_can_create_a_gaussian_proposal_distribution():
-    ProposalDistribution("gaussian", sigma=1.)
+def test_you_can_create_a_gaussian_proposal_distribution() -> None:
+    ProposalDistribution("gaussian", sigma=np.array(1.))
 
 
-def test_it_throws_if_you_specify_gaussian_without_a_value_for_sigma():
+def test_it_throws_if_you_specify_gaussian_without_a_value_for_sigma() -> None:
     with pytest.raises(TypeError) as excinfo:
         ProposalDistribution("gaussian")
 
     assert str(excinfo.value) == "Gaussian Proposal Distribution requires a value for sigma"
 
 
-def test_it_throws_if_you_specify_sigma_but_the_type_isnt_gaussian():
+def test_it_throws_if_you_specify_sigma_but_the_type_isnt_gaussian() -> None:
     with pytest.raises(TypeError) as excinfo:
         ProposalDistribution("prior", sigma=np.array(1.))
 
     assert str(excinfo.value) == 'Parameter sigma is not valid unless type is "gaussian"'
 
 
-def test_it_throws_if_it_doesnt_recognise_the_type():
+def test_it_throws_if_it_doesnt_recognise_the_type() -> None:
     with pytest.raises(KeyError) as excinfo:
         ProposalDistribution("foo")
 


### PR DESCRIPTION
I've created a new Spotless configuration that checks our python source code for important problems:

1. using `logging` with the root logger
2. making a test without type annotations

Not intended for subjective code styling!