### PR TITLE
Bug/slice with nuts

### DIFF
--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -5,6 +5,7 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialsOf;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Test;
@@ -272,8 +273,12 @@ public class MatrixMultiplicationVertexTest {
     @Test
     public void changesMatchGradient() {
         UniformVertex inputA = new UniformVertex(new long[]{2, 5}, -10.0, 10.0);
-        UniformVertex inputB = new UniformVertex(new long[]{5, 4}, -10.0, 10.0);
-        MatrixMultiplicationVertex outputVertex = inputA.matrixMultiply(inputB);
+        UniformVertex inputB = new UniformVertex(new long[]{5, 2}, -10.0, 10.0);
+        MatrixMultiplicationVertex mmultVertex = inputA.matrixMultiply(inputB);
+        MultiplicationVertex outputVertex = mmultVertex.times(
+            new ConstantDoubleVertex(new double[]{1., 2., 3., 4., 5., 6., 7., 8.}, new long[]{2, 2, 2})
+        );
+
         final double INCREMENT = 10;
         final double DELTA = 1e-10;
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -174,7 +174,8 @@ public class SliceVertexTest {
     public void changesMatchGradient() {
         UniformVertex cube = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         SliceVertex slice = new SliceVertex(cube, 2, 0);
-        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(cube), slice, 10.0, 1e-10);
+        MultiplicationVertex result = slice.times(5.0);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(cube), result, 10.0, 1e-10);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -174,7 +174,9 @@ public class SliceVertexTest {
     public void changesMatchGradient() {
         UniformVertex cube = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         SliceVertex slice = new SliceVertex(cube, 2, 0);
-        MultiplicationVertex result = slice.times(5.0);
+        MultiplicationVertex result = slice.times(
+            new ConstantDoubleVertex(new double[]{1., 2., 3., 4., 5., 6., 7., 8.}, new long[]{2, 2, 2})
+        );
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(cube), result, 10.0, 1e-10);
     }
 

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/SliceVertexTest.java
@@ -6,13 +6,16 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.multiple.ConcatenationVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SliceVertex;
+import io.improbable.keanu.vertices.dbl.probabilistic.GaussianVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import static io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.TensorTestOperations.finiteDifferenceMatchesForwardAndReverseModeGradient;
+import static org.junit.Assert.assertEquals;
 
 public class SliceVertexTest {
 
@@ -21,6 +24,24 @@ public class SliceVertexTest {
     @Before
     public void setup() {
         matrixA = new ConstantDoubleVertex(DoubleTensor.create(new double[]{1, 2, 3, 4, 5, 6}, 2, 3));
+    }
+
+    @Test
+    public void canDoAutodiffAcrossSliceAndConcat() {
+        GaussianVertex latent = new GaussianVertex(new long[]{4, 1}, 0.0, 1.0);
+        SliceVertex slices[] = new SliceVertex[4];
+
+        for (int i = 0; i < slices.length; i++) {
+            slices[i] = new SliceVertex(latent, 0, i);
+        }
+
+        ConcatenationVertex concatenationVertex = new ConcatenationVertex(0, slices);
+        GaussianVertex observed = new GaussianVertex(concatenationVertex, 1);
+
+        DoubleTensor dForward = Differentiator.forwardModeAutoDiff(latent, concatenationVertex).of(concatenationVertex);
+        DoubleTensor dReverse = Differentiator.reverseModeAutoDiff(concatenationVertex, latent).withRespectTo(latent);
+
+        assertEquals(dForward, dReverse);
     }
 
     @Test
@@ -59,7 +80,7 @@ public class SliceVertexTest {
         SliceVertex columnZero = new SliceVertex(m, 0, 0);
         SliceVertex elementZero = new SliceVertex(columnZero, 0, 0);
 
-        Assert.assertEquals(elementZero.getValue().scalar(), 1, 1e-6);
+        assertEquals(elementZero.getValue().scalar(), 1, 1e-6);
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/multiple/ConcatenationVertexTest.java
@@ -11,6 +11,7 @@ import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialsWithRespec
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.AdditionVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MatrixMultiplicationVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.binary.MultiplicationVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SliceVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.operators.unary.SumVertex;
 import io.improbable.keanu.vertices.dbl.probabilistic.UniformVertex;
 import org.junit.Assert;
@@ -497,7 +498,8 @@ public class ConcatenationVertexTest {
         UniformVertex inputA = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         UniformVertex inputB = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
         UniformVertex inputC = new UniformVertex(new long[]{2, 2, 2}, -10.0, 10.0);
-        ConcatenationVertex outputVertex = new ConcatenationVertex(0, inputA, inputB, inputC);
+        ConcatenationVertex concatenationVertex = new ConcatenationVertex(0, inputA, inputB, inputC);
+        SliceVertex outputVertex = concatenationVertex.slice(1, 0);
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB, inputC), outputVertex, 10.0, 1e-10);
     }
 


### PR DESCRIPTION
Fixed a problem with the way the slice Vertex calculated reverse Autodiff - it was altering the "of" shape on the way through when it shouldn't be leading to breakages further up the graph.  For now, I've just fixed, added a new test to catch this and changed a few other tests that also cause shape changes to make sure that the shape is maintained correctly through those nodes.

Ideally we'd track and verify the shapes as part of the Differentiator run to avoid hard to debug problems like this from popping up in future, but that feels like a future task.