### PR TITLE
Feature/python nuts params

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/PosteriorSamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/PosteriorSamplingAlgorithm.java
@@ -1,5 +1,6 @@
 package io.improbable.keanu.algorithms;
 
+import io.improbable.keanu.algorithms.mcmc.NetworkSamplesGenerator;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.vertices.Vertex;
 
@@ -21,5 +22,8 @@ public interface PosteriorSamplingAlgorithm {
     default NetworkSamples getPosteriorSamples(BayesianNetwork bayesianNetwork, int sampleCount) {
         return getPosteriorSamples(bayesianNetwork, bayesianNetwork.getTopLevelLatentVertices(), sampleCount);
     }
+
+    NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesianNetwork,
+                                                     final List<? extends Vertex> verticesToSampleFrom);
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/PosteriorSamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/PosteriorSamplingAlgorithm.java
@@ -15,9 +15,17 @@ public interface PosteriorSamplingAlgorithm {
         return getPosteriorSamples(bayesianNetwork, Collections.singletonList(vertexToSampleFrom), sampleCount);
     }
 
-    NetworkSamples getPosteriorSamples(BayesianNetwork bayesNet,
-                                       List<? extends Vertex> verticesToSampleFrom,
-                                       int sampleCount);
+    /**
+     * @param bayesNet      a bayesian network containing latent vertices
+     * @param verticesToSampleFrom the vertices to include in the returned samples
+     * @param sampleCount          number of samples to take using the algorithm
+     * @return Samples for each vertex ordered by MCMC iteration
+     */
+    default NetworkSamples getPosteriorSamples(BayesianNetwork bayesNet,
+                                               List<? extends Vertex> verticesToSampleFrom,
+                                               int sampleCount) {
+        return generatePosteriorSamples(bayesNet, verticesToSampleFrom).generate(sampleCount);
+    }
 
     default NetworkSamples getPosteriorSamples(BayesianNetwork bayesianNetwork, int sampleCount) {
         return getPosteriorSamples(bayesianNetwork, bayesianNetwork.getTopLevelLatentVertices(), sampleCount);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -1,6 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc;
 
-import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
@@ -60,22 +59,6 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
     @Builder.Default
     //the amount of distance to move each leapfrog
     private double stepSize = DEFAULT_STEP_SIZE;
-
-    /**
-     * Sample from the posterior of a Bayesian Network using the Hamiltonian Monte Carlo algorithm
-     *
-     * @param bayesNet     The bayesian network to sample from
-     * @param fromVertices the vertices to sample from
-     * @param sampleCount  the number of samples to take
-     * @return Samples taken with Hamiltonian Monte Carlo
-     */
-    @Override
-    public NetworkSamples getPosteriorSamples(final BayesianNetwork bayesNet,
-                                              final List<? extends Vertex> fromVertices,
-                                              final int sampleCount) {
-        return generatePosteriorSamples(bayesNet, fromVertices)
-            .generate(sampleCount);
-    }
 
     @Override
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesNet,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/Hamiltonian.java
@@ -77,6 +77,7 @@ public class Hamiltonian implements PosteriorSamplingAlgorithm {
             .generate(sampleCount);
     }
 
+    @Override
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesNet,
                                                             final List<? extends Vertex> fromVertices) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.algorithms.mcmc;
 
 import io.improbable.keanu.algorithms.NetworkSample;
-import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
 import io.improbable.keanu.algorithms.mcmc.proposal.MHStepVariableSelector;
 import io.improbable.keanu.algorithms.mcmc.proposal.ProposalDistribution;
@@ -63,20 +62,6 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
     @Setter
     @Builder.Default
     private boolean useCacheOnRejection = DEFAULT_USE_CACHE_ON_REJECTION;
-
-    /**
-     * @param bayesianNetwork      a bayesian network containing latent vertices
-     * @param verticesToSampleFrom the vertices to include in the returned samples
-     * @param sampleCount          number of samples to take using the algorithm
-     * @return Samples for each vertex ordered by MCMC iteration
-     */
-    @Override
-    public NetworkSamples getPosteriorSamples(BayesianNetwork bayesianNetwork,
-                                              List<? extends Vertex> verticesToSampleFrom,
-                                              int sampleCount) {
-        return generatePosteriorSamples(bayesianNetwork, verticesToSampleFrom)
-            .generate(sampleCount);
-    }
 
     @Override
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesianNetwork,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/MetropolisHastings.java
@@ -78,6 +78,7 @@ public class MetropolisHastings implements PosteriorSamplingAlgorithm {
             .generate(sampleCount);
     }
 
+    @Override
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesianNetwork,
                                                             final List<? extends Vertex> verticesToSampleFrom) {
 

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/NUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/NUTS.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.algorithms.mcmc.nuts;
 
 import com.google.common.base.Preconditions;
-import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.PosteriorSamplingAlgorithm;
 import io.improbable.keanu.algorithms.Statistics;
 import io.improbable.keanu.algorithms.mcmc.NetworkSamplesGenerator;
@@ -83,21 +82,6 @@ public class NUTS implements PosteriorSamplingAlgorithm {
     //Sets whether or not to save debug STATISTICS. The STATISTICS available are: Step size, Log Prob, Mean Tree Acceptance Prob, Tree Size.
     @Builder.Default
     private boolean saveStatistics = false;
-
-    /**
-     * Sample from the posterior of a Bayesian Network using the No-U-Turn-Sampling algorithm
-     *
-     * @param bayesNet           the bayesian network to sample from
-     * @param sampleFromVertices the vertices inside the bayesNet to sample from
-     * @return Samples taken with NUTS
-     */
-    @Override
-    public NetworkSamples getPosteriorSamples(final BayesianNetwork bayesNet,
-                                              final List<? extends Vertex> sampleFromVertices,
-                                              final int sampleCount) {
-        return generatePosteriorSamples(bayesNet, sampleFromVertices)
-            .generate(sampleCount);
-    }
 
     @Override
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesNet,

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/NUTS.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/NUTS.java
@@ -99,6 +99,7 @@ public class NUTS implements PosteriorSamplingAlgorithm {
             .generate(sampleCount);
     }
 
+    @Override
     public NetworkSamplesGenerator generatePosteriorSamples(final BayesianNetwork bayesNet,
                                                             final List<? extends Vertex> fromVertices) {
 

--- a/keanu-python/keanu/algorithm/__init__.py
+++ b/keanu-python/keanu/algorithm/__init__.py
@@ -1,3 +1,3 @@
 from .optimization import (GradientOptimizer, NonGradientOptimizer)
-from .sampling import sample, generate_samples, MetropolisHastingsSampler, HamiltonianSampler, NUTSSampler
+from .sampling import sample, generate_samples, MetropolisHastingsSampler, HamiltonianSampler, NUTSSampler, PosteriorSamplingAlgorithm
 from .proposal_listeners import AcceptanceRateTracker

--- a/keanu-python/keanu/algorithm/__init__.py
+++ b/keanu-python/keanu/algorithm/__init__.py
@@ -1,3 +1,3 @@
 from .optimization import (GradientOptimizer, NonGradientOptimizer)
-from .sampling import sample, generate_samples
+from .sampling import sample, generate_samples, MetropolisHastingsSampler, HamiltonianSampler, NUTSSampler
 from .proposal_listeners import AcceptanceRateTracker

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -16,12 +16,6 @@ java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.MetropolisHasting
 java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.nuts.NUTS")
 java_import(k.jvm_view(), "io.improbable.keanu.algorithms.mcmc.Hamiltonian")
 
-algorithms = {
-    'metropolis': k.jvm_view().MetropolisHastings,
-    'NUTS': k.jvm_view().NUTS,
-    'hamiltonian': k.jvm_view().Hamiltonian
-}
-
 
 class PosteriorSamplingAlgorithm:
 

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -57,13 +57,13 @@ class MetropolisHastingsSampler(PosteriorSamplingAlgorithm):
 class HamiltonianSampler(PosteriorSamplingAlgorithm):
 
     def __init__(self):
-        pass
+        super().__init__(k.jvm_view().Hamiltonian.withDefaultConfig())
 
 
 class NUTSSampler(PosteriorSamplingAlgorithm):
 
     def __init__(self):
-        pass
+        super().__init__(k.jvm_view().NUTS.withDefaultConfig())
 
 
 def sample(net: BayesNet,

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -2,7 +2,6 @@ from py4j.java_gateway import java_import, JavaObject
 from py4j.java_collections import JavaList
 
 from keanu.algorithm._proposal_distribution import ProposalDistribution
-from keanu.algorithm.proposal_listeners import proposal_listener_types
 from keanu.context import KeanuContext
 from keanu.tensor import Tensor
 from keanu.vertex.base import Vertex
@@ -38,7 +37,8 @@ class MetropolisHastingsSampler(PosteriorSamplingAlgorithm):
     def __init__(self,
                  proposal_distribution: str = None,
                  proposal_distribution_sigma: numpy_types = None,
-                 proposal_listeners=[]):
+                 proposal_listeners=[],
+                 use_cache_on_rejection: bool = None):
 
         if (proposal_distribution is None and len(proposal_listeners) > 0):
             raise TypeError("If you pass in proposal_listeners you must also specify proposal_distribution")
@@ -50,19 +50,21 @@ class MetropolisHastingsSampler(PosteriorSamplingAlgorithm):
                 type_=proposal_distribution, sigma=proposal_distribution_sigma, listeners=proposal_listeners)
             builder = builder.proposalDistribution(proposal_distribution_object.unwrap())
 
-        sampling_algorithm: JavaObject = builder.build()
-        super().__init__(sampling_algorithm)
+        if use_cache_on_rejection is not None:
+            builder.useCacheOnRejection(use_cache_on_rejection)
+
+        super().__init__(builder.build())
 
 
 class HamiltonianSampler(PosteriorSamplingAlgorithm):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(k.jvm_view().Hamiltonian.withDefaultConfig())
 
 
 class NUTSSampler(PosteriorSamplingAlgorithm):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(k.jvm_view().NUTS.withDefaultConfig())
 
 

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -24,24 +24,60 @@ algorithms = {
 }
 
 
+class PosteriorSamplingAlgorithm:
+
+    def __init__(self, sampler: JavaObject):
+        self._sampler = sampler
+
+    def get_sampler(self) -> JavaObject:
+        return self._sampler
+
+
+class MetropolisHastingsSampler(PosteriorSamplingAlgorithm):
+
+    def __init__(self,
+                 proposal_distribution: str = None,
+                 proposal_distribution_sigma: numpy_types = None,
+                 proposal_listeners=[]):
+
+        if (proposal_distribution is None and len(proposal_listeners) > 0):
+            raise TypeError("If you pass in proposal_listeners you must also specify proposal_distribution")
+
+        builder: JavaObject = k.jvm_view().MetropolisHastings.builder()
+
+        if proposal_distribution is not None:
+            proposal_distribution_object = ProposalDistribution(
+                type_=proposal_distribution, sigma=proposal_distribution_sigma, listeners=proposal_listeners)
+            builder = builder.proposalDistribution(proposal_distribution_object.unwrap())
+
+        sampling_algorithm: JavaObject = builder.build()
+        super().__init__(sampling_algorithm)
+
+
+class HamiltonianSampler(PosteriorSamplingAlgorithm):
+
+    def __init__(self):
+        pass
+
+
+class NUTSSampler(PosteriorSamplingAlgorithm):
+
+    def __init__(self):
+        pass
+
+
 def sample(net: BayesNet,
            sample_from: Iterable[Vertex],
-           algo: str = 'metropolis',
-           proposal_distribution: str = None,
-           proposal_distribution_sigma: numpy_types = None,
-           proposal_listeners=[],
+           sampling_algorithm: PosteriorSamplingAlgorithm = MetropolisHastingsSampler(),
            draws: int = 500,
            drop: int = 0,
            down_sample_interval: int = 1,
            plot: bool = False,
            ax: Any = None) -> sample_types:
 
-    sampling_algorithm: JavaObject = build_sampling_algorithm(algo, proposal_distribution, proposal_distribution_sigma,
-                                                              proposal_listeners)
-
     vertices_unwrapped: JavaList = k.to_java_object_list(sample_from)
 
-    network_samples: JavaObject = sampling_algorithm.getPosteriorSamples(
+    network_samples: JavaObject = sampling_algorithm.get_sampler().getPosteriorSamples(
         net.unwrap(), vertices_unwrapped, draws).drop(drop).downSample(down_sample_interval)
 
     vertex_samples = {
@@ -58,49 +94,21 @@ def sample(net: BayesNet,
 
 def generate_samples(net: BayesNet,
                      sample_from: Iterable[Vertex],
-                     algo: str = 'metropolis',
-                     proposal_distribution: str = None,
-                     proposal_distribution_sigma: numpy_types = None,
-                     proposal_listeners: List[proposal_listener_types] = [],
+                     sampling_algorithm: PosteriorSamplingAlgorithm = MetropolisHastingsSampler(),
                      drop: int = 0,
                      down_sample_interval: int = 1,
                      live_plot: bool = False,
                      refresh_every: int = 100,
                      ax: Any = None) -> sample_generator_types:
 
-    sampling_algorithm: JavaObject = build_sampling_algorithm(algo, proposal_distribution, proposal_distribution_sigma,
-                                                              proposal_listeners)
-
     vertices_unwrapped: JavaList = k.to_java_object_list(sample_from)
 
-    samples: JavaObject = sampling_algorithm.generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
+    samples: JavaObject = sampling_algorithm.get_sampler().generatePosteriorSamples(net.unwrap(), vertices_unwrapped)
     samples = samples.dropCount(drop).downSampleInterval(down_sample_interval)
     sample_iterator: JavaObject = samples.stream().iterator()
 
     return _samples_generator(
         sample_iterator, vertices_unwrapped, live_plot=live_plot, refresh_every=refresh_every, ax=ax)
-
-
-def build_sampling_algorithm(algo, proposal_distribution: Optional[str],
-                             proposal_distribution_sigma: Optional[numpy_types],
-                             proposal_listeners: List[proposal_listener_types]):
-    if algo != "metropolis":
-        if proposal_distribution is not None:
-            raise TypeError("Only Metropolis Hastings supports the proposal_distribution parameter")
-        if len(proposal_listeners) > 0:
-            raise TypeError("Only Metropolis Hastings supports the proposal_listeners parameter")
-
-    if (proposal_distribution is None and len(proposal_listeners) > 0):
-        raise TypeError("If you pass in proposal_listeners you must also specify proposal_distribution")
-
-    builder: JavaObject = algorithms[algo].builder()
-
-    if proposal_distribution is not None:
-        proposal_distribution_object = ProposalDistribution(
-            type_=proposal_distribution, sigma=proposal_distribution_sigma, listeners=proposal_listeners)
-        builder = builder.proposalDistribution(proposal_distribution_object.unwrap())
-    sampling_algorithm: JavaObject = builder.build()
-    return sampling_algorithm
 
 
 def _samples_generator(sample_iterator: JavaObject, vertices_unwrapped: JavaList, live_plot: bool, refresh_every: int,

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -58,8 +58,31 @@ class HamiltonianSampler(PosteriorSamplingAlgorithm):
 
 class NUTSSampler(PosteriorSamplingAlgorithm):
 
-    def __init__(self) -> None:
-        super().__init__(k.jvm_view().NUTS.withDefaultConfig())
+    def __init__(self,
+                 adapt_count: int = None,
+                 target_acceptance_prob: float = None,
+                 adapt_enabled: bool = None,
+                 initial_step_size: float = None,
+                 max_tree_height: int = None):
+
+        builder: JavaObject = k.jvm_view().NUTS.builder()
+
+        if adapt_count is not None:
+            builder.adaptCount(adapt_count)
+
+        if target_acceptance_prob is not None:
+            builder.targetAcceptanceProb(target_acceptance_prob)
+
+        if adapt_enabled is not None:
+            builder.adaptEnabled(adapt_enabled)
+
+        if initial_step_size is not None:
+            builder.initialStepSize(initial_step_size)
+
+        if max_tree_height is not None:
+            builder.maxTreeHeight(max_tree_height)
+
+        super().__init__(builder.build())
 
 
 def sample(net: BayesNet,

--- a/keanu-python/keanu/algorithm/sampling.py
+++ b/keanu-python/keanu/algorithm/sampling.py
@@ -68,12 +68,15 @@ class NUTSSampler(PosteriorSamplingAlgorithm):
 
 def sample(net: BayesNet,
            sample_from: Iterable[Vertex],
-           sampling_algorithm: PosteriorSamplingAlgorithm = MetropolisHastingsSampler(),
+           sampling_algorithm: PosteriorSamplingAlgorithm = None,
            draws: int = 500,
            drop: int = 0,
            down_sample_interval: int = 1,
            plot: bool = False,
            ax: Any = None) -> sample_types:
+
+    if sampling_algorithm is None:
+        sampling_algorithm = MetropolisHastingsSampler()
 
     vertices_unwrapped: JavaList = k.to_java_object_list(sample_from)
 
@@ -94,12 +97,15 @@ def sample(net: BayesNet,
 
 def generate_samples(net: BayesNet,
                      sample_from: Iterable[Vertex],
-                     sampling_algorithm: PosteriorSamplingAlgorithm = MetropolisHastingsSampler(),
+                     sampling_algorithm: PosteriorSamplingAlgorithm = None,
                      drop: int = 0,
                      down_sample_interval: int = 1,
                      live_plot: bool = False,
                      refresh_every: int = 100,
                      ax: Any = None) -> sample_generator_types:
+
+    if sampling_algorithm is None:
+        sampling_algorithm = MetropolisHastingsSampler()
 
     vertices_unwrapped: JavaList = k.to_java_object_list(sample_from)
 

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -97,15 +97,17 @@ def test_can_iter_through_samples(algo: str, net: BayesNet) -> None:
     assert count == draws
 
 
-@pytest.mark.parametrize("algo", [(MetropolisHastingsSampler()), (HamiltonianSampler())])
+@pytest.mark.parametrize("algo", [MetropolisHastingsSampler, HamiltonianSampler])
 def test_iter_returns_same_result_as_sample(algo: str) -> None:
     draws = 100
     model = thermometers.model()
     net = BayesNet(model.temperature.get_connected_graph())
     set_starting_state(model)
-    samples = sample(net=net, sample_from=net.get_latent_vertices(), sampling_algorithm=algo, draws=draws)
+    sampler = algo()
+    samples = sample(net=net, sample_from=net.get_latent_vertices(), sampling_algorithm=sampler, draws=draws)
     set_starting_state(model)
-    iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo)
+    sampler = algo()
+    iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), sampling_algorithm=sampler)
 
     samples_dataframe = pd.DataFrame()
     for iter_sample in islice(iter_samples, draws):

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -161,6 +161,11 @@ def test_it_throws_if_you_pass_in_a_proposal_listener_but_you_didnt_specify_the_
 
     assert str(excinfo.value) == "If you pass in proposal_listeners you must also specify proposal_distribution"
 
+def test_can_specify_nuts_params(net: BayesNet):
+    algo = NUTSSampler(1000, 0.65, True, 0.1, 10)
+
+    samples = sample(net, list(net.get_latent_vertices()), algo, draws=500, drop=100)
+
 
 def set_starting_state(model: Model) -> None:
     KeanuRandom.set_default_random_seed(1)

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -162,7 +162,7 @@ def test_it_throws_if_you_pass_in_a_proposal_listener_but_you_didnt_specify_the_
     assert str(excinfo.value) == "If you pass in proposal_listeners you must also specify proposal_distribution"
 
 
-def test_can_specify_nuts_params(net: BayesNet):
+def test_can_specify_nuts_params(net: BayesNet) -> None:
     algo = NUTSSampler(1000, 0.65, True, 0.1, 10)
 
     samples = sample(net, list(net.get_latent_vertices()), algo, draws=500, drop=100)

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -8,7 +8,12 @@ import pytest
 
 from examples import thermometers
 from keanu import BayesNet, KeanuRandom, Model
-from keanu.algorithm import sample, generate_samples, AcceptanceRateTracker
+from keanu.algorithm import (sample,
+                             generate_samples,
+                             AcceptanceRateTracker,
+                             MetropolisHastingsSampler,
+                             HamiltonianSampler,
+                             NUTSSampler)
 from keanu.vertex import Gamma, Exponential, Cauchy, KeanuContext, Bernoulli
 from typing import Any
 
@@ -23,13 +28,13 @@ def net() -> BayesNet:
     return m.to_bayes_net()
 
 
-@pytest.mark.parametrize("algo", [("metropolis"), ("NUTS"), ("hamiltonian")])
+@pytest.mark.parametrize("algo", [(MetropolisHastingsSampler()), (NUTSSampler()), (HamiltonianSampler())])
 def test_sampling_returns_dict_of_list_of_ndarrays_for_vertices_in_sample_from(algo: str, net: BayesNet) -> None:
     draws = 5
     sample_from = list(net.get_latent_vertices())
     vertex_labels = [vertex.get_label() for vertex in sample_from]
 
-    samples = sample(net=net, sample_from=sample_from, algo=algo, draws=draws)
+    samples = sample(net=net, sample_from=sample_from, sampling_algorithm=algo, draws=draws)
     assert len(samples) == len(sample_from)
     assert type(samples) == dict
 
@@ -77,30 +82,28 @@ def test_sample_with_plot(net: BayesNet) -> None:
 
 
 def test_can_specify_a_gaussian_proposal_distribution(net: BayesNet) -> None:
-    generate_samples(
-        net=net,
-        sample_from=net.get_latent_vertices(),
-        proposal_distribution="gaussian",
-        proposal_distribution_sigma=np.array(1.))
+    algo = MetropolisHastingsSampler(proposal_distribution="gaussian",
+                                     proposal_distribution_sigma=np.array(1.))
+    generate_samples(net=net, sample_from=net.get_latent_vertices(), sampling_algorithm=algo)
 
 
-@pytest.mark.parametrize("algo", [("metropolis"), ("hamiltonian")])
+@pytest.mark.parametrize("algo", [(MetropolisHastingsSampler()), (HamiltonianSampler())])
 def test_can_iter_through_samples(algo: str, net: BayesNet) -> None:
     draws = 10
-    samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo, down_sample_interval=1)
+    samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), sampling_algorithm=algo, down_sample_interval=1)
     count = 0
     for sample in islice(samples, draws):
         count += 1
     assert count == draws
 
 
-@pytest.mark.parametrize("algo", [("metropolis"), ("hamiltonian")])
+@pytest.mark.parametrize("algo", [(MetropolisHastingsSampler()), (HamiltonianSampler())])
 def test_iter_returns_same_result_as_sample(algo: str) -> None:
     draws = 100
     model = thermometers.model()
     net = BayesNet(model.temperature.get_connected_graph())
     set_starting_state(model)
-    samples = sample(net=net, sample_from=net.get_latent_vertices(), algo=algo, draws=draws)
+    samples = sample(net=net, sample_from=net.get_latent_vertices(), sampling_algorithm=algo, draws=draws)
     set_starting_state(model)
     iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo=algo)
 
@@ -131,12 +134,13 @@ def test_can_get_acceptance_rates(net: BayesNet) -> None:
     acceptance_rate_tracker = AcceptanceRateTracker()
     latents = list(net.get_latent_vertices())
 
+    algo = MetropolisHastingsSampler(proposal_distribution='prior',
+                                     proposal_listeners=[acceptance_rate_tracker])
     samples = sample(
-        net=net,
-        sample_from=latents,
-        proposal_distribution='prior',
-        proposal_listeners=[acceptance_rate_tracker],
-        drop=3)
+        net = net,
+        sample_from = latents,
+        sampling_algorithm = algo,
+        drop = 3)
 
     for latent in latents:
         rate = acceptance_rate_tracker.get_acceptance_rate(latent)
@@ -147,11 +151,11 @@ def test_can_track_acceptance_rate_when_iterating(net: BayesNet) -> None:
     acceptance_rate_tracker = AcceptanceRateTracker()
     latents = list(net.get_latent_vertices())
 
+    algo = MetropolisHastingsSampler(proposal_distribution='prior', proposal_listeners=[acceptance_rate_tracker])
     samples = generate_samples(
         net=net,
         sample_from=latents,
-        proposal_distribution='prior',
-        proposal_listeners=[acceptance_rate_tracker],
+        sampling_algorithm=algo,
         drop=3)
 
     draws = 100
@@ -161,27 +165,10 @@ def test_can_track_acceptance_rate_when_iterating(net: BayesNet) -> None:
             assert 0 <= rate <= 1
 
 
-def test_it_throws_if_you_pass_in_a_proposal_distribution_but_the_algo_isnt_metropolis(net: BayesNet) -> None:
-    with pytest.raises(TypeError) as excinfo:
-        sample(
-            net=net, sample_from=net.get_latent_vertices(), algo="hamiltonian", proposal_distribution="prior", drop=3)
-    assert str(excinfo.value) == "Only Metropolis Hastings supports the proposal_distribution parameter"
-
-
-def test_it_throws_if_you_pass_in_a_proposal_listener_but_the_algo_isnt_metropolis(net: BayesNet) -> None:
-    with pytest.raises(TypeError) as excinfo:
-        sample(
-            net=net,
-            sample_from=net.get_latent_vertices(),
-            algo="hamiltonian",
-            proposal_listeners=[AcceptanceRateTracker()],
-            drop=3)
-    assert str(excinfo.value) == "Only Metropolis Hastings supports the proposal_listeners parameter"
-
-
 def test_it_throws_if_you_pass_in_a_proposal_listener_but_you_didnt_specify_the_proposal_type(net: BayesNet) -> None:
     with pytest.raises(TypeError) as excinfo:
-        sample(net=net, sample_from=net.get_latent_vertices(), proposal_listeners=[AcceptanceRateTracker()], drop=3)
+        algo = MetropolisHastingsSampler(proposal_listeners=[AcceptanceRateTracker()])
+
     assert str(excinfo.value) == "If you pass in proposal_listeners you must also specify proposal_distribution"
 
 

--- a/keanu-python/tests/test_sampling.py
+++ b/keanu-python/tests/test_sampling.py
@@ -161,6 +161,7 @@ def test_it_throws_if_you_pass_in_a_proposal_listener_but_you_didnt_specify_the_
 
     assert str(excinfo.value) == "If you pass in proposal_listeners you must also specify proposal_distribution"
 
+
 def test_can_specify_nuts_params(net: BayesNet):
     algo = NUTSSampler(1000, 0.65, True, 0.1, 10)
 

--- a/keanu-python/tests/test_stats.py
+++ b/keanu-python/tests/test_stats.py
@@ -65,18 +65,13 @@ def test_autocorrelation_same_for_streaming_as_batch() -> None:
     net = model.to_bayes_net()
     draws = 15
     set_starting_state(model)
-    print(model.uniform.get_value())
     samples = sample(net=net, sample_from=net.get_latent_vertices(), draws=draws)
     set_starting_state(model)
-    print(model.uniform.get_value())
     iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices())
-    print(samples)
 
     samples_dataframe = pd.DataFrame()
     for next_sample in islice(iter_samples, draws):
         samples_dataframe = samples_dataframe.append(next_sample, ignore_index=True)
-
-    print(samples_dataframe)
 
     for vertex_id in samples_dataframe:
         autocorr_streaming = stats.autocorrelation(list(samples_dataframe[vertex_id].values))

--- a/keanu-python/tests/test_stats.py
+++ b/keanu-python/tests/test_stats.py
@@ -36,7 +36,7 @@ def test_autocorr_returns_ndarray_of_correct_dtype() -> None:
     with Model() as m:
         m.uniform = Uniform(0, 1000)
     net = m.to_bayes_net()
-    samples = sample(net=net, sample_from=net.get_latent_vertices(), algo="metropolis", draws=1000)
+    samples = sample(net=net, sample_from=net.get_latent_vertices(), draws=1000)
     valid_key = list(samples.keys())[0]
     sample_ = samples.get(valid_key)
     assert sample_ is not None
@@ -65,13 +65,18 @@ def test_autocorrelation_same_for_streaming_as_batch() -> None:
     net = model.to_bayes_net()
     draws = 15
     set_starting_state(model)
-    samples = sample(net=net, sample_from=net.get_latent_vertices(), algo="metropolis", draws=draws)
+    print(model.uniform.get_value())
+    samples = sample(net=net, sample_from=net.get_latent_vertices(), draws=draws)
     set_starting_state(model)
-    iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices(), algo="metropolis")
+    print(model.uniform.get_value())
+    iter_samples = generate_samples(net=net, sample_from=net.get_latent_vertices())
+    print(samples)
 
     samples_dataframe = pd.DataFrame()
     for next_sample in islice(iter_samples, draws):
         samples_dataframe = samples_dataframe.append(next_sample, ignore_index=True)
+
+    print(samples_dataframe)
 
     for vertex_id in samples_dataframe:
         autocorr_streaming = stats.autocorrelation(list(samples_dataframe[vertex_id].values))


### PR DESCRIPTION
Made NUTS parameters settable from the python API (and slightly changed how the python "sample" API works so that it now takes an optional PosteriorSamplingAlgorithm object that represents the constructed sampler.

At the moment if the user doesn't specify an explicit sampler we just use metropolis hastings with default params, but this should probably change to use something a little more automagic (ie based on  differentiability).

Note - I haven't added customisable options for Hamiltonian just because it may go away.