### PR TITLE
Support for vector-vector and matrix-vector product.

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -100,7 +100,8 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
      * Matrix product of two vertices
      *
      * @param that  a double vertex to matrix multiply
-     * @return a vertex that represents the matrix multiplication of two vertices.
+     * @return a vertex that represents the matrix multiplication of two vertices. Note that this operation
+     * does that always return a MatrixMultiplicationVertex.
      * - If both left and right operands are rank 2, they are multiplied like conventional matrices.
      * - If both left and right operands are rank 1, they are promoted to a matrix by prepending a 1 to its dimensions.
      *   After matrix multiplication, it is reshaped to be a scalar. This is essentially a dot product.

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -96,6 +96,26 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return new MultiplicationVertex(this, that);
     }
 
+    /*
+        - If both arguments are rank 2 they are multiplied like conventional matrices.
+        - If the first argument has rank 1, it is promoted to a matrix by prepending a 1 to its dimensions.
+          After matrix multiplication the prepended 1 is removed.
+        - If the second argument has rank1 1, it is promoted to a matrix by appending a 1 to its dimensions.
+          After matrix multiplication the appended 1 is removed.
+        - If both arguments are rank 1, dot product is applied.
+     */
+
+    /**
+     * Matrix product of two vertices
+     *
+     * @param that  a double vertex to matrix multiply
+     * @return a vertex that represents the matrix multiplication of two vertices.
+     * - If both left and right operands are rank 2, they are multiplied like conventional matrices.
+     * - If both left and right operands are rank 1, they are promoted to a matrix by prepending a 1 to its dimensions.
+     *   After matrix multiplication, it is reshaped to be a scalar. This is essentially a dot product.
+     * - If only one of the operands are rank 1, it is promoted to a matrix by prepending a 1 to its dimensions.
+     *   After matrix multiplication, the appended 1 is removed. This is essentially a matrix-vector product.
+     */
     public DoubleVertex matrixMultiply(DoubleVertex that) {
         int leftRank = this.getRank();
         int rightRank = that.getRank();

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -96,15 +96,6 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return new MultiplicationVertex(this, that);
     }
 
-    /*
-        - If both arguments are rank 2 they are multiplied like conventional matrices.
-        - If the first argument has rank 1, it is promoted to a matrix by prepending a 1 to its dimensions.
-          After matrix multiplication the prepended 1 is removed.
-        - If the second argument has rank1 1, it is promoted to a matrix by appending a 1 to its dimensions.
-          After matrix multiplication the appended 1 is removed.
-        - If both arguments are rank 1, dot product is applied.
-     */
-
     /**
      * Matrix product of two vertices
      *

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -56,6 +56,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TakeVer
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TanVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.CastToIntegerVertex;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -99,14 +100,16 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
     /**
      * Matrix product of two vertices
      *
-     * @param that  a double vertex to matrix multiply
-     * @return a vertex that represents the matrix multiplication of two vertices. Note that this operation
-     * does that always return a MatrixMultiplicationVertex.
-     * - If both left and right operands are rank 2, they are multiplied like conventional matrices.
+     * @param that  a double vertex representing a matrix or a vector to matrix multiply
+     * @return a vertex that represents the matrix multiplication of two vertices.
      * - If both left and right operands are rank 1, they are promoted to a matrix by prepending a 1 to its dimensions.
      *   After matrix multiplication, it is reshaped to be a scalar. This is essentially a dot product.
+     *   This returns a ReshapeVertex.
      * - If only one of the operands are rank 1, it is promoted to a matrix by prepending a 1 to its dimensions.
      *   After matrix multiplication, the appended 1 is removed. This is essentially a matrix-vector product.
+     *   This returns a ReshapeVertex.
+     * - Otherwise, they are multiplied like conventional matrices.
+     *   This returns a MatrixMultiplicationVertex.
      */
     public DoubleVertex matrixMultiply(DoubleVertex that) {
         int leftRank = this.getRank();
@@ -120,9 +123,9 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         if (leftRank == 1 && rightRank == 1) {
             return result.reshape();
         } else if (leftRank == 1) {
-            return result.reshape(result.getShape()[1]);
+            return result.reshape(ArrayUtils.remove(result.getShape(), 0));
         } else if (rightRank == 1) {
-            return result.reshape(result.getShape()[0]);
+            return result.reshape(ArrayUtils.remove(result.getShape(), 1));
         } else {
             return result;
         }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -114,6 +114,10 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         int leftRank = this.getRank();
         int rightRank = that.getRank();
 
+        if (leftRank < 1 || rightRank < 1) {
+            throw new IllegalArgumentException("Matrix multiply for rank 0 is not supported. Use multiply instead.");
+        }
+
         DoubleVertex leftMatrix = leftRank == 1 ? this.reshape(1, this.getShape()[0]) : this;
         DoubleVertex rightMatrix = rightRank == 1 ? that.reshape(that.getShape()[0], 1) : that;
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -115,7 +115,7 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         int rightRank = that.getRank();
 
         if (leftRank < 1 || rightRank < 1) {
-            throw new IllegalArgumentException("Matrix multiply for rank 0 is not supported. Use multiply instead.");
+            throw new IllegalArgumentException("Matrix multiply for rank 0 is not supported. Use times instead.");
         }
 
         DoubleVertex leftMatrix = leftRank == 1 ? this.reshape(1, this.getShape()[0]) : this;

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -124,7 +124,7 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         MatrixMultiplicationVertex result = new MatrixMultiplicationVertex(leftMatrix, rightMatrix);
 
         if (leftRank == 1 && rightRank == 1) {
-            return result.reshape();
+            return result.reshape(new long[0]);
         } else if (leftRank == 1 && rightRank == 2) {
             return result.reshape(result.getShape()[1]);
         } else if (leftRank == 2 && rightRank == 1) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -96,8 +96,24 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return new MultiplicationVertex(this, that);
     }
 
-    public MatrixMultiplicationVertex matrixMultiply(DoubleVertex that) {
-        return new MatrixMultiplicationVertex(this, that);
+    public DoubleVertex matrixMultiply(DoubleVertex that) {
+        int leftRank = this.getRank();
+        int rightRank = that.getRank();
+
+        DoubleVertex leftMatrix = leftRank == 1 ? this.reshape(1, this.getShape()[0]) : this;
+        DoubleVertex rightMatrix = rightRank == 1 ? that.reshape(that.getShape()[0], 1) : that;
+
+        MatrixMultiplicationVertex result = new MatrixMultiplicationVertex(leftMatrix, rightMatrix);
+
+        if (leftRank == 1 && rightRank == 1) {
+            return result.reshape();
+        } else if (leftRank == 1) {
+            return result.reshape(result.getShape()[1]);
+        } else if (rightRank == 1) {
+            return result.reshape(result.getShape()[0]);
+        } else {
+            return result;
+        }
     }
 
     public MatrixInverseVertex matrixInverse() {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -56,7 +56,6 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TakeVer
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.TanVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
 import io.improbable.keanu.vertices.intgr.nonprobabilistic.CastToIntegerVertex;
-import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -105,7 +104,7 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
      * - If both left and right operands are rank 1, they are promoted to a matrix by prepending a 1 to its dimensions.
      *   After matrix multiplication, it is reshaped to be a scalar. This is essentially a dot product.
      *   This returns a ReshapeVertex.
-     * - If only one of the operands are rank 1, it is promoted to a matrix by prepending a 1 to its dimensions.
+     * - If only one of the operands is rank 1 (and the other operand is rank 2), it is promoted to a matrix by prepending a 1 to its dimensions.
      *   After matrix multiplication, the appended 1 is removed. This is essentially a matrix-vector product.
      *   This returns a ReshapeVertex.
      * - Otherwise, they are multiplied like conventional matrices.
@@ -122,10 +121,10 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
 
         if (leftRank == 1 && rightRank == 1) {
             return result.reshape();
-        } else if (leftRank == 1) {
-            return result.reshape(ArrayUtils.remove(result.getShape(), 0));
-        } else if (rightRank == 1) {
-            return result.reshape(ArrayUtils.remove(result.getShape(), 1));
+        } else if (leftRank == 1 && rightRank == 2) {
+            return result.reshape(result.getShape()[1]);
+        } else if (leftRank == 2 && rightRank == 1) {
+            return result.reshape(result.getShape()[0]);
         } else {
             return result;
         }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
@@ -7,15 +7,21 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
+import static org.hamcrest.Matchers.equalTo;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import org.junit.rules.ExpectedException;
 
 public class DoubleVertexTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     private DoubleVertex vectorA;
     private DoubleVertex matrixA;
@@ -148,6 +154,27 @@ public class DoubleVertexTest {
                 19., 26., 33.,
                 29., 40., 51.
             }, 3, 3);
+        assertThat(result, valuesAndShapesMatch(expectedResult));
+    }
+
+    @Test
+    public void cannotMatrixMultiplyScalarsWithRank0() {
+        DoubleVertex scalarWithRank0 = ConstantVertex.of(2.);
+        DoubleVertex matrix = ConstantVertex.of(new double[]{2., 3.}, 1, 2);
+        assertThat(scalarWithRank0.getRank(), equalTo(0));
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Matrix multiply for rank 0 is not supported. Use multiply instead.");
+
+        scalarWithRank0.matrixMultiply(matrix);
+    }
+
+    @Test
+    public void canMatrixMultiplyScalarsWithRank1() {
+        DoubleVertex scalarWithRank0 = ConstantVertex.of(new double[]{2.}, 1);
+        DoubleVertex matrix = ConstantVertex.of(new double[]{2., 3.}, 1, 2);
+        DoubleTensor result = scalarWithRank0.matrixMultiply(matrix).lazyEval();
+        DoubleTensor expectedResult = DoubleTensor.create(new double[]{4., 6.}, 2);
         assertThat(result, valuesAndShapesMatch(expectedResult));
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
@@ -164,7 +164,7 @@ public class DoubleVertexTest {
         assertThat(scalarWithRank0.getRank(), equalTo(0));
 
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Matrix multiply for rank 0 is not supported. Use multiply instead.");
+        thrown.expectMessage("Matrix multiply for rank 0 is not supported. Use times instead.");
 
         scalarWithRank0.matrixMultiply(matrix);
     }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
@@ -122,24 +122,24 @@ public class DoubleVertexTest {
 
     @Test
     public void canMatrixMultiplyVectorAndMatrix() {
-        DoubleVertex vectorsMultiplied = ConstantVertex.of(vectorA).matrixMultiply(ConstantVertex.of(vectorB.reshape(2, 3)));
-        DoubleTensor result = vectorsMultiplied.lazyEval();
+        DoubleVertex vectorAndMatrixMultiplied = ConstantVertex.of(vectorA).matrixMultiply(ConstantVertex.of(vectorB.reshape(2, 3)));
+        DoubleTensor result = vectorAndMatrixMultiplied.lazyEval();
         DoubleTensor expectedResult = DoubleTensor.create(new double[]{9., 12., 15.}, 3);
         assertThat(result, valuesAndShapesMatch(expectedResult));
     }
 
     @Test
     public void canMatrixMultiplyMatrixAndVector() {
-        DoubleVertex vectorsMultiplied = ConstantVertex.of(vectorB.reshape(3, 2)).matrixMultiply(ConstantVertex.of(vectorA));
-        DoubleTensor result = vectorsMultiplied.lazyEval();
+        DoubleVertex matrixAndVectorMultiplied = ConstantVertex.of(vectorB.reshape(3, 2)).matrixMultiply(ConstantVertex.of(vectorA));
+        DoubleTensor result = matrixAndVectorMultiplied.lazyEval();
         DoubleTensor expectedResult = DoubleTensor.create(new double[]{5., 11., 17.}, 3);
         assertThat(result, valuesAndShapesMatch(expectedResult));
     }
 
     @Test
     public void canMatrixMultiplyMatrices() {
-        DoubleVertex vectorsMultiplied = ConstantVertex.of(vectorB.reshape(3, 2)).matrixMultiply(ConstantVertex.of(vectorB.reshape(2, 3)));
-        DoubleTensor result = vectorsMultiplied.lazyEval();
+        DoubleVertex matricesMultiplied = ConstantVertex.of(vectorB.reshape(3, 2)).matrixMultiply(ConstantVertex.of(vectorB.reshape(2, 3)));
+        DoubleTensor result = matricesMultiplied.lazyEval();
         DoubleTensor expectedResult = DoubleTensor.create(
             new double[]{
                  9., 12., 15.,

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
@@ -17,13 +17,15 @@ import static org.junit.Assert.assertEquals;
 
 public class DoubleVertexTest {
 
-    private DoubleTensor vectorA;
-    private DoubleTensor vectorB;
+    private DoubleVertex vectorA;
+    private DoubleVertex matrixA;
+    private DoubleVertex matrixB;
 
     @Before
     public void initVectors() {
-        vectorA = DoubleTensor.create(new double[]{1., 2.}, 2);
-        vectorB = DoubleTensor.create(new double[]{1., 2., 3., 4., 5., 6.}, 6);
+        vectorA = ConstantVertex.of(new double[]{1., 2.}, 2);
+        matrixA = ConstantVertex.of(new double[]{1., 2., 3., 4., 5., 6.}, 3, 2);
+        matrixB = ConstantVertex.of(new double[]{1., 2., 3., 4., 5., 6.}, 2, 3);
     }
 
     @Test
@@ -114,7 +116,7 @@ public class DoubleVertexTest {
 
     @Test
     public void canMatrixMultiplyVectors() {
-        DoubleVertex vectorsMultiplied = ConstantVertex.of(vectorA).matrixMultiply(ConstantVertex.of(vectorA));
+        DoubleVertex vectorsMultiplied = vectorA.matrixMultiply(vectorA);
         DoubleTensor result = vectorsMultiplied.lazyEval();
         DoubleTensor expectedResult = DoubleTensor.scalar(5.);
         assertThat(result, valuesAndShapesMatch(expectedResult));
@@ -122,7 +124,7 @@ public class DoubleVertexTest {
 
     @Test
     public void canMatrixMultiplyVectorAndMatrix() {
-        DoubleVertex vectorAndMatrixMultiplied = ConstantVertex.of(vectorA).matrixMultiply(ConstantVertex.of(vectorB.reshape(2, 3)));
+        DoubleVertex vectorAndMatrixMultiplied = vectorA.matrixMultiply(matrixB);
         DoubleTensor result = vectorAndMatrixMultiplied.lazyEval();
         DoubleTensor expectedResult = DoubleTensor.create(new double[]{9., 12., 15.}, 3);
         assertThat(result, valuesAndShapesMatch(expectedResult));
@@ -130,7 +132,7 @@ public class DoubleVertexTest {
 
     @Test
     public void canMatrixMultiplyMatrixAndVector() {
-        DoubleVertex matrixAndVectorMultiplied = ConstantVertex.of(vectorB.reshape(3, 2)).matrixMultiply(ConstantVertex.of(vectorA));
+        DoubleVertex matrixAndVectorMultiplied = matrixA.matrixMultiply(vectorA);
         DoubleTensor result = matrixAndVectorMultiplied.lazyEval();
         DoubleTensor expectedResult = DoubleTensor.create(new double[]{5., 11., 17.}, 3);
         assertThat(result, valuesAndShapesMatch(expectedResult));
@@ -138,7 +140,7 @@ public class DoubleVertexTest {
 
     @Test
     public void canMatrixMultiplyMatrices() {
-        DoubleVertex matricesMultiplied = ConstantVertex.of(vectorB.reshape(3, 2)).matrixMultiply(ConstantVertex.of(vectorB.reshape(2, 3)));
+        DoubleVertex matricesMultiplied = matrixA.matrixMultiply(matrixB);
         DoubleTensor result = matricesMultiplied.lazyEval();
         DoubleTensor expectedResult = DoubleTensor.create(
             new double[]{

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/DoubleVertexTest.java
@@ -7,16 +7,16 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import io.improbable.keanu.vertices.intgr.IntegerVertex;
-import static org.hamcrest.Matchers.equalTo;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static io.improbable.keanu.tensor.TensorMatchers.valuesAndShapesMatch;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import org.junit.rules.ExpectedException;
 
 public class DoubleVertexTest {
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/DoubleIfVertexTest.java
@@ -12,7 +12,6 @@ import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialsOf;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.AdditionVertex;
-import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MatrixMultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
@@ -32,7 +31,7 @@ public class DoubleIfVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
-        MatrixMultiplicationVertex c = a.matrixMultiply(b);
+        DoubleVertex c = a.matrixMultiply(b);
         DoubleVertex d = b.matrixMultiply(a);
 
         PartialsOf dC = Differentiator.reverseModeAutoDiff(c, a, b);
@@ -100,7 +99,7 @@ public class DoubleIfVertexTest {
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
         DoubleVertex c = a.matrixMultiply(b);
-        MatrixMultiplicationVertex d = b.matrixMultiply(a);
+        DoubleVertex d = b.matrixMultiply(a);
 
         PartialsOf dD = Differentiator.reverseModeAutoDiff(d, a, b);
         DoubleTensor dDda = dD.withRespectTo(a);
@@ -131,8 +130,8 @@ public class DoubleIfVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
-        MatrixMultiplicationVertex c = a.matrixMultiply(b);
-        MatrixMultiplicationVertex d = b.matrixMultiply(a);
+        DoubleVertex c = a.matrixMultiply(b);
+        DoubleVertex d = b.matrixMultiply(a);
 
         DoubleTensor dCda = Differentiator.reverseModeAutoDiff(c, a).withRespectTo(a);
         DoubleTensor dDda = Differentiator.reverseModeAutoDiff(d, a).withRespectTo(a);
@@ -168,7 +167,7 @@ public class DoubleIfVertexTest {
         DoubleVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
-        MatrixMultiplicationVertex c = a.matrixMultiply(b);
+        DoubleVertex c = a.matrixMultiply(b);
 
         DoubleVertex d = new UniformVertex(0, 10);
         d.setValue(DoubleTensor.create(new double[]{9, 10, 11, 12}, 2, 2));
@@ -176,7 +175,7 @@ public class DoubleIfVertexTest {
         DoubleVertex e = new UniformVertex(0, 10);
         e.setValue(DoubleTensor.create(new double[]{13, 14, 15, 16}, 2, 2));
 
-        MatrixMultiplicationVertex f = d.matrixMultiply(e);
+        DoubleVertex f = d.matrixMultiply(e);
 
         DoubleTensor dCda = Differentiator.reverseModeAutoDiff(c, a).withRespectTo(a);
         DoubleTensor dFdd = Differentiator.reverseModeAutoDiff(f, d).withRespectTo(d);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -39,7 +39,7 @@ public class MatrixMultiplicationVertexTest {
         UniformVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{5, 6, 7, 8}, 2, 2));
 
-        MatrixMultiplicationVertex c = a.matrixMultiply(b);
+        MatrixMultiplicationVertex c = (MatrixMultiplicationVertex) a.matrixMultiply(b);
 
         //of c wrt a,b
         DoubleTensor dCda = Differentiator.forwardModeAutoDiff(a, c).of(c);
@@ -77,7 +77,7 @@ public class MatrixMultiplicationVertexTest {
         assertEquals(expecteddCda, dCdaReverse);
         assertEquals(expecteddCdb, dCdbReverse);
 
-        MatrixMultiplicationVertex d = b.matrixMultiply(a);
+        MatrixMultiplicationVertex d = (MatrixMultiplicationVertex) b.matrixMultiply(a);
 
         DoubleTensor dDda = Differentiator.forwardModeAutoDiff(a, d).of(d);
         DoubleTensor dDdb = Differentiator.forwardModeAutoDiff(b, d).of(d);
@@ -141,7 +141,7 @@ public class MatrixMultiplicationVertexTest {
         UniformVertex alpha = new UniformVertex(0, 10);
         alpha.setValue(DoubleTensor.create(new double[]{1, 3, 5, 2, 4, 6}, 2, 3));
 
-        MatrixMultiplicationVertex N = m.matrixMultiply(alpha);
+        MatrixMultiplicationVertex N = (MatrixMultiplicationVertex) m.matrixMultiply(alpha);
 
         PartialsOf reverseModePartialDiff = Differentiator.reverseModeAutoDiff(N, m, alpha);
 
@@ -188,7 +188,7 @@ public class MatrixMultiplicationVertexTest {
         }, 2, 2));
 
         DoubleVertex N = m.matrixMultiply(alpha);
-        MatrixMultiplicationVertex y = N.matrixMultiply(beta);
+        MatrixMultiplicationVertex y = (MatrixMultiplicationVertex) N.matrixMultiply(beta);
 
         PartialsOf dydx = Differentiator.reverseModeAutoDiff(y, m, alpha, beta);
 
@@ -251,7 +251,7 @@ public class MatrixMultiplicationVertexTest {
         DoubleVertex N = alpha.matrixMultiply(m);
         DoubleVertex L = beta.matrixMultiply(alpha);
         //y = L x N = (beta x alpha) x (alpha x m)
-        MatrixMultiplicationVertex y = L.matrixMultiply(N);
+        MatrixMultiplicationVertex y = (MatrixMultiplicationVertex) L.matrixMultiply(N);
         PartialsOf dydx = Differentiator.reverseModeAutoDiff(y, alpha);
 
         DoubleTensor dydalphaForward = Differentiator.forwardModeAutoDiff(alpha, y).of(y);
@@ -273,7 +273,7 @@ public class MatrixMultiplicationVertexTest {
     public void changesMatchGradient() {
         UniformVertex inputA = new UniformVertex(new long[]{2, 5}, -10.0, 10.0);
         UniformVertex inputB = new UniformVertex(new long[]{5, 4}, -10.0, 10.0);
-        MatrixMultiplicationVertex outputVertex = inputA.matrixMultiply(inputB);
+        MatrixMultiplicationVertex outputVertex = (MatrixMultiplicationVertex) inputA.matrixMultiply(inputB);
         final double INCREMENT = 10;
         final double DELTA = 1e-10;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -89,7 +89,7 @@ public class SliceVertexTest {
         DoubleVertex alpha = new UniformVertex(0, 10);
         alpha.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25, 30, 35}, 3, 2));
 
-        MatrixMultiplicationVertex N = m.matrixMultiply(alpha);
+        DoubleVertex N = m.matrixMultiply(alpha);
 
         SliceVertex sliceN = new SliceVertex(N, dim, ind);
 
@@ -117,7 +117,7 @@ public class SliceVertexTest {
         DoubleVertex alpha = new UniformVertex(0, 10);
         alpha.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        MatrixMultiplicationVertex N = m.matrixMultiply(alpha);
+        DoubleVertex N = m.matrixMultiply(alpha);
 
         SliceVertex sliceN = new SliceVertex(N, 1, 1);
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertexTest.java
@@ -317,8 +317,8 @@ public class ConcatenationVertexTest {
         UniformVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        MatrixMultiplicationVertex c = sharedMatrix.matrixMultiply(a);
-        MatrixMultiplicationVertex d = sharedMatrix.matrixMultiply(b);
+        MatrixMultiplicationVertex c = (MatrixMultiplicationVertex) sharedMatrix.matrixMultiply(a);
+        MatrixMultiplicationVertex d = (MatrixMultiplicationVertex) sharedMatrix.matrixMultiply(b);
 
         DoubleTensor dCdshared = Differentiator.forwardModeAutoDiff(sharedMatrix, c).of(c);
         DoubleTensor dDdshared = Differentiator.forwardModeAutoDiff(sharedMatrix, d).of(d);
@@ -369,8 +369,8 @@ public class ConcatenationVertexTest {
         UniformVertex b = new UniformVertex(0, 10);
         b.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        MatrixMultiplicationVertex c = sharedMatrix.matrixMultiply(a);
-        MatrixMultiplicationVertex d = sharedMatrix.matrixMultiply(b);
+        MatrixMultiplicationVertex c = (MatrixMultiplicationVertex) sharedMatrix.matrixMultiply(a);
+        MatrixMultiplicationVertex d = (MatrixMultiplicationVertex) sharedMatrix.matrixMultiply(b);
 
         DoubleTensor dCdshared = Differentiator.forwardModeAutoDiff(sharedMatrix, c).of(c);
         DoubleTensor dDdshared = Differentiator.forwardModeAutoDiff(sharedMatrix, d).of(d);
@@ -424,9 +424,9 @@ public class ConcatenationVertexTest {
         UniformVertex f = new UniformVertex(0, 10);
         f.setValue(DoubleTensor.create(new double[]{90, 91, 92, 93}, 2, 2));
 
-        MatrixMultiplicationVertex c = sharedMatrix.matrixMultiply(a);
-        MatrixMultiplicationVertex d = sharedMatrix.matrixMultiply(b);
-        MatrixMultiplicationVertex e = sharedMatrix.matrixMultiply(f);
+        MatrixMultiplicationVertex c = (MatrixMultiplicationVertex) sharedMatrix.matrixMultiply(a);
+        MatrixMultiplicationVertex d = (MatrixMultiplicationVertex) sharedMatrix.matrixMultiply(b);
+        MatrixMultiplicationVertex e = (MatrixMultiplicationVertex) sharedMatrix.matrixMultiply(f);
 
         DoubleTensor dCdshared = Differentiator.forwardModeAutoDiff(sharedMatrix, c).of(c);
         DoubleTensor dDdshared = Differentiator.forwardModeAutoDiff(sharedMatrix, d).of(d);

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/MatrixInverseVertexTest.java
@@ -85,7 +85,7 @@ public class MatrixInverseVertexTest {
     public void inverseMultipliedEqualsIdentity() {
         UniformVertex inputVertex = new UniformVertex(new long[]{4, 4}, -20.0, 20.0);
         DoubleVertex inverseVertex = inputVertex.matrixInverse();
-        MatrixMultiplicationVertex multiplied = inverseVertex.matrixMultiply(inputVertex);
+        MatrixMultiplicationVertex multiplied = (MatrixMultiplicationVertex) inverseVertex.matrixMultiply(inputVertex);
 
         for (int i = 0; i < NUM_ITERATIONS; i++) {
             inputVertex.setValue(inputVertex.sample());

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/unary/ReshapeVertexTest.java
@@ -36,7 +36,7 @@ public class ReshapeVertexTest {
         DoubleVertex alpha = new UniformVertex(0, 10);
         alpha.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        MatrixMultiplicationVertex N = m.matrixMultiply(alpha);
+        MatrixMultiplicationVertex N = (MatrixMultiplicationVertex) m.matrixMultiply(alpha);
 
         ReshapeVertex reshapedN = new ReshapeVertex(N, 4, 1);
 
@@ -57,7 +57,7 @@ public class ReshapeVertexTest {
         UniformVertex a = new UniformVertex(0, 10);
         a.setValue(DoubleTensor.create(new double[]{10, 15, 20, 25}, 2, 2));
 
-        MatrixMultiplicationVertex N = m.matrixMultiply(a);
+        MatrixMultiplicationVertex N = (MatrixMultiplicationVertex) m.matrixMultiply(a);
 
         DoubleTensor dNdm = Differentiator.reverseModeAutoDiff(N, m).withRespectTo(m);
         DoubleTensor dNda = Differentiator.reverseModeAutoDiff(N, a).withRespectTo(a);

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,10 @@
 ## Version 0.0.22
 
-## Python
+### Common
+
+* `DoubleVertex#matrixMultiply` now performs dot product when given two vectors, and matrix-vector product when given a matrix and a vector.
+
+### Python
 
 * Improved performance of getting samples by coercing them into a `Tensor` in Java (instead of iterating through an `ArrayList`).
 


### PR DESCRIPTION
Note that the reshape is not done at the tensor level, because that will interfere with auto diff.

The new behaviour of matrix multiply was copied from numpy's `matmul`.