### PR TITLE
Use interface defaults for PosteriorSamplingAlgorithms

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -13,7 +13,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,12 +75,6 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
                                               final int sampleCount) {
         return generatePosteriorSamples(bayesNet, fromVertices)
             .generate(sampleCount);
-    }
-
-    public NetworkSamples getPosteriorSamples(final BayesianNetwork bayesNet,
-                                              final Vertex fromVertex,
-                                              final int sampleCount) {
-        return getPosteriorSamples(bayesNet, Collections.singletonList(fromVertex), sampleCount);
     }
 
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesNet,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -16,7 +16,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,13 +75,6 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
                                               List<? extends Vertex> verticesToSampleFrom,
                                               int sampleCount) {
         return generatePosteriorSamples(bayesianNetwork, verticesToSampleFrom)
-            .generate(sampleCount);
-    }
-
-    public NetworkSamples getPosteriorSamples(BayesianNetwork bayesianNetwork,
-                                              Vertex vertexToSampleFrom,
-                                              int sampleCount) {
-        return generatePosteriorSamples(bayesianNetwork, Collections.singletonList(vertexToSampleFrom))
             .generate(sampleCount);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/NUTS.java
@@ -15,7 +15,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,17 +85,12 @@ public class NUTS implements PosteriorSamplingAlgorithm {
      * @param sampleFromVertices the vertices inside the bayesNet to sample from
      * @return Samples taken with NUTS
      */
+    @Override
     public NetworkSamples getPosteriorSamples(final BayesianNetwork bayesNet,
                                               final List<? extends Vertex> sampleFromVertices,
                                               final int sampleCount) {
         return generatePosteriorSamples(bayesNet, sampleFromVertices)
             .generate(sampleCount);
-    }
-
-    public NetworkSamples getPosteriorSamples(final BayesianNetwork bayesNet,
-                                              final Vertex fromVertex,
-                                              final int sampleCount) {
-        return getPosteriorSamples(bayesNet, Collections.singletonList(fromVertex), sampleCount);
     }
 
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesNet,


### PR DESCRIPTION
Some of the code within the samplers is redundant as the `PosteriorSamplingAlgorithm` interface has default methods that provide the same functionality.