### PR TITLE
Fix progress bar dual percentage displaying

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/util/ProgressBar.java
@@ -63,6 +63,7 @@ public class ProgressBar {
     private final AtomicInteger nextFrameIndex = new AtomicInteger(0);
 
     private final List<Runnable> onFinish = new ArrayList<>();
+    private int previouslyPrintedUpdateLength = 0;
 
     public ProgressBar(PrintStream printStream, ScheduledExecutorService scheduler) {
         this.printStream = printStream;
@@ -159,8 +160,17 @@ public class ProgressBar {
             if (update.getProgressPercentage() != null) {
                 sb.append(String.format(" %3.1f%%", Math.min(100.0, Math.max(0, update.getProgressPercentage() * 100))));
             }
+            appendSpacesToClearPreviousContent(sb);
             printStream.print(sb.toString());
         }
+    }
+
+    private void appendSpacesToClearPreviousContent(StringBuilder sb) {
+        int originalStringLength = sb.length();
+        for (int i = originalStringLength; i < previouslyPrintedUpdateLength; i++) {
+            sb.append(" ");
+        }
+        previouslyPrintedUpdateLength = originalStringLength;
     }
 
     private void printFinish() {


### PR DESCRIPTION
In the case that samples are dropped, the progress bar showed two percentages after the dropping had occurred. This is due to the difference in the string length between `Dropping samples...` and `Sampling...` which meant the dropping samples percentage wasn't being cleared. I have fixed this by appending spaces to clear previous output when the previous output was longer. 

This is a bit hacky so open to other ideas. Tried using `\b` as a backspace but that didn't seem to work.
![screenshot 2019-01-09 at 11 15 14](https://user-images.githubusercontent.com/9009191/50898561-77475180-1407-11e9-94c7-bb395576cfef.png)
