### PR TITLE
Bump develop to 19 and add release journal

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-current_version: 0.0.18
+current_version: 0.0.19
 
 # Theme settings
 doks:

--- a/docs/_data/previous_versions.yml
+++ b/docs/_data/previous_versions.yml
@@ -1,3 +1,5 @@
+- title: 0.0.18
+  url: /docs/0_0_18
 - title: 0.0.17
   url: /docs/0_0_17
 - title: 0.0.16

--- a/docs/release_notes.txt
+++ b/docs/release_notes.txt
@@ -1,0 +1,3 @@
+### Version 0.0.19 ###
+
+Added the release notes text file to the repo

--- a/keanu-python/docs/conf.py
+++ b/keanu-python/docs/conf.py
@@ -23,9 +23,9 @@ copyright = u'2018, Improbable'
 author = u'Improbable'
 
 # The short X.Y version
-version = u'0.0.18'
+version = u'0.0.19'
 # The full version, including alpha/beta/rc tags
-release = u'0.0.18'
+release = u'0.0.19'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Set docs version of develop to 0.0.19.

Added a `release_notes.txt` file for people to populate with new features. I prefer this to Google docs as it's versioned and visible to users.