### PR TITLE
Out of bounds sampling fix

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
@@ -131,6 +131,8 @@ public class NUTS implements PosteriorSamplingAlgorithm {
             random
         ) : initialStepSize;
 
+        resetVertexValue(sampleFromVertices, position);
+
         NUTSSampler.AutoTune autoTune = new NUTSSampler.AutoTune(
             stepSize,
             targetAcceptanceProb,
@@ -190,6 +192,12 @@ public class NUTS implements PosteriorSamplingAlgorithm {
 
     private static <T> void putValue(Vertex<T> vertex, Map<VertexId, ?> target) {
         ((Map<VertexId, T>) target).put(vertex.getId(), vertex.getValue());
+    }
+
+    private static void resetVertexValue(List<? extends Vertex> sampleFromVertices, Map<VertexId, DoubleTensor> previousPosition) {
+        for (Vertex vertex : sampleFromVertices) {
+            vertex.setValue(previousPosition.get(vertex.getId()));
+        }
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -1,14 +1,14 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.LoadVertexParam;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+
+import java.util.Map;
+import java.util.Set;
 
 public class HalfCauchyVertex extends CauchyVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -55,7 +55,8 @@ public class HalfCauchyVertex extends CauchyVertex {
             return logProb;
         } else {
             for (Map.Entry<Vertex, DoubleTensor> entry : logProb.entrySet()) {
-                logProb.put(entry.getKey(), DoubleTensor.create(0.0, entry.getValue().getShape()));
+                DoubleTensor v = entry.getValue();
+                logProb.put(entry.getKey(), v.setWithMaskInPlace(value.getLessThanMask(DoubleTensor.scalar(LOC_ZERO)), 0.0));
             }
             return logProb;
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertex.java
@@ -1,8 +1,12 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
+import java.util.Map;
+import java.util.Set;
+
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.LoadVertexParam;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 
@@ -42,6 +46,19 @@ public class HalfCauchyVertex extends CauchyVertex {
             return super.logProb(value) + LOG_TWO * value.getLength();
         }
         return Double.NEGATIVE_INFINITY;
+    }
+
+    @Override
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
+        Map<Vertex, DoubleTensor> logProb = super.dLogProb(value, withRespectTo);
+        if (value.greaterThanOrEqual(LOC_ZERO).allTrue()) {
+            return logProb;
+        } else {
+            for (Map.Entry<Vertex, DoubleTensor> entry : logProb.entrySet()) {
+                logProb.put(entry.getKey(), DoubleTensor.create(0.0, entry.getValue().getShape()));
+            }
+            return logProb;
+        }
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertex.java
@@ -56,7 +56,8 @@ public class HalfGaussianVertex extends GaussianVertex {
             return logProb;
         } else {
             for (Map.Entry<Vertex, DoubleTensor> entry : logProb.entrySet()) {
-                logProb.put(entry.getKey(), DoubleTensor.create(0.0, entry.getValue().getShape()));
+                DoubleTensor v = entry.getValue();
+                logProb.put(entry.getKey(), v.setWithMaskInPlace(value.getLessThanMask(DoubleTensor.scalar(MU_ZERO)), 0.0));
             }
             return logProb;
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertex.java
@@ -1,8 +1,5 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
-import java.util.Map;
-import java.util.Set;
-
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.LoadVertexParam;
@@ -10,6 +7,9 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+
+import java.util.Map;
+import java.util.Set;
 
 public class HalfGaussianVertex extends GaussianVertex {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertex.java
@@ -1,8 +1,12 @@
 package io.improbable.keanu.vertices.dbl.probabilistic;
 
+import java.util.Map;
+import java.util.Set;
+
 import io.improbable.keanu.annotation.ExportVertexToPythonBindings;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.LoadVertexParam;
+import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
@@ -43,6 +47,19 @@ public class HalfGaussianVertex extends GaussianVertex {
             return super.logProb(value) + LOG_TWO * value.getLength();
         }
         return Double.NEGATIVE_INFINITY;
+    }
+
+    @Override
+    public Map<Vertex, DoubleTensor> dLogProb(DoubleTensor value, Set<? extends Vertex> withRespectTo) {
+        Map<Vertex, DoubleTensor> logProb = super.dLogProb(value, withRespectTo);
+        if (value.greaterThanOrEqual(MU_ZERO).allTrue()) {
+            return logProb;
+        } else {
+            for (Map.Entry<Vertex, DoubleTensor> entry : logProb.entrySet()) {
+                logProb.put(entry.getKey(), DoubleTensor.create(0.0, entry.getValue().getShape()));
+            }
+            return logProb;
+        }
     }
 
     @Override

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NUTSTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/NUTSTest.java
@@ -8,18 +8,17 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.HalfGaussianVertex;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.List;
+
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
-import java.util.List;
 
 public class NUTSTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -9,6 +9,7 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.distribution.CauchyDistribution;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -158,5 +159,14 @@ public class HalfCauchyVertexTest {
             latentScaleList,
             random
         );
+    }
+
+    @Test
+    public void outOfBoundsGradientCalculation() {
+        HalfCauchyVertex cauchyVertex = new HalfCauchyVertex(5);
+        double outOfBoundsValue = -1.0;
+        Map<Vertex, DoubleTensor> actualDerivatives = cauchyVertex.dLogPdf(outOfBoundsValue, cauchyVertex);
+        DoubleTensor derivative = actualDerivatives.get(cauchyVertex);
+        Assert.assertEquals(0.0, derivative.scalar(), 1e-6);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfCauchyVertexTest.java
@@ -163,10 +163,11 @@ public class HalfCauchyVertexTest {
 
     @Test
     public void outOfBoundsGradientCalculation() {
-        HalfCauchyVertex cauchyVertex = new HalfCauchyVertex(5);
-        double outOfBoundsValue = -1.0;
-        Map<Vertex, DoubleTensor> actualDerivatives = cauchyVertex.dLogPdf(outOfBoundsValue, cauchyVertex);
+        HalfCauchyVertex cauchyVertex = new HalfCauchyVertex(new long[]{2}, 5);
+        DoubleTensor value = DoubleTensor.create(-5.0, 5.0);
+        Map<Vertex, DoubleTensor> actualDerivatives = cauchyVertex.dLogPdf(value, cauchyVertex);
         DoubleTensor derivative = actualDerivatives.get(cauchyVertex);
-        Assert.assertEquals(0.0, derivative.scalar(), 1e-6);
+        Assert.assertEquals(0.0, derivative.getValue(0), 1e-6);
+        Assert.assertTrue(derivative.getValue(1) != 0.);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
@@ -9,6 +9,7 @@ import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import org.apache.commons.math3.distribution.NormalDistribution;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -160,5 +161,14 @@ public class HalfGaussianVertexTest {
             latentSigmaList,
             random
         );
+    }
+
+    @Test
+    public void outOfBoundsGradientCalculation() {
+        HalfGaussianVertex gaussianVertex = new HalfGaussianVertex(5);
+        double outOfBoundsValue = -1.0;
+        Map<Vertex, DoubleTensor> actualDerivatives = gaussianVertex.dLogPdf(outOfBoundsValue, gaussianVertex);
+        DoubleTensor derivative = actualDerivatives.get(gaussianVertex);
+        Assert.assertEquals(0.0, derivative.scalar(), 1e-6);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/HalfGaussianVertexTest.java
@@ -165,10 +165,11 @@ public class HalfGaussianVertexTest {
 
     @Test
     public void outOfBoundsGradientCalculation() {
-        HalfGaussianVertex gaussianVertex = new HalfGaussianVertex(5);
-        double outOfBoundsValue = -1.0;
-        Map<Vertex, DoubleTensor> actualDerivatives = gaussianVertex.dLogPdf(outOfBoundsValue, gaussianVertex);
+        HalfGaussianVertex gaussianVertex = new HalfGaussianVertex(new long[]{2}, 5);
+        DoubleTensor value = DoubleTensor.create(-5.0, 5.0);
+        Map<Vertex, DoubleTensor> actualDerivatives = gaussianVertex.dLogPdf(value, gaussianVertex);
         DoubleTensor derivative = actualDerivatives.get(gaussianVertex);
-        Assert.assertEquals(0.0, derivative.scalar(), 1e-6);
+        Assert.assertEquals(0.0, derivative.getValue(0), 1e-6);
+        Assert.assertTrue(derivative.getValue(1) != 0.);
     }
 }


### PR DESCRIPTION
NUTS has an algorithm to find a good value of the `stepsize` before it begins sampling. The way this algorithm works is by continually increasing it, taking a leapfrog and measuring the delta in log likelihood until it goes under some threshold. We were not resetting the value of the vertices to their initial value after running this algorithm to find a good starting size, meaning it was left in the state that produced the low likelihood. In the case of vertices with bounds (`half_gaussian`, `half_cauchy`) this low likelihood area happened to be a negative value.

This PR resets the value of the vertices to their starting value after finding a good value for the stepsize.

This PR also adds boundary checks for `dLogProb` for `halfGaussian` and `halfCauchy` and returns zero if it's invalid, we were previously just calling to the super no matter what the value of `x` was.

This can be merged in separately to the NUTS refactor.