### PR TITLE
 Use pip3 and python3

### DIFF
--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -28,7 +28,7 @@ task pythonVersionInfo {
         }
         exec {
             // NB: the pip version inside pipenv is not necessarily the same as the version outside pipenv
-            commandLine 'pipenv', 'run', 'pip', '--version'
+            commandLine 'pipenv', 'run', 'pip3', '--version'
         }
     }
 }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -6,7 +6,7 @@ import static org.apache.tools.ant.taskdefs.condition.Os.isFamily
 task installPipenv {
     doLast {
         exec {
-            commandLine 'pip', 'install', 'pipenv==2018.11.26'
+            commandLine 'pip3', 'install', 'pipenv==2018.11.26'
         }
     }
 }
@@ -17,7 +17,7 @@ task pythonVersionInfo {
             commandLine 'python', '--version'
         }
         exec {
-            commandLine 'pip', '--version'
+            commandLine 'pip3', '--version'
         }
         exec {
             commandLine 'pipenv', '--version'

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -14,7 +14,7 @@ task installPipenv {
 task pythonVersionInfo {
     doLast {
         exec {
-            commandLine 'python', '--version'
+            commandLine 'python3', '--version'
         }
         exec {
             commandLine 'pip3', '--version'
@@ -24,7 +24,7 @@ task pythonVersionInfo {
         }
         exec {
             // NB: the python version inside pipenv is not necessarily the same as the version outside pipenv
-            commandLine 'pipenv', 'run', 'python', '--version'
+            commandLine 'pipenv', 'run', 'python3', '--version'
         }
         exec {
             // NB: the pip version inside pipenv is not necessarily the same as the version outside pipenv
@@ -88,7 +88,7 @@ task generateDocumentation {
             // This ensures that there are no directories prefixed with an underscore
             // because Jekyll will ignore these directories which causes the generated docs not to be served properly
             workingDir("docs/")
-            commandLine "pipenv", "run", 'python', 'remove_underscores.py'
+            commandLine "pipenv", "run", 'python3', 'remove_underscores.py'
         }
         exec {
             commandLine 'mv', 'docs/_build/html/', '../docs/python/latest/'
@@ -128,7 +128,7 @@ task buildWheelDistribution {
 
     doLast {
         exec {
-            commandLine 'pipenv', 'run', 'python', project.file("setup.py"), 'sdist', 'bdist_wheel'
+            commandLine 'pipenv', 'run', 'python3', project.file("setup.py"), 'sdist', 'bdist_wheel'
         }
     }
 }

--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -24,7 +24,7 @@ task pythonVersionInfo {
         }
         exec {
             // NB: the python version inside pipenv is not necessarily the same as the version outside pipenv
-            commandLine 'pipenv', 'run', 'python3', '--version'
+            commandLine 'pipenv', 'run', 'python', '--version'
         }
         exec {
             // NB: the pip version inside pipenv is not necessarily the same as the version outside pipenv
@@ -88,7 +88,7 @@ task generateDocumentation {
             // This ensures that there are no directories prefixed with an underscore
             // because Jekyll will ignore these directories which causes the generated docs not to be served properly
             workingDir("docs/")
-            commandLine "pipenv", "run", 'python3', 'remove_underscores.py'
+            commandLine "pipenv", "run", 'python', 'remove_underscores.py'
         }
         exec {
             commandLine 'mv', 'docs/_build/html/', '../docs/python/latest/'
@@ -128,7 +128,7 @@ task buildWheelDistribution {
 
     doLast {
         exec {
-            commandLine 'pipenv', 'run', 'python3', project.file("setup.py"), 'sdist', 'bdist_wheel'
+            commandLine 'pipenv', 'run', 'python', project.file("setup.py"), 'sdist', 'bdist_wheel'
         }
     }
 }


### PR DESCRIPTION
We use Python 3 so we should be using pip3 and python3 commands. It's not a guarantee that pip links through to pip3 on all systems so we should explicitly call the correct version. Specifically hitting this issue on Ubuntu 16.04 build agents.