### PR TITLE
finalize build with making python docs

### DIFF
--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -141,3 +141,4 @@ test.dependsOn(formatCheck)
 test.dependsOn(pytest)
 
 buildWheelDistribution.dependsOn(test)
+build.finalizedBy(generateDocumentation)


### PR DESCRIPTION
The python docs weren't being generated as part of the build. This meant that changes to the Python API weren't reflected in the docs automatically. 