### PR TITLE
Snippet writer removes leading whitespace

### DIFF
--- a/docs/bin/snippet_writer.py
+++ b/docs/bin/snippet_writer.py
@@ -115,6 +115,12 @@ def check_output_dir_exists(output_dir):
     if (not os.path.exists(output_dir)):
         os.mkdir(output_dir)
 
+def strip_block_whitespace(string_list):
+    """Treats a list of strings as a code block and strips
+        whitespace so that the min whitespace line sits at char 0 of line."""
+    min_ws = min([(len(x) - len(x.lstrip())) for x in string_list if x != '\n'])
+    return [x[min_ws:] if x != '\n' else x for x in string_list]
+
 
 def main():
     """Parse args (expects source and dest doc directories and snippet source dir)
@@ -135,12 +141,13 @@ def main():
     snippet_store = {}
     for_all_in_dir(args.java_src_dir, lambda x: read_file_snippets(args.java_src_dir + x, snippet_store))
     for_all_in_dir(args.python_src_dir, lambda x: read_file_snippets(args.python_src_dir + x, snippet_store))
-    printd(str(snippet_store))
+    stripped_snippet_store = {k: strip_block_whitespace(v) for k, v in snippet_store.items()}
+    printd(str(stripped_snippet_store))
     check_output_dir_exists(args.output_dir)
     for_all_in_subdirs(args.input_dir, lambda x: do_rewrites(x,
                                                               args.input_dir,
                                                               args.output_dir,
-                                                              snippet_store))
+                                                              stripped_snippet_store))
 
 if __name__ == "__main__":
     main()

--- a/docs/current_docs/autocorrelation.md
+++ b/docs/current_docs/autocorrelation.md
@@ -49,5 +49,5 @@ NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPost
     bayesNet.getLatentVertices(),
     100
 );
-DoubleTensor autocorrelation = posteriorSamples.getDoubleTensorSamples(A).getAutocorrelation(0,1);
+DoubleTensor autocorrelation = posteriorSamples.getDoubleTensorSamples(A).getAutocorrelation(0, 1);
 ```

--- a/docs/current_docs/data-io.md
+++ b/docs/current_docs/data-io.md
@@ -105,8 +105,8 @@ The CSV can be loaded as a Java object by
 
 ```java
 List<MyClass> myPojos = ReadCsv.fromFile("some/file/path")
-        .asRowsDefinedBy(MyClass.class)
-        .load();
+    .asRowsDefinedBy(MyClass.class)
+    .load();
 ```
 
 If your CSV header names contain illegal characters you have the option to
@@ -251,9 +251,9 @@ To learn more about the parameters being used here, head over to the [NUTS docum
 
 ```java
 NetworkSamples samples = NUTS.withDefaultConfig().getPosteriorSamples(
-        new BayesianNetwork(aVertex.getConnectedGraph()),
-        aVertex,
-        1000
+    new BayesianNetwork(aVertex.getConnectedGraph()),
+    aVertex,
+    1000
 );
 ```
 

--- a/docs/current_docs/getting-started.md
+++ b/docs/current_docs/getting-started.md
@@ -118,9 +118,9 @@ A.observe(true);
 B.observe(true);
 
 NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
-        new BayesianNetwork(C.getConnectedGraph()),
-        Arrays.asList(A, B),
-        100000
+    new BayesianNetwork(C.getConnectedGraph()),
+    Arrays.asList(A, B),
+    100000
 ).drop(10000).downSample(2);
 double probabilityOfA = posteriorSamples.get(A).probability(isTrue -> isTrue.scalar() == true);
 //probabilityOfA evaluates to 1.0

--- a/docs/current_docs/inference-map.md
+++ b/docs/current_docs/inference-map.md
@@ -60,11 +60,11 @@ Let's say you've described the [thermometer model]({{ site.baseurl }}/docs/examp
 whether to use the Gradient or Non-Gradient Optimizer. You can use the following code to let Keanu decide which one to use.
 
 ```java
-        BayesianNetwork bayesNet = new BayesianNetwork(temperature.getConnectedGraph());
-        Optimizer optimizer = KeanuOptimizer.of(bayesNet);
-        optimizer.maxAPosteriori();
+BayesianNetwork bayesNet = new BayesianNetwork(temperature.getConnectedGraph());
+Optimizer optimizer = KeanuOptimizer.of(bayesNet);
+optimizer.maxAPosteriori();
 
-        double calculatedTemperature = temperature.getValue().scalar();
+double calculatedTemperature = temperature.getValue().scalar();
 ```
 
 The Optimizer mutates the values of the graph while finding the most probable values and leaves the graph in its

--- a/docs/current_docs/inference-posterior-sampling.md
+++ b/docs/current_docs/inference-posterior-sampling.md
@@ -107,9 +107,9 @@ We will be taking 100,000 samples from the distributions of A and B.
 
 ```java
 NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
-        bayesNet,
-        bayesNet.getLatentVertices(),
-        100000
+    bayesNet,
+    bayesNet.getLatentVertices(),
+    100000
 );
 ```
 
@@ -196,9 +196,9 @@ The parameters are:
 
 ```java
 NetworkSamples posteriorSamples = Hamiltonian.withDefaultConfig().getPosteriorSamples(
-        bayesNet,
-        bayesNet.getLatentVertices(),
-        2000
+    bayesNet,
+    bayesNet.getLatentVertices(),
+    2000
 );
 ```
 
@@ -225,9 +225,9 @@ It also attempts to calculate and auto-tune those difficult leapfrog and step si
 
 ```java
 NetworkSamples posteriorSamples = NUTS.withDefaultConfig().getPosteriorSamples(
-        bayesNet,
-        bayesNet.getLatentVertices(),
-        2000
+    bayesNet,
+    bayesNet.getLatentVertices(),
+    2000
 );
 ```
 

--- a/docs/current_docs/lorenz-example.md
+++ b/docs/current_docs/lorenz-example.md
@@ -137,12 +137,12 @@ fun calculateLorenzTimesteps(graphTimeSteps: MutableList<List<DoubleVertex>>, wi
     for (i in 0.until(windowSize - 1)) {
         val startConditions = graphTimeSteps[i]
         val timesteppedCoordinates = lorenzTimestep(startConditions.first(),
-                startConditions[1],
-                startConditions.last(),
-                LorenzModel.timeStep,
-                LorenzModel.sigma,
-                LorenzModel.rho,
-                LorenzModel.beta)
+            startConditions[1],
+            startConditions.last(),
+            LorenzModel.timeStep,
+            LorenzModel.sigma,
+            LorenzModel.rho,
+            LorenzModel.beta)
         graphTimeSteps.add(timesteppedCoordinates)
     }
 }
@@ -261,53 +261,53 @@ private var error = Double.MAX_VALUE
 
 fun main(args: Array<String>) {
 
-val model = LorenzModel()
-val lorenzCoordinates = model.runModel(maxWindows * windowSize)
+    val model = LorenzModel()
+    val lorenzCoordinates = model.runModel(maxWindows * windowSize)
 
-val random = DoubleVertexFactory()
-val origin = 0.0
-var initX = random.nextGaussian(origin, 2.5)
-var initY = random.nextGaussian(origin, 2.5)
-var initZ = random.nextGaussian(origin, 2.5)
+    val random = DoubleVertexFactory()
+    val origin = 0.0
+    var initX = random.nextGaussian(origin, 2.5)
+    var initY = random.nextGaussian(origin, 2.5)
+    var initZ = random.nextGaussian(origin, 2.5)
 
-while (error > convergedError && window < maxWindows) {
+    while (error > convergedError && window < maxWindows) {
 
-val initialConditions = listOf(initX, initY, initZ)
-val graphTimeSteps = mutableListOf(initialConditions) as MutableList<List<DoubleVertex>>
+        val initialConditions = listOf(initX, initY, initZ)
+        val graphTimeSteps = mutableListOf(initialConditions) as MutableList<List<DoubleVertex>>
 
-calculateLorenzTimesteps(graphTimeSteps, windowSize)
+        calculateLorenzTimesteps(graphTimeSteps, windowSize)
 
-applyObservations(graphTimeSteps, windowSize, window, lorenzCoordinates, random)
+        applyObservations(graphTimeSteps, windowSize, window, lorenzCoordinates, random)
 
-val net = BayesianNetwork(graphTimeSteps.first().first().connectedGraph)
-val optimiser = KeanuOptimizer.of(net)
-optimiser.maxAPosteriori()
+        val net = BayesianNetwork(graphTimeSteps.first().first().connectedGraph)
+        val optimiser = KeanuOptimizer.of(net)
+        optimiser.maxAPosteriori()
 
-val posterior = getTimestepValues(graphTimeSteps, windowSize - 1)
-val postTimestep = (window + 1) * (windowSize - 1)
-val coordinatesAtPostTimestep = lorenzCoordinates[postTimestep]
+        val posterior = getTimestepValues(graphTimeSteps, windowSize - 1)
+        val postTimestep = (window + 1) * (windowSize - 1)
+        val coordinatesAtPostTimestep = lorenzCoordinates[postTimestep]
 
-error = error(coordinatesAtPostTimestep, posterior)
-println("Error: " + error)
+        error = error(coordinatesAtPostTimestep, posterior)
+        println("Error: " + error)
 
-initX = random.nextGaussian(posterior[0], 2.5)
-initY = random.nextGaussian(posterior[1], 2.5)
-initZ = random.nextGaussian(posterior[2], 2.5)
+        initX = random.nextGaussian(posterior[0], 2.5)
+        initY = random.nextGaussian(posterior[1], 2.5)
+        initZ = random.nextGaussian(posterior[2], 2.5)
 
-window++
-}
+        window++
+    }
 }
 
 fun calculateLorenzTimesteps(graphTimeSteps: MutableList<List<DoubleVertex>>, windowSize: Int) {
     for (i in 0.until(windowSize - 1)) {
         val startConditions = graphTimeSteps[i]
         val timesteppedCoordinates = lorenzTimestep(startConditions.first(),
-                startConditions[1],
-                startConditions.last(),
-                LorenzModel.timeStep,
-                LorenzModel.sigma,
-                LorenzModel.rho,
-                LorenzModel.beta)
+            startConditions[1],
+            startConditions.last(),
+            LorenzModel.timeStep,
+            LorenzModel.sigma,
+            LorenzModel.rho,
+            LorenzModel.beta)
         graphTimeSteps.add(timesteppedCoordinates)
     }
 }
@@ -340,9 +340,9 @@ fun getTimestepValues(graphTimeSteps: MutableList<List<DoubleVertex>>, time: Int
 
 fun error(coordinates: LorenzModel.Coordinates, posterior: List<Double>): Double {
     return Math.sqrt(
-            Math.pow(coordinates.x - posterior[0], 2.0) +
-                    Math.pow(coordinates.y - posterior[1], 2.0) +
-                    Math.pow(coordinates.z - posterior[2], 2.0)
+        Math.pow(coordinates.x - posterior[0], 2.0) +
+            Math.pow(coordinates.y - posterior[1], 2.0) +
+            Math.pow(coordinates.z - posterior[2], 2.0)
     )
 }
 ```

--- a/docs/current_docs/overview.md
+++ b/docs/current_docs/overview.md
@@ -109,20 +109,20 @@ BoolVertex rain = new BernoulliVertex(0.2);
 //whether or not it has rained. It's very unlikely that the
 //sprinkler comes on if it's raining.
 BoolVertex sprinkler = new BernoulliVertex(
-        If.isTrue(rain)
-                .then(0.01)
-                .orElse(0.4)
+    If.isTrue(rain)
+        .then(0.01)
+        .orElse(0.4)
 );
 
 //The grass being wet is dependent on whether or not it rained or
 //the sprinkler was on.
 // The following probabilities are the same as those used in Wikipedia article linked above.
 BoolVertex wetGrass = new BernoulliVertex(
-        ConditionalProbabilityTable.of(sprinkler, rain)
-                .when(false, false).then(0.001)
-                .when(false, true).then(0.8)
-                .when(true, false).then(0.9)
-                .orDefault(0.99)
+    ConditionalProbabilityTable.of(sprinkler, rain)
+        .when(false, false).then(0.001)
+        .when(false, true).then(0.8)
+        .when(true, false).then(0.9)
+        .orDefault(0.99)
 );
 
 //We observe that the grass is wet
@@ -131,9 +131,9 @@ wetGrass.observe(true);
 //What does that observation say about the probability that it rained or that
 //the sprinkler was on?
 NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
-        new BayesianNetwork(wetGrass.getConnectedGraph()),
-        Arrays.asList(sprinkler, rain),
-        100000
+    new BayesianNetwork(wetGrass.getConnectedGraph()),
+    Arrays.asList(sprinkler, rain),
+    100000
 ).drop(10000).downSample(2);
 
 double probabilityOfRainGivenWetGrass = posteriorSamples.get(rain).probability(isRaining -> isRaining.scalar() == true);

--- a/docs/current_docs/particle-filter.md
+++ b/docs/current_docs/particle-filter.md
@@ -40,7 +40,7 @@ thermometerB.observe(19.5);
 
 //Create a particle filter with default settings
 ParticleFilter filter = ParticleFilter.ofVertexInGraph(temperature)
-        .build();
+    .build();
 
 //Get a sorted list of the most probable particles in order of descending probability
 List<Particle> particles = filter.getSortedMostProbableParticles();

--- a/docs/current_docs/plates.md
+++ b/docs/current_docs/plates.md
@@ -50,18 +50,20 @@ This is an example of how you could pull in data from a csv file and run linear 
 plates to build identical sections of the graph for each line of the csv.
 
 ```java
+
 /**
-    * Each plate contains a linear regression model:
-    * VertexY = VertexX * VertexM + VertexB
-    * @param dataFileName The input data file defines, for each plate:
-    *                          - the value of the input, VertexX
-    *                          - the value of the observed output, VertexY
-    */
+ * Each plate contains a linear regression model:
+ * VertexY = VertexX * VertexM + VertexB
+ *
+ * @param dataFileName The input data file defines, for each plate:
+ *                     - the value of the input, VertexX
+ *                     - the value of the observed output, VertexY
+ */
 public Plates buildPlates(String dataFileName) {
     //Parse the csv data to MyData objects
     List<MyData> allMyData = ReadCsv.fromFile(dataFileName)
-            .asRowsDefinedBy(MyData.class)
-            .load();
+        .asRowsDefinedBy(MyData.class)
+        .load();
 
     DoubleVertex m = new GaussianVertex(0, 1);
     DoubleVertex b = new GaussianVertex(0, 1);
@@ -70,26 +72,26 @@ public Plates buildPlates(String dataFileName) {
 
     //Build plates from each line in the csv
     Plates plates = new PlateBuilder<MyData>()
-            .fromIterator(allMyData.iterator())
-            .withFactory((plate, csvMyData) -> {
+        .fromIterator(allMyData.iterator())
+        .withFactory((plate, csvMyData) -> {
 
-                ConstantDoubleVertex x = new ConstantDoubleVertex(csvMyData.x).setLabel(xLabel);
-                DoubleVertex y = m.multiply(x).plus(b).setLabel(yLabel);
+            ConstantDoubleVertex x = new ConstantDoubleVertex(csvMyData.x).setLabel(xLabel);
+            DoubleVertex y = m.multiply(x).plus(b).setLabel(yLabel);
 
-                DoubleVertex yObserved = new GaussianVertex(y, 1);
-                yObserved.observe(csvMyData.y);
+            DoubleVertex yObserved = new GaussianVertex(y, 1);
+            yObserved.observe(csvMyData.y);
 
-                // this labels the x and y vertex for later use
-                plate.add(x);
-                plate.add(y);
-            })
-            .build();
+            // this labels the x and y vertex for later use
+            plate.add(x);
+            plate.add(y);
+        })
+        .build();
 
     //now you have access to the "x" from any one of the plates
     DoubleTensor valueForXAtCSVLine1 = plates.asList()
-            .get(1) // get plate 1 which is built from csv line 1
-            .<DoubleVertex>get(xLabel) //get the vertex that we labelled "x" in that plate
-            .getValue(); //get the value from that vertex
+        .get(1) // get plate 1 which is built from csv line 1
+        .<DoubleVertex>get(xLabel) //get the vertex that we labelled "x" in that plate
+        .getValue(); //get the value from that vertex
 
     //Now run an inference algorithm on vertex m and vertex b and you have linear regression
 

--- a/docs/current_docs/save-and-load.md
+++ b/docs/current_docs/save-and-load.md
@@ -46,8 +46,8 @@ and indicating whether they wish to save the current state of the model or to st
 example to save as a Protobuf:
 ```java
 public void saveNetToProtobuf(BayesianNetwork net,
-                                OutputStream outputStream,
-                                boolean saveValuesAndObservations) throws IOException {
+                              OutputStream outputStream,
+                              boolean saveValuesAndObservations) throws IOException {
     NetworkSaver saver = new ProtobufSaver(net);
     saver.save(outputStream, saveValuesAndObservations);
 }

--- a/docs/current_docs/tensors.md
+++ b/docs/current_docs/tensors.md
@@ -136,10 +136,10 @@ long[] shape = new long[]{3, 1};
 DoubleVertex mu = new ConstantDoubleVertex(new double[]{1, 2, 3});
 GaussianVertex vertex = new GaussianVertex(shape, mu, 0);
 /** Creates a GaussianVertex that looks like...
-* [ Gaussian(mu: 1, sigma: 0),
-*   Gaussian(mu: 2, sigma: 0),
-*   Gaussian(mu: 3, sigma: 0) ]
-*/
+ * [ Gaussian(mu: 1, sigma: 0),
+ *   Gaussian(mu: 2, sigma: 0),
+ *   Gaussian(mu: 3, sigma: 0) ]
+ */
 ```  
 
 

--- a/docs/current_docs/thermometer-example.md
+++ b/docs/current_docs/thermometer-example.md
@@ -60,7 +60,7 @@ Let's assume we're on a distant planet and have no prior knowledge about what th
 we define the temperature as a Uniform Distribution between 20° and 30°.
 
 ```java
-        UniformVertex temperature = new UniformVertex(20., 30.);
+UniformVertex temperature = new UniformVertex(20., 30.);
 ```
 
 Let's now define our two thermometers. Looking at the graph we made earlier, we can see that each thermometer
@@ -70,26 +70,26 @@ Let's represent each thermometer as a Gaussian distribution with a mu of the roo
 As the first thermometer is more accurate, its sigma will be smaller.
 
 ```java
-        GaussianVertex firstThermometer = new GaussianVertex(temperature, 2.5);
-        GaussianVertex secondThermometer = new GaussianVertex(temperature, 5.);
+GaussianVertex firstThermometer = new GaussianVertex(temperature, 2.5);
+GaussianVertex secondThermometer = new GaussianVertex(temperature, 5.);
 ```
 
 Now we can take the readings of each thermometer.
 
 ```java
-        firstThermometer.observe(25.);
-        secondThermometer.observe(30.);
+firstThermometer.observe(25.);
+secondThermometer.observe(30.);
 ```
 
 Now that we have taken our thermometer readings, let's calculate the most probable value for the 
 room temperature.
 
 ```java
-        BayesianNetwork bayesNet = new BayesianNetwork(temperature.getConnectedGraph());
-        Optimizer optimizer = KeanuOptimizer.of(bayesNet);
-        optimizer.maxAPosteriori();
+BayesianNetwork bayesNet = new BayesianNetwork(temperature.getConnectedGraph());
+Optimizer optimizer = KeanuOptimizer.of(bayesNet);
+optimizer.maxAPosteriori();
 
-        double calculatedTemperature = temperature.getValue().scalar();
+double calculatedTemperature = temperature.getValue().scalar();
 ```
 
 Given our graph and observed values, this will attempt to calculate the most likely value for each vertex.

--- a/docs/src/test/java/io/improbable/snippet/AutocorrelationExample.java
+++ b/docs/src/test/java/io/improbable/snippet/AutocorrelationExample.java
@@ -14,39 +14,39 @@ public class AutocorrelationExample {
     }
 
     private static void scalarAutocorrelationExample() {
-DoubleVertex A = new GaussianVertex(20.0, 1.0);
-DoubleVertex B = new GaussianVertex(20.0, 1.0);
-DoubleVertex C = new GaussianVertex(A.plus(B), 1.0);
-C.observe(43.0);
-A.setValue(20.0);
-B.setValue(20.0);
-BayesianNetwork bayesNet = new BayesianNetwork(C.getConnectedGraph());
+        DoubleVertex A = new GaussianVertex(20.0, 1.0);
+        DoubleVertex B = new GaussianVertex(20.0, 1.0);
+        DoubleVertex C = new GaussianVertex(A.plus(B), 1.0);
+        C.observe(43.0);
+        A.setValue(20.0);
+        B.setValue(20.0);
+        BayesianNetwork bayesNet = new BayesianNetwork(C.getConnectedGraph());
 
-//%%SNIPPET_START%% ScalarAutocorrelation
-NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
-    bayesNet,
-    bayesNet.getLatentVertices(),
-    100
-);
-DoubleTensor autocorrelation = posteriorSamples.getDoubleTensorSamples(A).getAutocorrelation();
-//%%SNIPPET_END%% ScalarAutocorrelation
+        //%%SNIPPET_START%% ScalarAutocorrelation
+        NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
+            bayesNet,
+            bayesNet.getLatentVertices(),
+            100
+        );
+        DoubleTensor autocorrelation = posteriorSamples.getDoubleTensorSamples(A).getAutocorrelation();
+        //%%SNIPPET_END%% ScalarAutocorrelation
     }
 
     private static void tensorAutocorrelationExample() {
-DoubleVertex A = new GaussianVertex(new long[]{1, 5}, 20.0, 1.0);
-DoubleVertex B = new GaussianVertex(new long[]{1, 5}, 20.0, 1.0);
-DoubleVertex C = new GaussianVertex(A.plus(B), 1.0);
-BayesianNetwork bayesNet = new BayesianNetwork(C.getConnectedGraph());
-C.observe(new double[]{1, 4, 5, 7, 8});
-bayesNet.probeForNonZeroProbability(100);
+        DoubleVertex A = new GaussianVertex(new long[]{1, 5}, 20.0, 1.0);
+        DoubleVertex B = new GaussianVertex(new long[]{1, 5}, 20.0, 1.0);
+        DoubleVertex C = new GaussianVertex(A.plus(B), 1.0);
+        BayesianNetwork bayesNet = new BayesianNetwork(C.getConnectedGraph());
+        C.observe(new double[]{1, 4, 5, 7, 8});
+        bayesNet.probeForNonZeroProbability(100);
 
-//%%SNIPPET_START%% TensorAutocorrelation
-NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
-    bayesNet,
-    bayesNet.getLatentVertices(),
-    100
-);
-DoubleTensor autocorrelation = posteriorSamples.getDoubleTensorSamples(A).getAutocorrelation(0,1);
-//%%SNIPPET_END%% TensorAutocorrelation
+        //%%SNIPPET_START%% TensorAutocorrelation
+        NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
+            bayesNet,
+            bayesNet.getLatentVertices(),
+            100
+        );
+        DoubleTensor autocorrelation = posteriorSamples.getDoubleTensorSamples(A).getAutocorrelation(0, 1);
+        //%%SNIPPET_END%% TensorAutocorrelation
     }
 }

--- a/docs/src/test/java/io/improbable/snippet/CsvOperations.java
+++ b/docs/src/test/java/io/improbable/snippet/CsvOperations.java
@@ -16,52 +16,52 @@ import java.util.stream.Stream;
 public class CsvOperations {
 
     public static void main(String[] args) {
-//%%SNIPPET_START%% ReadPOJOIn
-List<MyClass> myPojos = ReadCsv.fromFile("some/file/path")
-        .asRowsDefinedBy(MyClass.class)
-        .load();
-//%%SNIPPET_END%% ReadPOJOIn
+        //%%SNIPPET_START%% ReadPOJOIn
+        List<MyClass> myPojos = ReadCsv.fromFile("some/file/path")
+            .asRowsDefinedBy(MyClass.class)
+            .load();
+        //%%SNIPPET_END%% ReadPOJOIn
     }
 
-//%%SNIPPET_START%% ReadPOJOObj
-public class MyClass {
-    public String myString;
-    public int myInt;
-}
-//%%SNIPPET_END%% ReadPOJOObj
-
-//%%SNIPPET_START%% ReadSetter
-public class MySetterClass {
-    private String myString;
-
-    public void setMyString(String aString) {
-        myString = aString;
+    //%%SNIPPET_START%% ReadPOJOObj
+    public class MyClass {
+        public String myString;
+        public int myInt;
     }
-}
-//%%SNIPPET_END%% ReadSetter
+    //%%SNIPPET_END%% ReadPOJOObj
+
+    //%%SNIPPET_START%% ReadSetter
+    public class MySetterClass {
+        private String myString;
+
+        public void setMyString(String aString) {
+            myString = aString;
+        }
+    }
+    //%%SNIPPET_END%% ReadSetter
 
     private static void readCsvs() {
-//%%SNIPPET_START%% ReadFromCurrent
-CsvReader reader1 = ReadCsv.fromFile("~/my_filename.csv");
-//%%SNIPPET_END%% ReadFromCurrent
-//%%SNIPPET_START%% ReadFromResource
-CsvReader reader2 = ReadCsv.fromResources("my_other_filename.csv");
-//%%SNIPPET_END%% ReadFromResource
+        //%%SNIPPET_START%% ReadFromCurrent
+        CsvReader reader1 = ReadCsv.fromFile("~/my_filename.csv");
+        //%%SNIPPET_END%% ReadFromCurrent
+        //%%SNIPPET_START%% ReadFromResource
+        CsvReader reader2 = ReadCsv.fromResources("my_other_filename.csv");
+        //%%SNIPPET_END%% ReadFromResource
 
-//%%SNIPPET_START%% ReadLines
-for (List<String> csvLine : reader1.readLines()) {
-    //do something with your csv line
-}
-//%%SNIPPET_END%% ReadLines
+        //%%SNIPPET_START%% ReadLines
+        for (List<String> csvLine : reader1.readLines()) {
+            //do something with your csv line
+        }
+        //%%SNIPPET_END%% ReadLines
 
-//%%SNIPPET_START%% ReadStream
-try (Stream<List<String>> lineStream = reader2.streamLines()) {
+        //%%SNIPPET_START%% ReadStream
+        try (Stream<List<String>> lineStream = reader2.streamLines()) {
 
-    lineStream.forEach(line -> {
-        //do something with your line.
-    });
-}
-//%%SNIPPET_END%% ReadStream
+            lineStream.forEach(line -> {
+                //do something with your line.
+            });
+        }
+        //%%SNIPPET_END%% ReadStream
     }
 
     private static List<DoubleVertex> runMyModel() {
@@ -69,49 +69,49 @@ try (Stream<List<String>> lineStream = reader2.streamLines()) {
     }
 
     private static void writeCsvs() {
-//%%SNIPPET_START%% WriteVars
-List<DoubleVertex> inferredVariables = runMyModel();
+        //%%SNIPPET_START%% WriteVars
+        List<DoubleVertex> inferredVariables = runMyModel();
 
-inferredVariables.get(0); // [0.5, 1.0, 1.5, 2.0]
-inferredVariables.get(1); // [5.0, 10.0, 15.0, 20.0]
-inferredVariables.get(2); // [50.0, 100.0, 150.0]
-//%%SNIPPET_END%% WriteVars
+        inferredVariables.get(0); // [0.5, 1.0, 1.5, 2.0]
+        inferredVariables.get(1); // [5.0, 10.0, 15.0, 20.0]
+        inferredVariables.get(2); // [50.0, 100.0, 150.0]
+        //%%SNIPPET_END%% WriteVars
 
-//%%SNIPPET_START%% WriteColumnTest
-File file = WriteCsv.asColumns(inferredVariables).toFile("columnTest.csv");
-//%%SNIPPET_END%% WriteColumnTest
+        //%%SNIPPET_START%% WriteColumnTest
+        File file = WriteCsv.asColumns(inferredVariables).toFile("columnTest.csv");
+        //%%SNIPPET_END%% WriteColumnTest
 
-//%%SNIPPET_START%% WriteRowTest
-File file2 = WriteCsv.asRows(inferredVariables).toFile("rowTest.csv");
-//%%SNIPPET_END%% WriteRowTest
+        //%%SNIPPET_START%% WriteRowTest
+        File file2 = WriteCsv.asRows(inferredVariables).toFile("rowTest.csv");
+        //%%SNIPPET_END%% WriteRowTest
 
-//%%SNIPPET_START%% WriteDefaultHeaders
-File file3 = WriteCsv.asColumns(inferredVariables).withDefaultHeader().toFile("columnTest.csv");
-//%%SNIPPET_END%% WriteDefaultHeaders
+        //%%SNIPPET_START%% WriteDefaultHeaders
+        File file3 = WriteCsv.asColumns(inferredVariables).withDefaultHeader().toFile("columnTest.csv");
+        //%%SNIPPET_END%% WriteDefaultHeaders
 
-//%%SNIPPET_START%% WriteDefaultHeadersRows
-File file4 = WriteCsv.asRows(inferredVariables).withDefaultHeader().toFile("rowTest.csv");
-//%%SNIPPET_END%% WriteDefaultHeadersRows
+        //%%SNIPPET_START%% WriteDefaultHeadersRows
+        File file4 = WriteCsv.asRows(inferredVariables).withDefaultHeader().toFile("rowTest.csv");
+        //%%SNIPPET_END%% WriteDefaultHeadersRows
 
-DoubleVertex aVertex = null;
-//%%SNIPPET_START%% WriteGetSamples
-NetworkSamples samples = NUTS.withDefaultConfig().getPosteriorSamples(
-        new BayesianNetwork(aVertex.getConnectedGraph()),
-        aVertex,
-        1000
-);
-//%%SNIPPET_END%% WriteGetSamples
+        DoubleVertex aVertex = null;
+        //%%SNIPPET_START%% WriteGetSamples
+        NetworkSamples samples = NUTS.withDefaultConfig().getPosteriorSamples(
+            new BayesianNetwork(aVertex.getConnectedGraph()),
+            aVertex,
+            1000
+        );
+        //%%SNIPPET_END%% WriteGetSamples
 
-//%%SNIPPET_START%% WriteSamples
-File file5 = WriteCsv.asSamples(samples, inferredVariables).withDefaultHeader().toFile("test.csv");
-//%%SNIPPET_END%% WriteSamples
+        //%%SNIPPET_START%% WriteSamples
+        File file5 = WriteCsv.asSamples(samples, inferredVariables).withDefaultHeader().toFile("test.csv");
+        //%%SNIPPET_END%% WriteSamples
     }
 
-//%%SNIPPET_START%% ReadProblemHeader
-public class MyOtherClass {
-    @CsvProperty("my-problematic*header")
-    public String myString;
-    public int myInt;
-}
-//%%SNIPPET_END%% ReadProblemHeader
+    //%%SNIPPET_START%% ReadProblemHeader
+    public class MyOtherClass {
+        @CsvProperty("my-problematic*header")
+        public String myString;
+        public int myInt;
+    }
+    //%%SNIPPET_END%% ReadProblemHeader
 }

--- a/docs/src/test/java/io/improbable/snippet/DescribingTheModel.java
+++ b/docs/src/test/java/io/improbable/snippet/DescribingTheModel.java
@@ -14,63 +14,63 @@ import java.util.Arrays;
 public class DescribingTheModel {
 
     public void doubleExample() {
-//%%SNIPPET_START%% DescribeVertex
-DoubleVertex A = new GaussianVertex(0, 1);
-DoubleVertex B = new GaussianVertex(0, 1);
-DoubleVertex C = A.plus(B);
-//%%SNIPPET_END%% DescribeVertex
+        //%%SNIPPET_START%% DescribeVertex
+        DoubleVertex A = new GaussianVertex(0, 1);
+        DoubleVertex B = new GaussianVertex(0, 1);
+        DoubleVertex C = A.plus(B);
+        //%%SNIPPET_END%% DescribeVertex
 
-//%%SNIPPET_START%% DescribePropagate
-A.setAndCascade(1.234);
-//%%SNIPPET_END%% DescribePropagate
+        //%%SNIPPET_START%% DescribePropagate
+        A.setAndCascade(1.234);
+        //%%SNIPPET_END%% DescribePropagate
 
-//%%SNIPPET_START%% DescribeLazy
-A.setValue(1.234);
-B.setValue(4.321);
-C.lazyEval();
-//%%SNIPPET_END%% DescribeLazy
+        //%%SNIPPET_START%% DescribeLazy
+        A.setValue(1.234);
+        B.setValue(4.321);
+        C.lazyEval();
+        //%%SNIPPET_END%% DescribeLazy
 
 
-//%%SNIPPET_START%% DescribeCascade
-A.setValue(1.234);
-B.setValue(4.321);
-VertexValuePropagation.cascadeUpdate(A, B);
-//%%SNIPPET_END%% DescribeCascade
+        //%%SNIPPET_START%% DescribeCascade
+        A.setValue(1.234);
+        B.setValue(4.321);
+        VertexValuePropagation.cascadeUpdate(A, B);
+        //%%SNIPPET_END%% DescribeCascade
     }
 
     public void booleanExample() {
-//%%SNIPPET_START%% DescribeAnd
-BoolVertex A = new BernoulliVertex(0.5);
-BoolVertex B = new BernoulliVertex(0.5);
-BoolVertex C = A.and(B);
-//%%SNIPPET_END%% DescribeAnd
+        //%%SNIPPET_START%% DescribeAnd
+        BoolVertex A = new BernoulliVertex(0.5);
+        BoolVertex B = new BernoulliVertex(0.5);
+        BoolVertex C = A.and(B);
+        //%%SNIPPET_END%% DescribeAnd
 
-//%%SNIPPET_START%% DescribeObserve
-C.observe(true);
-//%%SNIPPET_END%% DescribeObserve
+        //%%SNIPPET_START%% DescribeObserve
+        C.observe(true);
+        //%%SNIPPET_END%% DescribeObserve
 
-//%%SNIPPET_START%% DescribeInfer
-A.observe(true);
-B.observe(true);
+        //%%SNIPPET_START%% DescribeInfer
+        A.observe(true);
+        B.observe(true);
 
-NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
-        new BayesianNetwork(C.getConnectedGraph()),
-        Arrays.asList(A, B),
-        100000
-).drop(10000).downSample(2);
-double probabilityOfA = posteriorSamples.get(A).probability(isTrue -> isTrue.scalar() == true);
-//probabilityOfA evaluates to 1.0
-//%%SNIPPET_END%% DescribeInfer
+        NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
+            new BayesianNetwork(C.getConnectedGraph()),
+            Arrays.asList(A, B),
+            100000
+        ).drop(10000).downSample(2);
+        double probabilityOfA = posteriorSamples.get(A).probability(isTrue -> isTrue.scalar() == true);
+        //probabilityOfA evaluates to 1.0
+        //%%SNIPPET_END%% DescribeInfer
 
-//%%SNIPPET_START%% DescribeInferIncorrect
-//WRONG
-A.lazyEval();
-B.lazyEval();
-System.out.println(A.getValue().scalar());
-//%%SNIPPET_END%% DescribeInferIncorrect
-//%%SNIPPET_START%% ProbeInfer
-BayesianNetwork net = new BayesianNetwork(C.getConnectedGraph());
-net.probeForNonZeroProbability(10);
-//%%SNIPPET_END%% ProbeInfer
+        //%%SNIPPET_START%% DescribeInferIncorrect
+        //WRONG
+        A.lazyEval();
+        B.lazyEval();
+        System.out.println(A.getValue().scalar());
+        //%%SNIPPET_END%% DescribeInferIncorrect
+        //%%SNIPPET_START%% ProbeInfer
+        BayesianNetwork net = new BayesianNetwork(C.getConnectedGraph());
+        net.probeForNonZeroProbability(10);
+        //%%SNIPPET_END%% ProbeInfer
     }
 }

--- a/docs/src/test/java/io/improbable/snippet/Inference.java
+++ b/docs/src/test/java/io/improbable/snippet/Inference.java
@@ -11,67 +11,67 @@ import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 
 public class Inference {
     private static void inferenceExample1() {
-//%%SNIPPET_START%% InfNormalDeclare
-DoubleVertex A = new GaussianVertex(20.0, 1.0);
-DoubleVertex B = new GaussianVertex(20.0, 1.0);
-//%%SNIPPET_END%% InfNormalDeclare
+        //%%SNIPPET_START%% InfNormalDeclare
+        DoubleVertex A = new GaussianVertex(20.0, 1.0);
+        DoubleVertex B = new GaussianVertex(20.0, 1.0);
+        //%%SNIPPET_END%% InfNormalDeclare
 
-//%%SNIPPET_START%% InfNoisyObservation
-DoubleVertex C = new GaussianVertex(A.plus(B), 1.0);
-C.observe(43.0);
-//%%SNIPPET_END%% InfNoisyObservation
+        //%%SNIPPET_START%% InfNoisyObservation
+        DoubleVertex C = new GaussianVertex(A.plus(B), 1.0);
+        C.observe(43.0);
+        //%%SNIPPET_END%% InfNoisyObservation
 
-//%%SNIPPET_START%% InfStartState
-// Set the values of A and B so the Metropolis Hastings
-// algorithm has a non-zero start state.
-// Alternatively you could infer a possible start state
-// using either a particle filter or something like
-// bayesNet.probeForNonZeroProbability(100);
-A.setValue(20.0);
-B.setValue(20.0);
+        //%%SNIPPET_START%% InfStartState
+        // Set the values of A and B so the Metropolis Hastings
+        // algorithm has a non-zero start state.
+        // Alternatively you could infer a possible start state
+        // using either a particle filter or something like
+        // bayesNet.probeForNonZeroProbability(100);
+        A.setValue(20.0);
+        B.setValue(20.0);
 
-BayesianNetwork bayesNet = new BayesianNetwork(C.getConnectedGraph());
-//%%SNIPPET_END%% InfStartState
+        BayesianNetwork bayesNet = new BayesianNetwork(C.getConnectedGraph());
+        //%%SNIPPET_END%% InfStartState
 
-//%%SNIPPET_START%% InfMetropolisHastings
-NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
-        bayesNet,
-        bayesNet.getLatentVertices(),
-        100000
-);
-//%%SNIPPET_END%% InfMetropolisHastings
+        //%%SNIPPET_START%% InfMetropolisHastings
+        NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
+            bayesNet,
+            bayesNet.getLatentVertices(),
+            100000
+        );
+        //%%SNIPPET_END%% InfMetropolisHastings
 
-//%%SNIPPET_START%% InfAverage
-double averagePosteriorA = posteriorSamples.getDoubleTensorSamples(A).getAverages().scalar(); //21.0
-double averagePosteriorB = posteriorSamples.getDoubleTensorSamples(B).getAverages().scalar(); //21.0
+        //%%SNIPPET_START%% InfAverage
+        double averagePosteriorA = posteriorSamples.getDoubleTensorSamples(A).getAverages().scalar(); //21.0
+        double averagePosteriorB = posteriorSamples.getDoubleTensorSamples(B).getAverages().scalar(); //21.0
 
-double actual = averagePosteriorA + averagePosteriorB; //42.0
-//%%SNIPPET_END%% InfAverage
+        double actual = averagePosteriorA + averagePosteriorB; //42.0
+        //%%SNIPPET_END%% InfAverage
     }
 
     private static void inferenceExample2() {
-BayesianNetwork bayesNet = null;
-KeanuRandom random = null;
+        BayesianNetwork bayesNet = null;
+        KeanuRandom random = null;
 
-//%%SNIPPET_START%% InfHamiltonian
-NetworkSamples posteriorSamples = Hamiltonian.withDefaultConfig().getPosteriorSamples(
-        bayesNet,
-        bayesNet.getLatentVertices(),
-        2000
-);
-//%%SNIPPET_END%% InfHamiltonian
+        //%%SNIPPET_START%% InfHamiltonian
+        NetworkSamples posteriorSamples = Hamiltonian.withDefaultConfig().getPosteriorSamples(
+            bayesNet,
+            bayesNet.getLatentVertices(),
+            2000
+        );
+        //%%SNIPPET_END%% InfHamiltonian
     }
 
     private static void nutsExample() {
         BayesianNetwork bayesNet = null;
         KeanuRandom random = null;
 
-//%%SNIPPET_START%% InfNuts
-NetworkSamples posteriorSamples = NUTS.withDefaultConfig().getPosteriorSamples(
-        bayesNet,
-        bayesNet.getLatentVertices(),
-        2000
-);
-//%%SNIPPET_END%% InfNuts
+        //%%SNIPPET_START%% InfNuts
+        NetworkSamples posteriorSamples = NUTS.withDefaultConfig().getPosteriorSamples(
+            bayesNet,
+            bayesNet.getLatentVertices(),
+            2000
+        );
+        //%%SNIPPET_END%% InfNuts
     }
 }

--- a/docs/src/test/java/io/improbable/snippet/Lorenz.kt
+++ b/docs/src/test/java/io/improbable/snippet/Lorenz.kt
@@ -17,53 +17,53 @@ private var error = Double.MAX_VALUE
 
 fun main(args: Array<String>) {
 
-//%%SNIPPET_START%% LorenzModel
-val model = LorenzModel()
-val lorenzCoordinates = model.runModel(maxWindows * windowSize)
-//%%SNIPPET_END%% LorenzModel
+    //%%SNIPPET_START%% LorenzModel
+    val model = LorenzModel()
+    val lorenzCoordinates = model.runModel(maxWindows * windowSize)
+    //%%SNIPPET_END%% LorenzModel
 
-//%%SNIPPET_START%% LorenzStartingPoint
-val random = DoubleVertexFactory()
-val origin = 0.0
-//%%SNIPPET_START%% LorenzStartValues
-var initX = random.nextGaussian(origin, 2.5)
-var initY = random.nextGaussian(origin, 2.5)
-var initZ = random.nextGaussian(origin, 2.5)
-//%%SNIPPET_END%% LorenzStartingPoint
-//%%SNIPPET_END%% LorenzStartValues
+    //%%SNIPPET_START%% LorenzStartingPoint
+    val random = DoubleVertexFactory()
+    val origin = 0.0
+    //%%SNIPPET_START%% LorenzStartValues
+    var initX = random.nextGaussian(origin, 2.5)
+    var initY = random.nextGaussian(origin, 2.5)
+    var initZ = random.nextGaussian(origin, 2.5)
+    //%%SNIPPET_END%% LorenzStartingPoint
+    //%%SNIPPET_END%% LorenzStartValues
 
-//%%SNIPPET_START%% LorenzIterate
-while (error > convergedError && window < maxWindows) {
-//%%SNIPPET_END%% LorenzIterate
+    //%%SNIPPET_START%% LorenzIterate
+    while (error > convergedError && window < maxWindows) {
+    //%%SNIPPET_END%% LorenzIterate
 
-val initialConditions = listOf(initX, initY, initZ)
-val graphTimeSteps = mutableListOf(initialConditions) as MutableList<List<DoubleVertex>>
+        val initialConditions = listOf(initX, initY, initZ)
+        val graphTimeSteps = mutableListOf(initialConditions) as MutableList<List<DoubleVertex>>
 
-calculateLorenzTimesteps(graphTimeSteps, windowSize)
+        calculateLorenzTimesteps(graphTimeSteps, windowSize)
 
-applyObservations(graphTimeSteps, windowSize, window, lorenzCoordinates, random)
+        applyObservations(graphTimeSteps, windowSize, window, lorenzCoordinates, random)
 
-//%%SNIPPET_START%% LorenzOptimise
-val net = BayesianNetwork(graphTimeSteps.first().first().connectedGraph)
-val optimiser = KeanuOptimizer.of(net)
-optimiser.maxAPosteriori()
-//%%SNIPPET_END%% LorenzOptimise
+        //%%SNIPPET_START%% LorenzOptimise
+        val net = BayesianNetwork(graphTimeSteps.first().first().connectedGraph)
+        val optimiser = KeanuOptimizer.of(net)
+        optimiser.maxAPosteriori()
+        //%%SNIPPET_END%% LorenzOptimise
 
-//%%SNIPPET_START%% LorenzNewStartValues
-val posterior = getTimestepValues(graphTimeSteps, windowSize - 1)
-val postTimestep = (window + 1) * (windowSize - 1)
-val coordinatesAtPostTimestep = lorenzCoordinates[postTimestep]
+        //%%SNIPPET_START%% LorenzNewStartValues
+        val posterior = getTimestepValues(graphTimeSteps, windowSize - 1)
+        val postTimestep = (window + 1) * (windowSize - 1)
+        val coordinatesAtPostTimestep = lorenzCoordinates[postTimestep]
 
-error = error(coordinatesAtPostTimestep, posterior)
-println("Error: " + error)
+        error = error(coordinatesAtPostTimestep, posterior)
+        println("Error: " + error)
 
-initX = random.nextGaussian(posterior[0], 2.5)
-initY = random.nextGaussian(posterior[1], 2.5)
-initZ = random.nextGaussian(posterior[2], 2.5)
-//%%SNIPPET_END%% LorenzNewStartValues
+        initX = random.nextGaussian(posterior[0], 2.5)
+        initY = random.nextGaussian(posterior[1], 2.5)
+        initZ = random.nextGaussian(posterior[2], 2.5)
+        //%%SNIPPET_END%% LorenzNewStartValues
 
-window++
-}
+        window++
+    }
 }
 
 //%%SNIPPET_START%% LorenzWindow
@@ -71,12 +71,12 @@ fun calculateLorenzTimesteps(graphTimeSteps: MutableList<List<DoubleVertex>>, wi
     for (i in 0.until(windowSize - 1)) {
         val startConditions = graphTimeSteps[i]
         val timesteppedCoordinates = lorenzTimestep(startConditions.first(),
-                startConditions[1],
-                startConditions.last(),
-                LorenzModel.timeStep,
-                LorenzModel.sigma,
-                LorenzModel.rho,
-                LorenzModel.beta)
+            startConditions[1],
+            startConditions.last(),
+            LorenzModel.timeStep,
+            LorenzModel.sigma,
+            LorenzModel.rho,
+            LorenzModel.beta)
         graphTimeSteps.add(timesteppedCoordinates)
     }
 }
@@ -116,9 +116,9 @@ fun getTimestepValues(graphTimeSteps: MutableList<List<DoubleVertex>>, time: Int
 
 fun error(coordinates: LorenzModel.Coordinates, posterior: List<Double>): Double {
     return Math.sqrt(
-            Math.pow(coordinates.x - posterior[0], 2.0) +
-                    Math.pow(coordinates.y - posterior[1], 2.0) +
-                    Math.pow(coordinates.z - posterior[2], 2.0)
+        Math.pow(coordinates.x - posterior[0], 2.0) +
+            Math.pow(coordinates.y - posterior[1], 2.0) +
+            Math.pow(coordinates.z - posterior[2], 2.0)
     )
 }
 //%%SNIPPET_END%% LorenzFull

--- a/docs/src/test/java/io/improbable/snippet/OptimizerExample.java
+++ b/docs/src/test/java/io/improbable/snippet/OptimizerExample.java
@@ -27,34 +27,34 @@ public class OptimizerExample {
     }
 
     private static double runGradientOptimizer(DoubleVertex temperature) {
-//%%SNIPPET_START%% GradientOptimizerMostProbable
-GradientOptimizer optimizer = KeanuOptimizer.Gradient.builderFor(temperature.getConnectedGraph())
-    .maxEvaluations(5000)
-    .relativeThreshold(1e-8)
-    .absoluteThreshold(1e-8)
-    .build();
-optimizer.maxAPosteriori();
+        //%%SNIPPET_START%% GradientOptimizerMostProbable
+        GradientOptimizer optimizer = KeanuOptimizer.Gradient.builderFor(temperature.getConnectedGraph())
+            .maxEvaluations(5000)
+            .relativeThreshold(1e-8)
+            .absoluteThreshold(1e-8)
+            .build();
+        optimizer.maxAPosteriori();
 
-double calculatedTemperature = temperature.getValue().scalar();
-//%%SNIPPET_END%% GradientOptimizerMostProbable
+        double calculatedTemperature = temperature.getValue().scalar();
+        //%%SNIPPET_END%% GradientOptimizerMostProbable
 
         return calculatedTemperature;
     }
 
     private static double runNonGradientOptimizer(DoubleVertex temperature) {
-//%%SNIPPET_START%% NonGradientOptimizerMostProbable
-OptimizerBounds temperatureBounds = new OptimizerBounds().addBound(temperature.getId(), -250., 250.0);
-NonGradientOptimizer optimizer = KeanuOptimizer.NonGradient.builderFor(temperature.getConnectedGraph())
-    .maxEvaluations(5000)
-    .boundsRange(100000)
-    .optimizerBounds(temperatureBounds)
-    .initialTrustRegionRadius(5.)
-    .stoppingTrustRegionRadius(2e-8)
-    .build();
-optimizer.maxAPosteriori();
+        //%%SNIPPET_START%% NonGradientOptimizerMostProbable
+        OptimizerBounds temperatureBounds = new OptimizerBounds().addBound(temperature.getId(), -250., 250.0);
+        NonGradientOptimizer optimizer = KeanuOptimizer.NonGradient.builderFor(temperature.getConnectedGraph())
+            .maxEvaluations(5000)
+            .boundsRange(100000)
+            .optimizerBounds(temperatureBounds)
+            .initialTrustRegionRadius(5.)
+            .stoppingTrustRegionRadius(2e-8)
+            .build();
+        optimizer.maxAPosteriori();
 
-double calculatedTemperature = temperature.getValue().scalar();
-//%%SNIPPET_END%% NonGradientOptimizerMostProbable
+        double calculatedTemperature = temperature.getValue().scalar();
+        //%%SNIPPET_END%% NonGradientOptimizerMostProbable
 
         return calculatedTemperature;
     }

--- a/docs/src/test/java/io/improbable/snippet/Overview.java
+++ b/docs/src/test/java/io/improbable/snippet/Overview.java
@@ -7,11 +7,11 @@ import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 public class Overview {
 
     public static void main(String[] args) {
-//%%SNIPPET_START%% Overview
-DoubleVertex x = new UniformVertex(1, 2);
-DoubleVertex y = x.times(2);
-DoubleVertex observedY = new UniformVertex(new long[]{1, 2}, y, y.plus(0.5));
-observedY.observe(new double[]{4.0, 4.49});
-//%%SNIPPET_END%% Overview
+        //%%SNIPPET_START%% Overview
+        DoubleVertex x = new UniformVertex(1, 2);
+        DoubleVertex y = x.times(2);
+        DoubleVertex observedY = new UniformVertex(new long[]{1, 2}, y, y.plus(0.5));
+        observedY.observe(new double[]{4.0, 4.49});
+        //%%SNIPPET_END%% Overview
     }
 }

--- a/docs/src/test/java/io/improbable/snippet/ParticleFilterExample.java
+++ b/docs/src/test/java/io/improbable/snippet/ParticleFilterExample.java
@@ -10,33 +10,33 @@ import java.util.List;
 
 public class ParticleFilterExample {
     public static void particleFilterExample() {
-//%%SNIPPET_START%% ParticleFilterExample
-//Create a dummy Bayesian Network
-DoubleVertex temperature = new UniformVertex(0.0, 100.0);
-DoubleVertex noiseAMu = new GaussianVertex(0.0, 2.0);
-DoubleVertex noiseA = new GaussianVertex(noiseAMu, 2.0);
-DoubleVertex noiseBMu = new GaussianVertex(0.0, 2.0);
-DoubleVertex noiseB = new GaussianVertex(noiseBMu, 2.0);
-DoubleVertex thermometerA = new GaussianVertex(temperature.plus(noiseA), 1.0);
-DoubleVertex thermometerB = new GaussianVertex(temperature.plus(noiseB), 1.0);
-thermometerA.observe(21.0);
-thermometerB.observe(19.5);
+        //%%SNIPPET_START%% ParticleFilterExample
+        //Create a dummy Bayesian Network
+        DoubleVertex temperature = new UniformVertex(0.0, 100.0);
+        DoubleVertex noiseAMu = new GaussianVertex(0.0, 2.0);
+        DoubleVertex noiseA = new GaussianVertex(noiseAMu, 2.0);
+        DoubleVertex noiseBMu = new GaussianVertex(0.0, 2.0);
+        DoubleVertex noiseB = new GaussianVertex(noiseBMu, 2.0);
+        DoubleVertex thermometerA = new GaussianVertex(temperature.plus(noiseA), 1.0);
+        DoubleVertex thermometerB = new GaussianVertex(temperature.plus(noiseB), 1.0);
+        thermometerA.observe(21.0);
+        thermometerB.observe(19.5);
 
-//Create a particle filter with default settings
-ParticleFilter filter = ParticleFilter.ofVertexInGraph(temperature)
-        .build();
+        //Create a particle filter with default settings
+        ParticleFilter filter = ParticleFilter.ofVertexInGraph(temperature)
+            .build();
 
-//Get a sorted list of the most probable particles in order of descending probability
-List<Particle> particles = filter.getSortedMostProbableParticles();
+        //Get a sorted list of the most probable particles in order of descending probability
+        List<Particle> particles = filter.getSortedMostProbableParticles();
 
-//Get the most probable particle
-Particle mostProbableParticle = filter.getMostProbableParticle();
+        //Get the most probable particle
+        Particle mostProbableParticle = filter.getMostProbableParticle();
 
-//Get the estimated temperature in the most probable particle
-double estimation = mostProbableParticle.getScalarValueOfVertex(temperature);
+        //Get the estimated temperature in the most probable particle
+        double estimation = mostProbableParticle.getScalarValueOfVertex(temperature);
 
-//Get the probability of this particle state
-double logProb = mostProbableParticle.logProb();
-//%%SNIPPET_END%% ParticleFilterExample
+        //Get the probability of this particle state
+        double logProb = mostProbableParticle.logProb();
+        //%%SNIPPET_END%% ParticleFilterExample
     }
 }

--- a/docs/src/test/java/io/improbable/snippet/PlatesExample.java
+++ b/docs/src/test/java/io/improbable/snippet/PlatesExample.java
@@ -12,38 +12,40 @@ import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import java.util.List;
 
 public class PlatesExample {
-//%%SNIPPET_START%% PlatesData
-public static class MyData {
-    public double x;
-    public double y;
+    //%%SNIPPET_START%% PlatesData
+    public static class MyData {
+        public double x;
+        public double y;
 
-    public MyData(String x, String y) {
-        this.x = Double.parseDouble(x);
-        this.y = Double.parseDouble(y);
+        public MyData(String x, String y) {
+            this.x = Double.parseDouble(x);
+            this.y = Double.parseDouble(y);
+        }
     }
-}
-//%%SNIPPET_END%% PlatesData
-//%%SNIPPET_START%% Plates
-/**
-    * Each plate contains a linear regression model:
-    * VertexY = VertexX * VertexM + VertexB
-    * @param dataFileName The input data file defines, for each plate:
-    *                          - the value of the input, VertexX
-    *                          - the value of the observed output, VertexY
-    */
-public Plates buildPlates(String dataFileName) {
-    //Parse the csv data to MyData objects
-    List<MyData> allMyData = ReadCsv.fromFile(dataFileName)
+    //%%SNIPPET_END%% PlatesData
+    //%%SNIPPET_START%% Plates
+
+    /**
+     * Each plate contains a linear regression model:
+     * VertexY = VertexX * VertexM + VertexB
+     *
+     * @param dataFileName The input data file defines, for each plate:
+     *                     - the value of the input, VertexX
+     *                     - the value of the observed output, VertexY
+     */
+    public Plates buildPlates(String dataFileName) {
+        //Parse the csv data to MyData objects
+        List<MyData> allMyData = ReadCsv.fromFile(dataFileName)
             .asRowsDefinedBy(MyData.class)
             .load();
 
-    DoubleVertex m = new GaussianVertex(0, 1);
-    DoubleVertex b = new GaussianVertex(0, 1);
-    VertexLabel xLabel = new VertexLabel("x");
-    VertexLabel yLabel = new VertexLabel("y");
+        DoubleVertex m = new GaussianVertex(0, 1);
+        DoubleVertex b = new GaussianVertex(0, 1);
+        VertexLabel xLabel = new VertexLabel("x");
+        VertexLabel yLabel = new VertexLabel("y");
 
-    //Build plates from each line in the csv
-    Plates plates = new PlateBuilder<MyData>()
+        //Build plates from each line in the csv
+        Plates plates = new PlateBuilder<MyData>()
             .fromIterator(allMyData.iterator())
             .withFactory((plate, csvMyData) -> {
 
@@ -59,15 +61,15 @@ public Plates buildPlates(String dataFileName) {
             })
             .build();
 
-    //now you have access to the "x" from any one of the plates
-    DoubleTensor valueForXAtCSVLine1 = plates.asList()
+        //now you have access to the "x" from any one of the plates
+        DoubleTensor valueForXAtCSVLine1 = plates.asList()
             .get(1) // get plate 1 which is built from csv line 1
             .<DoubleVertex>get(xLabel) //get the vertex that we labelled "x" in that plate
             .getValue(); //get the value from that vertex
 
-    //Now run an inference algorithm on vertex m and vertex b and you have linear regression
+        //Now run an inference algorithm on vertex m and vertex b and you have linear regression
 
-    return plates;
-}
-//%%SNIPPET_END%% Plates
+        return plates;
+    }
+    //%%SNIPPET_END%% Plates
 }

--- a/docs/src/test/java/io/improbable/snippet/SaveLoadExamples.java
+++ b/docs/src/test/java/io/improbable/snippet/SaveLoadExamples.java
@@ -16,55 +16,55 @@ import java.io.OutputStream;
 
 public class SaveLoadExamples {
 
-//%%SNIPPET_START%% SaveToProtobuf
-public void saveNetToProtobuf(BayesianNetwork net,
-                                OutputStream outputStream,
-                                boolean saveValuesAndObservations) throws IOException {
-    NetworkSaver saver = new ProtobufSaver(net);
-    saver.save(outputStream, saveValuesAndObservations);
-}
-//%%SNIPPET_END%% SaveToProtobuf
+    //%%SNIPPET_START%% SaveToProtobuf
+    public void saveNetToProtobuf(BayesianNetwork net,
+                                  OutputStream outputStream,
+                                  boolean saveValuesAndObservations) throws IOException {
+        NetworkSaver saver = new ProtobufSaver(net);
+        saver.save(outputStream, saveValuesAndObservations);
+    }
+    //%%SNIPPET_END%% SaveToProtobuf
 
-//%%SNIPPET_START%% SaveToJSON
-public void saveNetToJSON(BayesianNetwork net,
-                          OutputStream outputStream,
-                          boolean saveValuesAndObservations) throws IOException {
-    NetworkSaver saver = new JsonSaver(net);
-    saver.save(outputStream, saveValuesAndObservations);
-}
-//%%SNIPPET_END%% SaveToJSON
+    //%%SNIPPET_START%% SaveToJSON
+    public void saveNetToJSON(BayesianNetwork net,
+                              OutputStream outputStream,
+                              boolean saveValuesAndObservations) throws IOException {
+        NetworkSaver saver = new JsonSaver(net);
+        saver.save(outputStream, saveValuesAndObservations);
+    }
+    //%%SNIPPET_END%% SaveToJSON
 
-//%%SNIPPET_START%% SaveToDot
-public void saveNetToDotFile(BayesianNetwork net,
-                             OutputStream outputStream,
-                             boolean saveValuesAndObservations) throws IOException {
-    NetworkSaver saver = new DotSaver(net);
-    saver.save(outputStream, saveValuesAndObservations);
-}
-//%%SNIPPET_END%% SaveToDot
+    //%%SNIPPET_START%% SaveToDot
+    public void saveNetToDotFile(BayesianNetwork net,
+                                 OutputStream outputStream,
+                                 boolean saveValuesAndObservations) throws IOException {
+        NetworkSaver saver = new DotSaver(net);
+        saver.save(outputStream, saveValuesAndObservations);
+    }
+    //%%SNIPPET_END%% SaveToDot
 
-//%%SNIPPET_START%% SavePartialToDot
-public void savePartialNetToDot(Vertex startingVertex,
-                                int degree,
-                                BayesianNetwork net,
-                                OutputStream outputStream,
-                                boolean saveValuesAndObservations) throws IOException {
-    DotSaver saver = new DotSaver(net);
-    saver.save(outputStream, startingVertex, degree, saveValuesAndObservations);
-}
-//%%SNIPPET_END%% SavePartialToDot
+    //%%SNIPPET_START%% SavePartialToDot
+    public void savePartialNetToDot(Vertex startingVertex,
+                                    int degree,
+                                    BayesianNetwork net,
+                                    OutputStream outputStream,
+                                    boolean saveValuesAndObservations) throws IOException {
+        DotSaver saver = new DotSaver(net);
+        saver.save(outputStream, startingVertex, degree, saveValuesAndObservations);
+    }
+    //%%SNIPPET_END%% SavePartialToDot
 
-//%%SNIPPET_START%% LoadFromProtobuf
-public BayesianNetwork loadNetFromProtobuf(InputStream input) throws IOException {
-    NetworkLoader loader = new ProtobufLoader();
-    return loader.loadNetwork(input);
-}
-//%%SNIPPET_END%% LoadFromProtobuf
+    //%%SNIPPET_START%% LoadFromProtobuf
+    public BayesianNetwork loadNetFromProtobuf(InputStream input) throws IOException {
+        NetworkLoader loader = new ProtobufLoader();
+        return loader.loadNetwork(input);
+    }
+    //%%SNIPPET_END%% LoadFromProtobuf
 
-//%%SNIPPET_START%% LoadFromJSON
-public BayesianNetwork loadNetFromJSON(InputStream input) throws IOException {
-    NetworkLoader loader = new JsonLoader();
-    return loader.loadNetwork(input);
-}
-//%%SNIPPET_END%% LoadFromJSON
+    //%%SNIPPET_START%% LoadFromJSON
+    public BayesianNetwork loadNetFromJSON(InputStream input) throws IOException {
+        NetworkLoader loader = new JsonLoader();
+        return loader.loadNetwork(input);
+    }
+    //%%SNIPPET_END%% LoadFromJSON
 }

--- a/docs/src/test/java/io/improbable/snippet/SelectVertexExample.java
+++ b/docs/src/test/java/io/improbable/snippet/SelectVertexExample.java
@@ -11,21 +11,21 @@ import static io.improbable.snippet.SelectVertexExample.MyType.*;
 
 public class SelectVertexExample {
 
-//%%SNIPPET_START%% VertexSelectVertexCode
-public enum MyType {
-    A, B, C, D
-}
+    //%%SNIPPET_START%% VertexSelectVertexCode
+    public enum MyType {
+        A, B, C, D
+    }
 
-public CategoricalVertex<MyType, GenericTensor<MyType>> getSelectorForMyType() {
+    public CategoricalVertex<MyType, GenericTensor<MyType>> getSelectorForMyType() {
 
-    LinkedHashMap<MyType, DoubleVertex> frequency = new LinkedHashMap<>();
-    frequency.put(A, new ConstantDoubleVertex(0.25));
-    frequency.put(B, new ConstantDoubleVertex(0.25));
-    frequency.put(C, new ConstantDoubleVertex(0.25));
-    frequency.put(D, new ConstantDoubleVertex(0.25));
+        LinkedHashMap<MyType, DoubleVertex> frequency = new LinkedHashMap<>();
+        frequency.put(A, new ConstantDoubleVertex(0.25));
+        frequency.put(B, new ConstantDoubleVertex(0.25));
+        frequency.put(C, new ConstantDoubleVertex(0.25));
+        frequency.put(D, new ConstantDoubleVertex(0.25));
 
-    return new CategoricalVertex<>(frequency);
-}
-//%%SNIPPET_END%% VertexSelectVertexCode
+        return new CategoricalVertex<>(frequency);
+    }
+    //%%SNIPPET_END%% VertexSelectVertexCode
 
 }

--- a/docs/src/test/java/io/improbable/snippet/SimpleLinearRegressionExample.java
+++ b/docs/src/test/java/io/improbable/snippet/SimpleLinearRegressionExample.java
@@ -9,32 +9,32 @@ import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 
 public class SimpleLinearRegressionExample {
     public static void main(String[] args) {
-//%%SNIPPET_START%% SimpleLinearRegressionExample
-//Define Model Parameters
-double weight = 2.0;
-double offset = 20.0;
-int numberOfSamples = 100;
+        //%%SNIPPET_START%% SimpleLinearRegressionExample
+        //Define Model Parameters
+        double weight = 2.0;
+        double offset = 20.0;
+        int numberOfSamples = 100;
 
-//Define random input data vertex by sampling from uniform probability distribution between 0 and 10
-DoubleVertex xGenerator = new UniformVertex(new long[]{1, numberOfSamples}, 0, 10);
+        //Define random input data vertex by sampling from uniform probability distribution between 0 and 10
+        DoubleVertex xGenerator = new UniformVertex(new long[]{1, numberOfSamples}, 0, 10);
 
-//Define the desired output vertices
-DoubleVertex yMu = xGenerator.multiply(weight).plus(offset);
+        //Define the desired output vertices
+        DoubleVertex yMu = xGenerator.multiply(weight).plus(offset);
 
-//Define a vertex for taking noisy readings of output data
-DoubleVertex yGenerator = new GaussianVertex(yMu, 1.0);
+        //Define a vertex for taking noisy readings of output data
+        DoubleVertex yGenerator = new GaussianVertex(yMu, 1.0);
 
-//Sample input data and then sample the corresponding noisy output data
-DoubleTensor xData = xGenerator.sample();
-xGenerator.setAndCascade(xData);
-DoubleTensor yData = yGenerator.sample();
+        //Sample input data and then sample the corresponding noisy output data
+        DoubleTensor xData = xGenerator.sample();
+        xGenerator.setAndCascade(xData);
+        DoubleTensor yData = yGenerator.sample();
 
-//Create a simple linear regression model and fit it with our input and output data
-RegressionModel regressionModel = RegressionModel.withTrainingData(xData, yData)
-    .withRegularization(RegressionRegularization.NONE)
-    .build();
+        //Create a simple linear regression model and fit it with our input and output data
+        RegressionModel regressionModel = RegressionModel.withTrainingData(xData, yData)
+            .withRegularization(RegressionRegularization.NONE)
+            .build();
 
-//It is now possible to use regressionModel.predict(value) to get a prediction of the output given an input value.
-//%%SNIPPET_END%% SimpleLinearRegressionExample
+        //It is now possible to use regressionModel.predict(value) to get a prediction of the output given an input value.
+        //%%SNIPPET_END%% SimpleLinearRegressionExample
     }
 }

--- a/docs/src/test/java/io/improbable/snippet/Tensors.java
+++ b/docs/src/test/java/io/improbable/snippet/Tensors.java
@@ -20,100 +20,100 @@ public class Tensors {
     @Ignore
     public void doesSimpleTensorInferenceExample() {
 
-//%%SNIPPET_START%% TensorExample
-DoubleVertex muA = ConstantVertex.of(new double[]{0.5, 1.5});
-DoubleVertex A = new GaussianVertex(new long[]{1, 2}, muA, 1);
-DoubleVertex B = ConstantVertex.of(new double[]{3, 4});
+        //%%SNIPPET_START%% TensorExample
+        DoubleVertex muA = ConstantVertex.of(new double[]{0.5, 1.5});
+        DoubleVertex A = new GaussianVertex(new long[]{1, 2}, muA, 1);
+        DoubleVertex B = ConstantVertex.of(new double[]{3, 4});
 
-DoubleVertex C = A.times(B);
-DoubleVertex CObservation = new GaussianVertex(C, 1);
-CObservation.observe(new double[]{6, 12});
+        DoubleVertex C = A.times(B);
+        DoubleVertex CObservation = new GaussianVertex(C, 1);
+        CObservation.observe(new double[]{6, 12});
 
-//Use algorithm to find MAP or posterior samples for A and/or B
-Optimizer optimizer = KeanuOptimizer.of(new BayesianNetwork(A.getConnectedGraph()));
-optimizer.maxLikelihood();
-//%%SNIPPET_END%% TensorExample
+        //Use algorithm to find MAP or posterior samples for A and/or B
+        Optimizer optimizer = KeanuOptimizer.of(new BayesianNetwork(A.getConnectedGraph()));
+        optimizer.maxLikelihood();
+        //%%SNIPPET_END%% TensorExample
 
-assertArrayEquals(new double[]{2.0, 3.0}, A.getValue().asFlatDoubleArray(), 1e-2);
+        assertArrayEquals(new double[]{2.0, 3.0}, A.getValue().asFlatDoubleArray(), 1e-2);
     }
 
     private static void tensorExamples1() {
-//%%SNIPPET_START%% TensorSharedValue
-DoubleTensor dTensor = DoubleTensor.create(5, new long[]{1, 4});     //[5, 5, 5, 5]
-IntegerTensor iTensor = IntegerTensor.create(1, new long[]{1, 4});    //[1, 1, 1, 1]
-BooleanTensor bTensor = BooleanTensor.create(true, new long[]{1, 4}); //[true, true, true, true]
-//%%SNIPPET_END%% TensorSharedValue
+        //%%SNIPPET_START%% TensorSharedValue
+        DoubleTensor dTensor = DoubleTensor.create(5, new long[]{1, 4});     //[5, 5, 5, 5]
+        IntegerTensor iTensor = IntegerTensor.create(1, new long[]{1, 4});    //[1, 1, 1, 1]
+        BooleanTensor bTensor = BooleanTensor.create(true, new long[]{1, 4}); //[true, true, true, true]
+        //%%SNIPPET_END%% TensorSharedValue
     }
 
     private static void tensorExamples2() {
-//%%SNIPPET_START%% Tensor2by2
-DoubleTensor dTensor = DoubleTensor.create(new double[]{0.5, 1.5, 2.5, 3.5}, new long[]{2, 2});
-IntegerTensor iTensor = IntegerTensor.create(new int[]{1, 2, 3, 4}, new long[]{2, 2});
-BooleanTensor bTensor = BooleanTensor.create(new boolean[]{true, true, false, false}, new long[]{2, 2});
-//%%SNIPPET_END%% Tensor2by2
+        //%%SNIPPET_START%% Tensor2by2
+        DoubleTensor dTensor = DoubleTensor.create(new double[]{0.5, 1.5, 2.5, 3.5}, new long[]{2, 2});
+        IntegerTensor iTensor = IntegerTensor.create(new int[]{1, 2, 3, 4}, new long[]{2, 2});
+        BooleanTensor bTensor = BooleanTensor.create(new boolean[]{true, true, false, false}, new long[]{2, 2});
+        //%%SNIPPET_END%% Tensor2by2
     }
 
     private static void tensorExample3() {
-//%%SNIPPET_START%% TensorReshape
-DoubleTensor tensor = DoubleTensor.create(new double[]{0.5, 1.5, 2.5, 3.5}, new long[]{2, 2});
-tensor.getShape();       //[2, 2]
-tensor.reshape(1, 4);
-tensor.getShape();       //[1, 4]
-//%%SNIPPET_END%% TensorReshape
+        //%%SNIPPET_START%% TensorReshape
+        DoubleTensor tensor = DoubleTensor.create(new double[]{0.5, 1.5, 2.5, 3.5}, new long[]{2, 2});
+        tensor.getShape();       //[2, 2]
+        tensor.reshape(1, 4);
+        tensor.getShape();       //[1, 4]
+        //%%SNIPPET_END%% TensorReshape
     }
 
     private static void tensorOps() {
-//%%SNIPPET_START%% TensorOps
-DoubleTensor tensor = DoubleTensor.create(new double[]{1, 2, 3, 4}, new long[]{2, 2});
-tensor.plus(1.0);           // [2, 3, 4, 5]
-tensor.times(2.0);          // [4, 6, 8, 10]
-tensor.pow(2);              // [16, 36, 64, 100]
-tensor.sin();               // [-0.2879, -0.9918, 0.9200, -0.5064]
-double sum = tensor.sum();  // -0.86602...
-//%%SNIPPET_END%% TensorOps
+        //%%SNIPPET_START%% TensorOps
+        DoubleTensor tensor = DoubleTensor.create(new double[]{1, 2, 3, 4}, new long[]{2, 2});
+        tensor.plus(1.0);           // [2, 3, 4, 5]
+        tensor.times(2.0);          // [4, 6, 8, 10]
+        tensor.pow(2);              // [16, 36, 64, 100]
+        tensor.sin();               // [-0.2879, -0.9918, 0.9200, -0.5064]
+        double sum = tensor.sum();  // -0.86602...
+        //%%SNIPPET_END%% TensorOps
     }
 
     private static void tensorVertex() {
-//%%SNIPPET_START%% TensorVertexCreate
-GaussianVertex vertex = new GaussianVertex(new long[]{1, 100}, 0, 1);
-//%%SNIPPET_END%% TensorVertexCreate
-//%%SNIPPET_START%% TensorVertexInspection
-DoubleTensor samples = vertex.sample();
-samples.getShape();         //[1, 100]
-samples.getLength();        //100
-samples.getValue(0, 50);    //Returns the sample of the 50th Gaussian
-//%%SNIPPET_END%% TensorVertexInspection
+        //%%SNIPPET_START%% TensorVertexCreate
+        GaussianVertex vertex = new GaussianVertex(new long[]{1, 100}, 0, 1);
+        //%%SNIPPET_END%% TensorVertexCreate
+        //%%SNIPPET_START%% TensorVertexInspection
+        DoubleTensor samples = vertex.sample();
+        samples.getShape();         //[1, 100]
+        samples.getLength();        //100
+        samples.getValue(0, 50);    //Returns the sample of the 50th Gaussian
+        //%%SNIPPET_END%% TensorVertexInspection
     }
 
     private static void tensorVector() {
-//%%SNIPPET_START%% TensorVector
-long[] shape = new long[]{3, 1};
-DoubleVertex mu = new ConstantDoubleVertex(new double[]{1, 2, 3});
-GaussianVertex vertex = new GaussianVertex(shape, mu, 0);
-/** Creates a GaussianVertex that looks like...
-* [ Gaussian(mu: 1, sigma: 0),
-*   Gaussian(mu: 2, sigma: 0),
-*   Gaussian(mu: 3, sigma: 0) ]
-*/
-//%%SNIPPET_END%% TensorVector
+        //%%SNIPPET_START%% TensorVector
+        long[] shape = new long[]{3, 1};
+        DoubleVertex mu = new ConstantDoubleVertex(new double[]{1, 2, 3});
+        GaussianVertex vertex = new GaussianVertex(shape, mu, 0);
+        /** Creates a GaussianVertex that looks like...
+         * [ Gaussian(mu: 1, sigma: 0),
+         *   Gaussian(mu: 2, sigma: 0),
+         *   Gaussian(mu: 3, sigma: 0) ]
+         */
+        //%%SNIPPET_END%% TensorVector
     }
 
     private static void tensorFinal() {
-//%%SNIPPET_START%% TensorFinal
-DoubleVertex muA = ConstantVertex.of(new double[]{0.5, 1.5});
-DoubleVertex A = new GaussianVertex(new long[]{1, 2}, muA, 1);
-DoubleVertex B = ConstantVertex.of(new double[]{3, 4});
+        //%%SNIPPET_START%% TensorFinal
+        DoubleVertex muA = ConstantVertex.of(new double[]{0.5, 1.5});
+        DoubleVertex A = new GaussianVertex(new long[]{1, 2}, muA, 1);
+        DoubleVertex B = ConstantVertex.of(new double[]{3, 4});
 
-DoubleVertex C = A.times(B);
-DoubleVertex CObservation = new GaussianVertex(C, 1);
-CObservation.observe(new double[]{6, 12});
+        DoubleVertex C = A.times(B);
+        DoubleVertex CObservation = new GaussianVertex(C, 1);
+        CObservation.observe(new double[]{6, 12});
 
-//Use algorithm to find MAP or posterior samples for A and/or B
-Optimizer optimizer = KeanuOptimizer.of(new BayesianNetwork(A.getConnectedGraph()));
-optimizer.maxAPosteriori();
+        //Use algorithm to find MAP or posterior samples for A and/or B
+        Optimizer optimizer = KeanuOptimizer.of(new BayesianNetwork(A.getConnectedGraph()));
+        optimizer.maxAPosteriori();
 
-//Retrieve the most likely estimate using MAP estimation
-DoubleTensor mostLikelyEstimate = A.getValue(); //approximately [2, 3]
-//%%SNIPPET_END%% TensorFinal
+        //Retrieve the most likely estimate using MAP estimation
+        DoubleTensor mostLikelyEstimate = A.getValue(); //approximately [2, 3]
+        //%%SNIPPET_END%% TensorFinal
     }
 }

--- a/docs/src/test/java/io/improbable/snippet/WetGrass.java
+++ b/docs/src/test/java/io/improbable/snippet/WetGrass.java
@@ -25,47 +25,47 @@ public class WetGrass {
     @Test
     public void doesFindCorrectProbability() {
 
-//%%SNIPPET_START%% Wetgrass
-//There's a simple 20% chance of rain and for the purposes
-//of this example, that doesn't depend on any other variables.
-BoolVertex rain = new BernoulliVertex(0.2);
+        //%%SNIPPET_START%% Wetgrass
+        //There's a simple 20% chance of rain and for the purposes
+        //of this example, that doesn't depend on any other variables.
+        BoolVertex rain = new BernoulliVertex(0.2);
 
-//The probability of the sprinkler being on is dependent on
-//whether or not it has rained. It's very unlikely that the
-//sprinkler comes on if it's raining.
-BoolVertex sprinkler = new BernoulliVertex(
-        If.isTrue(rain)
+        //The probability of the sprinkler being on is dependent on
+        //whether or not it has rained. It's very unlikely that the
+        //sprinkler comes on if it's raining.
+        BoolVertex sprinkler = new BernoulliVertex(
+            If.isTrue(rain)
                 .then(0.01)
                 .orElse(0.4)
-);
+        );
 
-//The grass being wet is dependent on whether or not it rained or
-//the sprinkler was on.
-// The following probabilities are the same as those used in Wikipedia article linked above.
-BoolVertex wetGrass = new BernoulliVertex(
-        ConditionalProbabilityTable.of(sprinkler, rain)
+        //The grass being wet is dependent on whether or not it rained or
+        //the sprinkler was on.
+        // The following probabilities are the same as those used in Wikipedia article linked above.
+        BoolVertex wetGrass = new BernoulliVertex(
+            ConditionalProbabilityTable.of(sprinkler, rain)
                 .when(false, false).then(0.001)
                 .when(false, true).then(0.8)
                 .when(true, false).then(0.9)
                 .orDefault(0.99)
-);
+        );
 
-//We observe that the grass is wet
-wetGrass.observe(true);
+        //We observe that the grass is wet
+        wetGrass.observe(true);
 
-//What does that observation say about the probability that it rained or that
-//the sprinkler was on?
-NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
-        new BayesianNetwork(wetGrass.getConnectedGraph()),
-        Arrays.asList(sprinkler, rain),
-        100000
-).drop(10000).downSample(2);
+        //What does that observation say about the probability that it rained or that
+        //the sprinkler was on?
+        NetworkSamples posteriorSamples = MetropolisHastings.withDefaultConfig().getPosteriorSamples(
+            new BayesianNetwork(wetGrass.getConnectedGraph()),
+            Arrays.asList(sprinkler, rain),
+            100000
+        ).drop(10000).downSample(2);
 
-double probabilityOfRainGivenWetGrass = posteriorSamples.get(rain).probability(isRaining -> isRaining.scalar() == true);
+        double probabilityOfRainGivenWetGrass = posteriorSamples.get(rain).probability(isRaining -> isRaining.scalar() == true);
 
-System.out.println(probabilityOfRainGivenWetGrass);
-//%%SNIPPET_END%% Wetgrass
+        System.out.println(probabilityOfRainGivenWetGrass);
+        //%%SNIPPET_END%% Wetgrass
 
-assertEquals(0.358, probabilityOfRainGivenWetGrass, 0.1);
+        assertEquals(0.358, probabilityOfRainGivenWetGrass, 0.1);
     }
 }


### PR DESCRIPTION
`snippet_writer.py` is a script we use for extracting snippets out of Java examples for the docs. Previously it did a straight copy from the source file and therefore included any leading whitespace the block of code had in the snippet. This required either poorly formatting the source files or modifying the generated snippet so that it formatted correctly on the shiny docs.

# In this PR
 - `snippet_writer.py` modified to remove leading whitespace from the block
 - Existing Java source code reformatted using IntelliJ formatter
 - Generated snippets updated with this formatting.

Note: commit 46550fc is where the generated snippets are updated with IntelliJ formatting so it may be easier to initially review without the diff of this commit.