### PR TITLE
Classic nuts fixes

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/SamplingAlgorithm.java
@@ -10,8 +10,9 @@ import java.util.stream.Collectors;
 
 public interface SamplingAlgorithm {
 
-    static <T> Map<VariableReference, T> takeSample(List<? extends Variable<T, ?>> sampleFromVariables) {
-        return sampleFromVariables.stream().collect(Collectors.toMap(Variable::getReference, Variable::getValue));
+    static Map<VariableReference, ?> takeSample(List<? extends Variable> sampleFromVariables) {
+        return sampleFromVariables.stream()
+            .collect(Collectors.toMap(Variable::getReference, Variable::getValue));
     }
 
     /**

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/Leapfrog.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/Leapfrog.java
@@ -49,7 +49,7 @@ class Leapfrog {
         final double halfTimeStep = epsilon / 2.0;
 
         Map<VariableReference, DoubleTensor> nextMomentum = stepMomentum(halfTimeStep, momentum, gradient);
-        Map<VariableReference, DoubleTensor> nextPosition = stepPosition(latentVariables, halfTimeStep, nextMomentum, position);
+        Map<VariableReference, DoubleTensor> nextPosition = stepPosition(latentVariables, epsilon, nextMomentum, position);
 
         Map<? extends VariableReference, DoubleTensor> nextPositionGradient = logProbGradientCalculator.logProbGradients(nextPosition);
 
@@ -58,16 +58,14 @@ class Leapfrog {
         return new Leapfrog(nextPosition, nextMomentum, nextPositionGradient);
     }
 
-    private Map<VariableReference, DoubleTensor> stepPosition(List<? extends Variable<DoubleTensor, ?>> latentVariables, double halfTimeStep, Map<VariableReference, DoubleTensor> nextMomentum, Map<? extends VariableReference, DoubleTensor> position) {
+    private Map<VariableReference, DoubleTensor> stepPosition(List<? extends Variable<DoubleTensor, ?>> latentVariables, double dt, Map<VariableReference, DoubleTensor> nextMomentum, Map<? extends VariableReference, DoubleTensor> position) {
         Map<VariableReference, DoubleTensor> nextPosition = new HashMap<>();
 
         for (Variable<DoubleTensor, ?> latent : latentVariables) {
 
-            final DoubleTensor nextPositionForLatent = nextMomentum.get(latent.getReference()).
-                times(halfTimeStep).
-                plusInPlace(
-                    position.get(latent.getReference())
-                );
+            final DoubleTensor nextPositionForLatent = nextMomentum.get(latent.getReference())
+                .times(dt)
+                .plusInPlace(position.get(latent.getReference()));
 
             nextPosition.put(latent.getReference(), nextPositionForLatent);
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/NUTSSampler.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/NUTSSampler.java
@@ -127,8 +127,8 @@ class NUTSSampler implements SamplingAlgorithm {
             }
 
             tree.incrementLeapfrogCount(otherHalfTree.getAcceptedLeapfrogCount());
-            tree.setDeltaLikelihoodOfLeapfrog(otherHalfTree.getDeltaLikelihoodOfLeapfrog());
-            tree.setTreeSize(otherHalfTree.getTreeSize());
+            tree.setDeltaLikelihoodOfLeapfrog(tree.getDeltaLikelihoodOfLeapfrog() + otherHalfTree.getDeltaLikelihoodOfLeapfrog());
+            tree.setTreeSize(tree.getTreeSize() + otherHalfTree.getTreeSize());
             tree.continueIfNotUTurning(otherHalfTree);
 
             treeHeight++;

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/Stepsize.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/Stepsize.java
@@ -1,7 +1,11 @@
 package io.improbable.keanu.algorithms.mcmc.nuts;
 
 import io.improbable.keanu.KeanuRandom;
-import io.improbable.keanu.algorithms.*;
+import io.improbable.keanu.algorithms.ProbabilisticModelWithGradient;
+import io.improbable.keanu.algorithms.SaveStatistics;
+import io.improbable.keanu.algorithms.Statistics;
+import io.improbable.keanu.algorithms.Variable;
+import io.improbable.keanu.algorithms.VariableReference;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 
 import java.util.List;
@@ -25,6 +29,7 @@ class Stepsize implements SaveStatistics {
 
     private double stepsize;
     private double averageAcceptanceProb;
+    private double averageTreeAcceptanceProb;
     private double logStepSizeFrozen;
     private double logStepSize;
 
@@ -37,6 +42,7 @@ class Stepsize implements SaveStatistics {
         this.targetAcceptanceProb = targetAcceptanceProb;
         this.stepsize = stepsize;
         this.averageAcceptanceProb = 0;
+        this.averageTreeAcceptanceProb = 0;
         this.logStepSize = Math.log(stepsize);
         this.logStepSizeFrozen = Math.log(1);
         this.adaptCount = adaptCount;
@@ -119,7 +125,7 @@ class Stepsize implements SaveStatistics {
         double proportionalAcceptanceProb = (1 - percentageLeftToTune) * averageAcceptanceProb;
 
         //alpha/nu_alpha
-        double averageTreeAcceptanceProb = tree.getDeltaLikelihoodOfLeapfrog() / tree.getTreeSize();
+        averageTreeAcceptanceProb = tree.getDeltaLikelihoodOfLeapfrog() / tree.getTreeSize();
 
         //delta - alpha/nu_alpha
         double acceptanceProb = targetAcceptanceProb - averageTreeAcceptanceProb;
@@ -156,6 +162,6 @@ class Stepsize implements SaveStatistics {
     @Override
     public void save(Statistics statistics) {
         statistics.store(NUTS.Metrics.STEPSIZE, stepsize);
-        statistics.store(NUTS.Metrics.MEAN_TREE_ACCEPT, averageAcceptanceProb);
+        statistics.store(NUTS.Metrics.MEAN_TREE_ACCEPT, averageTreeAcceptanceProb);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/nuts/LeapfrogTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/nuts/LeapfrogTest.java
@@ -25,8 +25,8 @@ public class LeapfrogTest {
 
     private static final double EPSILON = 1.0;
 
-    private DoubleVertex vertexA = new GaussianVertex(0, 1);;
-    private DoubleVertex vertexB = new GaussianVertex(0, 1);;
+    private DoubleVertex vertexA = new GaussianVertex(0, 1);
+    private DoubleVertex vertexB = new GaussianVertex(0, 1);
 
     private VariableReference aID = vertexA.getId();;
     private VariableReference bID = vertexB.getId();
@@ -71,8 +71,8 @@ public class LeapfrogTest {
         Leapfrog start = new Leapfrog(position, momentum, gradient);
         Leapfrog leap = start.step(vertices, mockedGradientCalculator, EPSILON);
 
-        Assert.assertEquals(1.0, leap.getPosition().get(aID).scalar(), 1e-6);
-        Assert.assertEquals(1.0, leap.getPosition().get(bID).scalar(), 1e-6);
+        Assert.assertEquals(2.0, leap.getPosition().get(aID).scalar(), 1e-6);
+        Assert.assertEquals(2.0, leap.getPosition().get(bID).scalar(), 1e-6);
 
         Assert.assertEquals(2.5, leap.getMomentum().get(aID).scalar(), 1e-6);
         Assert.assertEquals(1.5, leap.getMomentum().get(bID).scalar(), 1e-6);

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/nuts/NUTSTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/nuts/NUTSTest.java
@@ -1,7 +1,6 @@
 package io.improbable.keanu.algorithms.mcmc.nuts;
 
 import io.improbable.keanu.DeterministicRule;
-import io.improbable.keanu.KeanuRandom;
 import io.improbable.keanu.algorithms.NetworkSamples;
 import io.improbable.keanu.algorithms.ProbabilisticModelWithGradient;
 import io.improbable.keanu.algorithms.Statistics;
@@ -13,8 +12,8 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.testcategory.Slow;
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.HalfGaussianVertex;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -164,6 +163,22 @@ public class NUTSTest {
         );
 
         assertFalse(posteriorSamples.get(A).asList().isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsIfStartingPositionIsZeroProbability() {
+
+        GaussianVertex A = new HalfGaussianVertex(1.0);
+        A.setValue(-1.0);
+
+        BayesianNetwork net = new BayesianNetwork(A.getConnectedGraph());
+
+        ProbabilisticModelWithGradient model = new KeanuProbabilisticModelWithGradient(net);
+
+        NUTS nuts = NUTS.builder()
+            .build();
+
+        nuts.getPosteriorSamples(model, 2);
     }
 
     @Category(Slow.class)

--- a/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/testcases/MCMCTestDistributions.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/algorithms/mcmc/testcases/MCMCTestDistributions.java
@@ -1,6 +1,5 @@
 package io.improbable.keanu.algorithms.mcmc.testcases;
 
-import io.improbable.keanu.KeanuRandom;
 import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
@@ -14,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 public class MCMCTestDistributions {
 
-    public static BayesianNetwork createSimpleGaussian(double mu, double sigma, double initialValue, KeanuRandom random) {
+    public static BayesianNetwork createSimpleGaussian(double mu, double sigma, double initialValue) {
         GaussianVertex A = new GaussianVertex(new long[]{2, 1}, mu, sigma);
         A.setAndCascade(initialValue);
         return new BayesianNetwork(A.getConnectedGraph());


### PR DESCRIPTION
A few fixes to our current NUTS implementation. It fixes:

1. Leapfrog was not leaping properly
1. The tree size and sum acceptance rate wasn't being tracked correctly
1. NUTS now checks to a network in a zero probability state before running inference

