### PR TITLE
Add title to index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: homepage
 keywords:
 
 # Hero section
-title: 
+title: Keanu Docs
 description: Keanu is a general-purpose probabilistic programming library. The main
              design goal is to build a Bayesian inference tool that scales to a point where
              we can model the world and therefore optimize it.


### PR DESCRIPTION
Currently the index page displays "https://improbable-research.github.io/keanu/" as the title. Changed this to "Keanu Docs".