### PR TITLE
Delete python classpath on clean

### DIFF
--- a/keanu-python/build.gradle
+++ b/keanu-python/build.gradle
@@ -147,6 +147,9 @@ task buildWheelDistribution {
     }
 }
 
+clean.doFirst {
+    delete 'keanu/classpath'
+}
 
 pythonVersionInfo.mustRunAfter(installPipenv)
 installDependencies.dependsOn(installPipenv)

--- a/keanu-python/nd4j/build.gradle
+++ b/keanu-python/nd4j/build.gradle
@@ -21,3 +21,7 @@ task buildWheelDistribution {
         }
     }
 }
+
+clean.doFirst {
+    delete 'nd4j/classpath'
+}


### PR DESCRIPTION
Currently running `./gradlew clean` doesn't delete the classpath in the python packages. This PR clears those directories on clean. This should give better guarantees when running `./gradlew clean build`