### PR TITLE
Ignore generated python from spotless

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 # to native line endings on checkout.
 *.java text
 *.py text
+*.ftl text
 
 # Declare files that will always have CRLF line endings on checkout.
 # *.sln text eol=crlf

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -11,6 +11,8 @@ spotless {
         target project.fileTree(project.rootDir) {
             include '**/*.py'
             exclude 'docs/src/test/python/*.py'
+            exclude 'keanu-python/keanu/vertex/generated.py'
+            exclude 'keanu-python/keanu/vertex/__init__.py'
         }
 
         replaceRegex 'loggers may not use root context', /logging.(debug|info|warning|error|critical|exception|log)/, 'logging.getLogger("keanu").$1'


### PR DESCRIPTION
## Problem description
Currently when building on Windows, the `spotlessPython` step will pass the first time the code is run however on further runs it will fail due to formatting errors in the generated python files.

## Cause
Spotless checks that the line endings are the ones that the user's OS uses (unless specified otherwise in gitattributes). For windows this is CRLF and for unix this LF. The files are currently being generated using LF line endings on all OS's.

## Solution
We don't really need to run any formatting checks on the generated files so for the time being they can be ignored.

## Testing
I was hitting this problem when running multiple times on a build agent. This fix stops this problem.