### PR TITLE
fix versions in pipfile

### DIFF
--- a/keanu-python/Pipfile
+++ b/keanu-python/Pipfile
@@ -4,18 +4,18 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-"py4j" = "*"
-numpy = "*"
+"py4j" = "==0.10.8.1"
+numpy = "==1.16.1"
 keanu = {editable = true, path = "."}
-pandas = "*"
+pandas = "==0.24.1"
 
 [dev-packages]
-pytest = "*"
-mypy = "*"
-sphinx = "*"
-yapf = "*"
-matplotlib = "*"
-sphinx-autodoc-typehints = "*"
+pytest = "==4.2.0"
+mypy = "==0.670"
+sphinx = "==1.8.4"
+yapf = "==0.26.0"
+matplotlib = "==3.0.2"
+sphinx-autodoc-typehints = "==1.6.0"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
A new release in a package we use (yapf) with different behaviour caused the build to start failing on a previously good commits. This PR fixes the versions of packages we use, which will stop this issue happening again.

The downside is that we are no longer up to date with the latest releases in these packages. We should make sure to periodically check if there have been any new releases to these packages, and whether it will be beneficial to upgrade.