### PR TITLE
tidy up the Vertex class hierarchy

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/GenericTensorVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/GenericTensorVertex.java
@@ -1,0 +1,14 @@
+package io.improbable.keanu.vertices.generic;
+
+import io.improbable.keanu.tensor.Tensor;
+
+public abstract class GenericTensorVertex<T extends Tensor> extends GenericVertex<T> {
+
+    public GenericTensorVertex() {
+        super();
+    }
+
+    public GenericTensorVertex(long[] shape) {
+        super(shape);
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/GenericVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/GenericVertex.java
@@ -1,0 +1,14 @@
+package io.improbable.keanu.vertices.generic;
+
+import io.improbable.keanu.vertices.Vertex;
+
+public abstract class GenericVertex<T> extends Vertex<T> {
+
+    public GenericVertex() {
+        super();
+    }
+
+    public GenericVertex(long[] shape) {
+        super(shape);
+    }
+}

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/CPTVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/CPTVertex.java
@@ -5,11 +5,12 @@ import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.NonSaveableVertex;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.generic.GenericTensorVertex;
 
 import java.util.List;
 import java.util.Map;
 
-public class CPTVertex<OUT extends Tensor> extends Vertex<OUT> implements NonProbabilistic<OUT>, NonSaveableVertex {
+public class CPTVertex<OUT extends Tensor> extends GenericTensorVertex<OUT> implements NonProbabilistic<OUT>, NonSaveableVertex {
 
     private final List<Vertex<? extends Tensor<Boolean>>> inputs;
     private final Map<CPTCondition, ? extends Vertex<OUT>> conditions;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/ConstantGenericVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/ConstantGenericVertex.java
@@ -2,10 +2,10 @@ package io.improbable.keanu.vertices.generic.nonprobabilistic;
 
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.NonSaveableVertex;
-import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.generic.GenericVertex;
 
-public class ConstantGenericVertex<T> extends Vertex<T> implements NonProbabilistic<T>, NonSaveableVertex {
+public class ConstantGenericVertex<T> extends GenericVertex<T> implements NonProbabilistic<T>, NonSaveableVertex {
 
     public ConstantGenericVertex(T value) {
         setValue(value);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/IfVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/IfVertex.java
@@ -8,8 +8,9 @@ import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.SaveVertexParam;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.generic.GenericTensorVertex;
 
-public class IfVertex<T> extends Vertex<Tensor<T>> implements NonProbabilistic<Tensor<T>> {
+public class IfVertex<T> extends GenericTensorVertex<Tensor<T>> implements NonProbabilistic<Tensor<T>> {
 
     private final static String PREDICATE_NAME = "predicate";
     private final static String THEN_NAME = "then";

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/MultiplexerVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/MultiplexerVertex.java
@@ -6,9 +6,10 @@ import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.SaveVertexParam;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.generic.GenericVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 
-public class MultiplexerVertex<T> extends Vertex<T> implements NonProbabilistic<T> {
+public class MultiplexerVertex<T> extends GenericVertex<T> implements NonProbabilistic<T> {
 
     private final static String SELECTOR_CONTROL_NAME = "selectorControlVertex";
     private final static String SELECT_VERTICES_NAME = "selectVertices";

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/binary/BinaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/binary/BinaryOpVertex.java
@@ -3,8 +3,9 @@ package io.improbable.keanu.vertices.generic.nonprobabilistic.operators.binary;
 import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.generic.GenericVertex;
 
-public abstract class BinaryOpVertex<A, B, C> extends Vertex<C> implements NonProbabilistic<C> {
+public abstract class BinaryOpVertex<A, B, C> extends GenericVertex<C> implements NonProbabilistic<C> {
 
     protected final Vertex<A> a;
     protected final Vertex<B> b;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/UnaryOpVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/nonprobabilistic/operators/unary/UnaryOpVertex.java
@@ -5,8 +5,9 @@ import io.improbable.keanu.vertices.NonProbabilistic;
 import io.improbable.keanu.vertices.SaveVertexParam;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
+import io.improbable.keanu.vertices.generic.GenericVertex;
 
-public abstract class UnaryOpVertex<IN, OUT> extends Vertex<OUT> implements NonProbabilistic<OUT> {
+public abstract class UnaryOpVertex<IN, OUT> extends GenericVertex<OUT> implements NonProbabilistic<OUT> {
 
     protected static final String INPUT_NAME = "inputVertex";
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/generic/probabilistic/discrete/CategoricalVertex.java
@@ -13,6 +13,7 @@ import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.KeanuRandom;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TakeVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.DirichletVertex;
+import io.improbable.keanu.vertices.generic.GenericTensorVertex;
 
 import java.util.Collections;
 import java.util.List;
@@ -26,7 +27,7 @@ import static io.improbable.keanu.tensor.TensorShapeValidation.checkTensorsMatch
 import static java.util.stream.Collectors.toMap;
 
 
-public class CategoricalVertex<CATEGORY, TENSOR extends Tensor<CATEGORY>> extends Vertex<TENSOR> implements Probabilistic<TENSOR>, NonSaveableVertex {
+public class CategoricalVertex<CATEGORY, TENSOR extends Tensor<CATEGORY>> extends GenericTensorVertex<TENSOR> implements Probabilistic<TENSOR>, NonSaveableVertex {
 
     private final Map<CATEGORY, DoubleVertex> selectableValues;
 


### PR DESCRIPTION
I've added 2 new abstract classes `GenericVertex` and `GenericTensorVertex`.

Just an idea I'm putting up to see what you think... some people may not like the idea of creating another abstract class, but personally I find it easier to reason about the hierarchy when it looks like this:

<img width="434" alt="screen shot 2018-12-21 at 08 41 43" src="https://user-images.githubusercontent.com/1508452/50353676-e5070880-0540-11e9-903e-ee070df63a4a.png">
