### PR TITLE
Multivariate Gaussian cleanup

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
@@ -39,7 +39,7 @@ public class MultivariateGaussian implements ContinuousDistribution {
         final double kLog2Pi = dimensions * LOG_2_PI;
         final double logCovDet = Math.log(covariance.determinant());
         DoubleTensor xMinusMu = x.minus(mu).reshape(dimensions, 1);
-        DoubleTensor xMinusMuT = xMinusMu.transpose();
+        DoubleTensor xMinusMuT = xMinusMu.reshape(1, dimensions);
         DoubleTensor covInv = covariance.matrixInverse();
 
         double scalar = isUnivariate() ?
@@ -59,7 +59,7 @@ public class MultivariateGaussian implements ContinuousDistribution {
         final double kLog2Pi = dimensions * LOG_2_PI;
         final DoubleVertex logCovDet = covariance.matrixDeterminant().log();
         DoubleVertex xMinusMu = x.minus(mu).reshape(dimensions, 1);
-        DoubleVertex xMinusMuT = xMinusMu.transpose();
+        DoubleVertex xMinusMuT = xMinusMu.reshape(1, dimensions);
         DoubleVertex covInv = covariance.matrixInverse();
 
         DoubleVertex scalar = isUnivariate(dimensions) ?

--- a/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/distributions/continuous/MultivariateGaussian.java
@@ -63,10 +63,10 @@ public class MultivariateGaussian implements ContinuousDistribution {
         DoubleVertex covInv = covariance.matrixInverse();
 
         DoubleVertex scalar = isUnivariate(dimensions) ?
-            covInv.times(xMinusMu).times(xMinusMuT).slice(0, 0) :
-            xMinusMuT.matrixMultiply(covInv.matrixMultiply(xMinusMu)).slice(0, 0);
+            covInv.times(xMinusMu).times(xMinusMuT) :
+            xMinusMuT.matrixMultiply(covInv.matrixMultiply(xMinusMu));
 
-        return scalar.plus(kLog2Pi).plus(logCovDet).times(-0.5).slice(0, 0);
+        return scalar.plus(kLog2Pi).plus(logCovDet).times(-0.5);
     }
 
     private boolean isUnivariate() {

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -5,6 +5,8 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Arrays;
 
+import static org.apache.commons.lang3.ArrayUtils.removeAll;
+
 public class TensorShape {
 
     private long[] shape;
@@ -246,6 +248,22 @@ public class TensorShape {
             dimension += rank;
         }
         return dimension;
+    }
+
+    public static long[] getTensorMultiplyResultShape(long[] leftShape, long[] rightShape, int[] dimsLeft, int[] dimsRight) {
+
+        if (dimsLeft.length != dimsRight.length) {
+            throw new IllegalArgumentException("Tensor multiply must match dimension lengths");
+        }
+
+
+        for (int i = 0; i < dimsLeft.length; i++) {
+            if (leftShape[dimsLeft[i]] != rightShape[dimsRight[i]]) {
+                throw new IllegalArgumentException("Cannot tensor multiply ");
+            }
+        }
+
+        return TensorShape.concat(removeAll(leftShape, dimsLeft), removeAll(rightShape, dimsRight));
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/TensorShape.java
@@ -5,7 +5,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Arrays;
 
-import static org.apache.commons.lang3.ArrayUtils.removeAll;
 
 public class TensorShape {
 
@@ -248,22 +247,6 @@ public class TensorShape {
             dimension += rank;
         }
         return dimension;
-    }
-
-    public static long[] getTensorMultiplyResultShape(long[] leftShape, long[] rightShape, int[] dimsLeft, int[] dimsRight) {
-
-        if (dimsLeft.length != dimsRight.length) {
-            throw new IllegalArgumentException("Tensor multiply must match dimension lengths");
-        }
-
-
-        for (int i = 0; i < dimsLeft.length; i++) {
-            if (leftShape[dimsLeft[i]] != rightShape[dimsRight[i]]) {
-                throw new IllegalArgumentException("Cannot tensor multiply ");
-            }
-        }
-
-        return TensorShape.concat(removeAll(leftShape, dimsLeft), removeAll(rightShape, dimsRight));
     }
 
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/BooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/BooleanTensor.java
@@ -26,6 +26,10 @@ public interface BooleanTensor extends Tensor<Boolean>, BooleanOperators<Boolean
         return new SimpleBooleanTensor(scalarValue);
     }
 
+    static BooleanTensor vector(boolean... values) {
+        return create(values, values.length);
+    }
+
     static BooleanTensor trues(long... shape) {
         return new SimpleBooleanTensor(true, shape);
     }
@@ -34,10 +38,10 @@ public interface BooleanTensor extends Tensor<Boolean>, BooleanOperators<Boolean
         return new SimpleBooleanTensor(false, shape);
     }
 
-     /**
-     * @param dimension  the dimension along which toStack are stacked
-     * @param toStack    an array of BooleanTensor's of the same shape
-     * @return  a BooleanTensor with toStack joined along a new dimension
+    /**
+     * @param dimension the dimension along which toStack are stacked
+     * @param toStack   an array of BooleanTensor's of the same shape
+     * @return a BooleanTensor with toStack joined along a new dimension
      * <p>
      * e.g. A, B, C = BooleanTensor.trues(4, 2)
      * <p>

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/bool/SimpleBooleanTensor.java
@@ -281,6 +281,9 @@ public class SimpleBooleanTensor implements BooleanTensor {
 
     @Override
     public Boolean scalar() {
+        if (this.getLength() > 1) {
+            throw new IllegalArgumentException("Not a scalar");
+        }
         return data[0];
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -97,9 +97,9 @@ public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, Double
     }
 
     /**
-     * @param dimension  the dimension along which toStack are stacked
-     * @param toStack    an array of DoubleTensor's of the same shape
-     * @return  a DoubleTensor with toStack joined along a new dimension
+     * @param dimension the dimension along which toStack are stacked
+     * @param toStack   an array of DoubleTensor's of the same shape
+     * @return a DoubleTensor with toStack joined along a new dimension
      * <p>
      * e.g. A, B, C = DoubleTensor.ones(4, 2)
      * <p>
@@ -129,10 +129,10 @@ public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, Double
         return concat(0, toConcat);
     }
 
-     /**
+    /**
      * @param dimension the dimension along which the tensors will be joined
      * @param toConcat  an array of DoubleTensor
-     * @return  a DoubleTensor with toConcat joined along an existing dimension
+     * @return a DoubleTensor with toConcat joined along an existing dimension
      * <p>
      * e.g. A, B, C = DoubleTensor.ones(4, 2)
      * <p>

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/DoubleTensor.java
@@ -96,6 +96,10 @@ public interface DoubleTensor extends NumberTensor<Double, DoubleTensor>, Double
         return new ScalarDoubleTensor(scalarValue);
     }
 
+    static DoubleTensor vector(double... values) {
+        return DoubleTensor.create(values, values.length);
+    }
+
     /**
      * @param dimension the dimension along which toStack are stacked
      * @param toStack   an array of DoubleTensor's of the same shape

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/Nd4jDoubleTensor.java
@@ -279,6 +279,9 @@ public class Nd4jDoubleTensor implements DoubleTensor {
 
     @Override
     public Double scalar() {
+        if (this.getLength() > 1) {
+            throw new IllegalArgumentException("Not a scalar");
+        }
         return tensor.getDouble(0);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensor.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static io.improbable.keanu.tensor.TensorShape.calculateShapeForLengthOneBroadcast;
-import static io.improbable.keanu.tensor.TensorShape.getTensorMultiplyResultShape;
+import static io.improbable.keanu.tensor.TensorShapeValidation.getTensorMultiplyResultShape;
 import static org.apache.commons.lang3.ArrayUtils.removeAll;
 
 public class ScalarDoubleTensor implements DoubleTensor {
@@ -159,17 +159,14 @@ public class ScalarDoubleTensor implements DoubleTensor {
 
     @Override
     public DoubleTensor matrixMultiply(DoubleTensor that) {
-        if (shape.length == 2) {
-            return that.times(value);
-        } else {
-            throw new IllegalArgumentException("Cannot matrix multiply shape: " + Arrays.toString(shape));
-        }
+        TensorShapeValidation.getMatrixMultiplicationResultingShape(shape, that.getShape());
+        return that.times(value);
     }
 
     @Override
     public DoubleTensor tensorMultiply(DoubleTensor that, int[] dimsLeft, int[] dimsRight) {
         long[] resultShape = getTensorMultiplyResultShape(this.shape, that.getShape(), dimsLeft, dimsRight);
-        return Nd4jDoubleTensor.create(value, shape).tensorMultiply(that, dimsLeft, dimsRight).reshape(resultShape);
+        return that.times(value).reshape(resultShape);
     }
 
     @Override

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/IntegerTensor.java
@@ -69,10 +69,14 @@ public interface IntegerTensor extends NumberTensor<Integer, IntegerTensor>, Int
         return new ScalarIntegerTensor(scalarValue);
     }
 
+    static IntegerTensor vector(int... values) {
+        return create(values, values.length);
+    }
+
     /**
-     * @param dimension  the dimension along which toStack are stacked
-     * @param toStack    an array of IntegerTensor
-     * @return  an IntegerTensor with toStack joined along a new dimension
+     * @param dimension the dimension along which toStack are stacked
+     * @param toStack   an array of IntegerTensor
+     * @return an IntegerTensor with toStack joined along a new dimension
      * <p>
      * e.g. A, B, C = IntegerTensor.ones(4, 2)
      * <p>
@@ -104,7 +108,7 @@ public interface IntegerTensor extends NumberTensor<Integer, IntegerTensor>, Int
     /**
      * @param dimension the dimension along which the tensors will be joined
      * @param toConcat  an array of IntegerTensor
-     * @return  an IntegerTensor with toConcat joined along existing dimension
+     * @return an IntegerTensor with toConcat joined along existing dimension
      * <p>
      * e.g. A, B, C = IntegerTensor.ones(4, 2)
      * <p>

--- a/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/tensor/intgr/Nd4jIntegerTensor.java
@@ -586,6 +586,9 @@ public class Nd4jIntegerTensor implements IntegerTensor {
 
     @Override
     public Integer scalar() {
+        if(this.getLength() > 1){
+            throw new IllegalArgumentException("Not a scalar");
+        }
         return (int) tensor.getDouble(0);
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/LogProbGraph.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/LogProbGraph.java
@@ -25,11 +25,7 @@ public class LogProbGraph {
      */
     @Getter
     @Singular
-    private final Map<Vertex<?>, Vertex<?>> inputs;
-
-    public <T> Vertex<T> getInput(Vertex<T> input) {
-        return (Vertex<T>) inputs.get(input);
-    }
+    private final Map<Vertex<?>, PlaceholderVertex<?>> inputs;
 
     /**
      * A vertex representing the result of log probability computation
@@ -41,7 +37,7 @@ public class LogProbGraph {
         return (Vertex<T>) inputs.get(input);
     }
 
-    static public class DoublePlaceholderVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor>, Differentiable, NonSaveableVertex {
+    static public class DoublePlaceholderVertex extends DoubleVertex implements PlaceholderVertex<DoubleTensor>, NonProbabilistic<DoubleTensor>, Differentiable, NonSaveableVertex {
 
         public DoublePlaceholderVertex(long... initialShape) {
             super(initialShape);
@@ -54,7 +50,7 @@ public class LogProbGraph {
 
     }
 
-    static public class IntegerPlaceholderVertex extends IntegerVertex implements NonProbabilistic<IntegerTensor>, Differentiable, NonSaveableVertex {
+    static public class IntegerPlaceholderVertex extends IntegerVertex implements PlaceholderVertex<IntegerTensor>, NonProbabilistic<IntegerTensor>, Differentiable, NonSaveableVertex {
 
         public IntegerPlaceholderVertex(long... initialShape) {
             super(initialShape);
@@ -67,7 +63,7 @@ public class LogProbGraph {
 
     }
 
-    static public class BooleanPlaceholderVertex extends BooleanVertex implements NonProbabilistic<BooleanTensor>, Differentiable, NonSaveableVertex {
+    static public class BooleanPlaceholderVertex extends BooleanVertex implements PlaceholderVertex<BooleanTensor>, NonProbabilistic<BooleanTensor>, Differentiable, NonSaveableVertex {
 
         public BooleanPlaceholderVertex(long... initialShape) {
             super(initialShape);
@@ -80,6 +76,8 @@ public class LogProbGraph {
 
     }
 
+    private interface PlaceholderVertex<T> {
+    }
 
     private static <T> T getPlaceholderVertexValue(Vertex<T> vertex) {
         if (!vertex.hasValue()) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/LogProbGraph.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/LogProbGraph.java
@@ -25,7 +25,11 @@ public class LogProbGraph {
      */
     @Getter
     @Singular
-    private final Map<Vertex<?>, PlaceholderVertex<?>> inputs;
+    private final Map<Vertex<?>, Vertex<?>> inputs;
+
+    public <T> Vertex<T> getInput(Vertex<T> input) {
+        return (Vertex<T>) inputs.get(input);
+    }
 
     /**
      * A vertex representing the result of log probability computation
@@ -37,7 +41,7 @@ public class LogProbGraph {
         return (Vertex<T>) inputs.get(input);
     }
 
-    static public class DoublePlaceholderVertex extends DoubleVertex implements PlaceholderVertex<DoubleTensor>, NonProbabilistic<DoubleTensor>, Differentiable, NonSaveableVertex {
+    static public class DoublePlaceholderVertex extends DoubleVertex implements NonProbabilistic<DoubleTensor>, Differentiable, NonSaveableVertex {
 
         public DoublePlaceholderVertex(long... initialShape) {
             super(initialShape);
@@ -50,7 +54,7 @@ public class LogProbGraph {
 
     }
 
-    static public class IntegerPlaceholderVertex extends IntegerVertex implements PlaceholderVertex<IntegerTensor>, NonProbabilistic<IntegerTensor>, Differentiable, NonSaveableVertex {
+    static public class IntegerPlaceholderVertex extends IntegerVertex implements NonProbabilistic<IntegerTensor>, Differentiable, NonSaveableVertex {
 
         public IntegerPlaceholderVertex(long... initialShape) {
             super(initialShape);
@@ -63,7 +67,7 @@ public class LogProbGraph {
 
     }
 
-    static public class BooleanPlaceholderVertex extends BooleanVertex implements PlaceholderVertex<BooleanTensor>, NonProbabilistic<BooleanTensor>, Differentiable, NonSaveableVertex {
+    static public class BooleanPlaceholderVertex extends BooleanVertex implements NonProbabilistic<BooleanTensor>, Differentiable, NonSaveableVertex {
 
         public BooleanPlaceholderVertex(long... initialShape) {
             super(initialShape);
@@ -76,8 +80,6 @@ public class LogProbGraph {
 
     }
 
-    private interface PlaceholderVertex<T> {
-    }
 
     private static <T> T getPlaceholderVertexValue(Vertex<T> vertex) {
         if (!vertex.hasValue()) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/Differentiator.java
@@ -58,7 +58,7 @@ public class Differentiator {
         return new PartialsWithRespectTo(wrt, ofWrt);
     }
 
-    public static PartialsOf reverseModeAutoDiff(Vertex ofVertex, Set<DoubleVertex> wrt) {
+    public static PartialsOf reverseModeAutoDiff(Vertex ofVertex, Set<? extends Vertex<?>> wrt) {
         if (ofVertex.isObserved()) {
             return new PartialsOf(ofVertex, Collections.emptyMap());
         } else {
@@ -66,7 +66,7 @@ public class Differentiator {
         }
     }
 
-    public static PartialsOf reverseModeAutoDiff(Vertex ofVertex, DoubleVertex... wrt) {
+    public static PartialsOf reverseModeAutoDiff(Vertex ofVertex, Vertex<?>... wrt) {
         return reverseModeAutoDiff(ofVertex, new HashSet<>(Arrays.asList(wrt)));
     }
 

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/DoubleVertex.java
@@ -99,16 +99,16 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
     /**
      * Matrix product of two vertices
      *
-     * @param that  a double vertex representing a matrix or a vector to matrix multiply
+     * @param that a double vertex representing a matrix or a vector to matrix multiply
      * @return a vertex that represents the matrix multiplication of two vertices.
      * - If both left and right operands are rank 1, they are promoted to a matrix by prepending a 1 to its dimensions.
-     *   After matrix multiplication, it is reshaped to be a scalar. This is essentially a dot product.
-     *   This returns a ReshapeVertex.
+     * After matrix multiplication, it is reshaped to be a scalar. This is essentially a dot product.
+     * This returns a ReshapeVertex.
      * - If only one of the operands is rank 1 (and the other operand is rank 2), it is promoted to a matrix by prepending a 1 to its dimensions.
-     *   After matrix multiplication, the appended 1 is removed. This is essentially a matrix-vector product.
-     *   This returns a ReshapeVertex.
+     * After matrix multiplication, the appended 1 is removed. This is essentially a matrix-vector product.
+     * This returns a ReshapeVertex.
      * - Otherwise, they are multiplied like conventional matrices.
-     *   This returns a MatrixMultiplicationVertex.
+     * This returns a MatrixMultiplicationVertex.
      */
     public DoubleVertex matrixMultiply(DoubleVertex that) {
         int leftRank = this.getRank();
@@ -270,6 +270,10 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return new PermuteVertex(this, rearrange);
     }
 
+    public PermuteVertex transpose() {
+        return new PermuteVertex(this, 1, 0);
+    }
+
     public DoubleUnaryOpLambda<DoubleTensor> lambda(long[] outputShape, Function<DoubleTensor, DoubleTensor> op,
                                                     Function<Map<Vertex, PartialDerivative>, PartialDerivative> forwardModeAutoDiffLambda,
                                                     Function<PartialDerivative, Map<Vertex, PartialDerivative>> reverseModeAutoDiffLambda) {
@@ -317,7 +321,9 @@ public abstract class DoubleVertex extends Vertex<DoubleTensor> implements Doubl
         return new EqualsVertex<>(this, rhs);
     }
 
-    public IntegerVertex toInteger() { return new CastToIntegerVertex(this); }
+    public IntegerVertex toInteger() {
+        return new CastToIntegerVertex(this);
+    }
 
     public <T extends Tensor> BooleanVertex notEqualTo(Vertex<T> rhs) {
         return new NotEqualsVertex<>(this, rhs);

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/ConstantDoubleVertex.java
@@ -29,8 +29,8 @@ public class ConstantDoubleVertex extends DoubleVertex implements Differentiable
         this(DoubleTensor.scalar(constant));
     }
 
-    public ConstantDoubleVertex(double[] vector) {
-        this(DoubleTensor.create(vector));
+    public ConstantDoubleVertex(double... vector) {
+        this(DoubleTensor.vector(vector));
     }
 
     public ConstantDoubleVertex(double[] data, long[] shape) {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffBroadcast.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffBroadcast.java
@@ -28,7 +28,9 @@ public class AutoDiffBroadcast {
 
             DoubleTensor correctedPartial = DoubleTensor
                 .zeros(resultShape)
-                .plusInPlace(partial.get().reshape(upRankedPartialShape));
+                .plusInPlace(
+                    partial.get().reshape(upRankedPartialShape)
+                );
 
             return new PartialDerivative(correctedPartial);
         } else {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffBroadcast.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/diff/AutoDiffBroadcast.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static io.improbable.keanu.tensor.TensorShape.shapeToDesiredRankByPrependingOnes;
+
 /**
  * This class is meant to help with auto diff in operations that support implicit broadcasting. E.g. In
  * addition/subtraction/multiplication/division scalar operands can be operated with non-scalar operands.
@@ -21,9 +23,12 @@ public class AutoDiffBroadcast {
         if (shouldCorrectPartialForBroadcast(partial, partialOfShape, targetOfShape)) {
 
             long[] wrtShape = partial.getWrtShape(partialOfShape);
+            long[] resultShape = TensorShape.concat(targetOfShape, wrtShape);
+            long[] upRankedPartialShape = shapeToDesiredRankByPrependingOnes(partial.get().getShape(), resultShape.length);
+
             DoubleTensor correctedPartial = DoubleTensor
-                .zeros(TensorShape.concat(targetOfShape, wrtShape))
-                .plus(partial.get());
+                .zeros(resultShape)
+                .plusInPlace(partial.get().reshape(upRankedPartialShape));
 
             return new PartialDerivative(correctedPartial);
         } else {

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertex.java
@@ -8,9 +8,10 @@ import io.improbable.keanu.vertices.dbl.Differentiable;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialDerivative;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import static io.improbable.keanu.tensor.TensorShapeValidation.getMatrixMultiplicationResultingShape;
 
 public class MatrixMultiplicationVertex extends DoubleBinaryOpVertex implements Differentiable {
     /**
@@ -23,7 +24,7 @@ public class MatrixMultiplicationVertex extends DoubleBinaryOpVertex implements 
     @ExportVertexToPythonBindings
     public MatrixMultiplicationVertex(@LoadVertexParam(LEFT_NAME) DoubleVertex left,
                                       @LoadVertexParam(RIGHT_NAME) DoubleVertex right) {
-        super(getResultingShape(left.getShape(), right.getShape()),
+        super(getMatrixMultiplicationResultingShape(left.getShape(), right.getShape()),
             left, right);
     }
 
@@ -75,17 +76,5 @@ public class MatrixMultiplicationVertex extends DoubleBinaryOpVertex implements 
         );
 
         return partialsFromLeft.add(partialsFromRight);
-    }
-
-    private static long[] getResultingShape(long[] left, long[] right) {
-        if (left.length != 2 || right.length != 2) {
-            throw new IllegalArgumentException("Matrix multiply must be used on matrices");
-        }
-
-        if (left[1] != right[0]) {
-            throw new IllegalArgumentException("Can not multiply matrices of shapes " + Arrays.toString(left) + " X " + Arrays.toString(right));
-        }
-
-        return new long[]{left[0], right[1]};
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -72,7 +72,7 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Differen
     }
 
     public MultivariateGaussianVertex(double mu, double covariance) {
-        this(oneByOneMatrix(mu), oneByOneMatrix(covariance));
+        this(new ConstantDoubleVertex(new double[]{mu}), oneByOneMatrix(covariance));
     }
 
     private static DoubleVertex oneByOneMatrix(double value) {
@@ -122,16 +122,23 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Differen
     }
 
     private static long[] checkValidMultivariateShape(long[] muShape, long[] covarianceShape) {
-        if (covarianceShape.length != 2 || muShape.length != 2) {
-            throw new IllegalArgumentException(String.format("Ranks of mu and covariance must be 2. Given: %d, %d", muShape.length, covarianceShape.length));
-        } else if (covarianceShape[0] != covarianceShape[1]) {
-            throw new IllegalArgumentException(String.format("Dimensions 0 and 1 of covariance must equal. Given: %s", Arrays.toString(covarianceShape)));
-        } else if (muShape[1] != 1) {
-            throw new IllegalArgumentException(String.format("Dimension 1 of mu must equal 1. Given: %d", muShape[1]));
-        } else if (muShape[0] != covarianceShape[0]) {
-            throw new IllegalArgumentException(String.format("Dimension 0 of mu must equal dimension 0 of covariance. Given: %s, %s", muShape[0], covarianceShape[0]));
-        } else {
-            return muShape;
+
+        if (covarianceShape.length != 2) {
+            throw new IllegalArgumentException("Covariance must be matrix");
         }
+
+        if (muShape.length != 1) {
+            throw new IllegalArgumentException("Mu must be vector");
+        }
+
+        if (covarianceShape[0] != covarianceShape[1]) {
+            throw new IllegalArgumentException("Covariance matrix must be square. Given shape: " + Arrays.toString(covarianceShape));
+        }
+
+        if (muShape[0] != covarianceShape[0]) {
+            throw new IllegalArgumentException("Dimension 0 of mu must equal dimension 0 of covariance. Given: " + muShape[0] + "," + covarianceShape[0]);
+        }
+
+        return muShape;
     }
 }

--- a/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianVertex.java
@@ -72,7 +72,7 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Differen
     }
 
     public MultivariateGaussianVertex(double mu, double covariance) {
-        this(new ConstantDoubleVertex(new double[]{mu}), oneByOneMatrix(covariance));
+        this(new ConstantDoubleVertex(DoubleTensor.vector(mu)), oneByOneMatrix(covariance));
     }
 
     private static DoubleVertex oneByOneMatrix(double value) {
@@ -124,11 +124,11 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Differen
     private static long[] checkValidMultivariateShape(long[] muShape, long[] covarianceShape) {
 
         if (covarianceShape.length != 2) {
-            throw new IllegalArgumentException("Covariance must be matrix");
+            throw new IllegalArgumentException("Covariance must be matrix but was rank " + covarianceShape.length);
         }
 
         if (muShape.length != 1) {
-            throw new IllegalArgumentException("Mu must be vector");
+            throw new IllegalArgumentException("Mu must be vector but was rank " + muShape.length);
         }
 
         if (covarianceShape[0] != covarianceShape[1]) {
@@ -136,7 +136,7 @@ public class MultivariateGaussianVertex extends DoubleVertex implements Differen
         }
 
         if (muShape[0] != covarianceShape[0]) {
-            throw new IllegalArgumentException("Dimension 0 of mu must equal dimension 0 of covariance. Given: " + muShape[0] + "," + covarianceShape[0]);
+            throw new IllegalArgumentException("Dimension 0 of mu must equal dimension 0 of covariance. Given: mu " + muShape[0] + ", covariance " + covarianceShape[0]);
         }
 
         return muShape;

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
@@ -229,4 +229,29 @@ public class ScalarDoubleTensorTest {
         DoubleTensor value = DoubleTensor.create(new double[]{1}, 1, 1, 1);
         assertEquals(3, value.lessThanOrEqual(2).getRank());
     }
+
+    @Test
+    public void doesMatrixMultiplyWhenRank2() {
+        DoubleTensor lengthOne = new ScalarDoubleTensor(2).reshape(1, 1);
+        DoubleTensor matrix = DoubleTensor.create(1, 2, 3, 4).reshape(2, 2);
+        DoubleTensor result = lengthOne.matrixMultiply(matrix);
+        DoubleTensor expected = DoubleTensor.create(2, 4, 6, 8).reshape(2, 2);
+        assertEquals(expected, result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesThrowOnMatrixMultiplyWhenRank0() {
+        DoubleTensor lengthOne = new ScalarDoubleTensor(2);
+        DoubleTensor matrix = DoubleTensor.create(1, 2, 3, 4).reshape(2, 2);
+        lengthOne.matrixMultiply(matrix);
+    }
+
+    @Test
+    public void doesTensorMultiply() {
+        DoubleTensor lengthOne = new ScalarDoubleTensor(2).reshape(1);
+        DoubleTensor matrix = DoubleTensor.arange(0, 4).reshape(2, 1, 2);
+        DoubleTensor result = lengthOne.tensorMultiply(matrix, new int[]{0}, new int[]{1});
+        DoubleTensor expected = DoubleTensor.create(0, 2, 4, 6).reshape(2, 2);
+        assertEquals(expected, result);
+    }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/tensor/dbl/ScalarDoubleTensorTest.java
@@ -233,14 +233,17 @@ public class ScalarDoubleTensorTest {
     @Test
     public void doesMatrixMultiplyWhenRank2() {
         DoubleTensor lengthOne = new ScalarDoubleTensor(2).reshape(1, 1);
-        DoubleTensor matrix = DoubleTensor.create(1, 2, 3, 4).reshape(2, 2);
+        DoubleTensor matrix = DoubleTensor.create(3, 4).reshape(1, 2);
         DoubleTensor result = lengthOne.matrixMultiply(matrix);
-        DoubleTensor expected = DoubleTensor.create(2, 4, 6, 8).reshape(2, 2);
+        DoubleTensor expected = DoubleTensor.create(6, 8).reshape(1, 2);
         assertEquals(expected, result);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void doesThrowOnMatrixMultiplyWhenRank0() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Matrix multiply must be used on matrices");
+
         DoubleTensor lengthOne = new ScalarDoubleTensor(2);
         DoubleTensor matrix = DoubleTensor.create(1, 2, 3, 4).reshape(2, 2);
         lengthOne.matrixMultiply(matrix);
@@ -253,5 +256,19 @@ public class ScalarDoubleTensorTest {
         DoubleTensor result = lengthOne.tensorMultiply(matrix, new int[]{0}, new int[]{1});
         DoubleTensor expected = DoubleTensor.create(0, 2, 4, 6).reshape(2, 2);
         assertEquals(expected, result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesThrowOnInvalidLeftDimsTensorMultiply() {
+        DoubleTensor lengthOne = new ScalarDoubleTensor(2);
+        DoubleTensor matrix = DoubleTensor.arange(0, 4).reshape(2, 1, 2);
+        lengthOne.tensorMultiply(matrix, new int[]{0}, new int[]{1});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesThrowOnInvalidRightDimsTensorMultiply() {
+        DoubleTensor lengthOne = new ScalarDoubleTensor(2).reshape(1);
+        DoubleTensor matrix = DoubleTensor.arange(0, 4).reshape(2, 1, 2);
+        lengthOne.tensorMultiply(matrix, new int[]{0}, new int[]{3});
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/util/io/JsonTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/util/io/JsonTest.java
@@ -60,7 +60,7 @@ public class JsonTest {
         gaussianVertex.setLabel("GaussianVertex");
         net = new BayesianNetwork(gaussianVertex.getConnectedGraph());
 
-        someMetadata = ImmutableMap.of( "Author", "Some Author", "Tag", "MyBayesNet" );
+        someMetadata = ImmutableMap.of("Author", "Some Author", "Tag", "MyBayesNet");
         JsonSaver jsonSaver = new JsonSaver(net);
         jsonSaver.save(outputStream, true, someMetadata);
     }
@@ -100,11 +100,12 @@ public class JsonTest {
         assertEquals(net.getLatentVertices().size(), loadedNetwork.getLatentVertices().size());
         assertEquals(net.getObservedVertices().size(), loadedNetwork.getObservedVertices().size());
         assertThat(net.getObservedVertices().get(0), instanceOf(GaussianVertex.class));
-        GaussianVertex gaussianVertex = (GaussianVertex)loadedNetwork.getObservedVertices().get(0);
+        GaussianVertex gaussianVertex = (GaussianVertex) loadedNetwork.getObservedVertices().get(0);
         assertThat(gaussianVertex.getMu().getValue().scalar(), closeTo(0.0, 1e-10));
         assertThat(gaussianVertex.getSigma().getValue(0), closeTo(3.0, 1e-10));
         assertThat(gaussianVertex.getSigma().getValue(1), closeTo(4.0, 1e-10));
-        assertThat(gaussianVertex.getValue().scalar(), closeTo(1.0, 1e-10));
+        assertThat(gaussianVertex.getValue().getValue(0), closeTo(1.0, 1e-10));
+        assertThat(gaussianVertex.getValue().getValue(1), closeTo(1.0, 1e-10));
     }
 
     @Test

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -285,4 +285,20 @@ public class MatrixMultiplicationVertexTest {
         finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB), outputVertex, INCREMENT, DELTA);
     }
 
+    @Test
+    public void changesMatchGradientWhenResultIsLengthOne() {
+        UniformVertex inputA = new UniformVertex(new long[]{1, 2}, -10.0, 10.0);
+        UniformVertex inputB = new UniformVertex(new long[]{2, 1}, -10.0, 10.0);
+        MatrixMultiplicationVertex mmultVertex = (MatrixMultiplicationVertex)inputA.matrixMultiply(inputB);
+
+//        MultiplicationVertex outputVertex = mmultVertex.times(
+//            new ConstantDoubleVertex(new double[]{1., 2., 3., 4., 5., 6., 7., 8.}, new long[]{2, 2, 2})
+//        );
+
+        final double INCREMENT = 10;
+        final double DELTA = 1e-10;
+
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB), mmultVertex, INCREMENT, DELTA);
+    }
+
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/nonprobabilistic/operators/binary/MatrixMultiplicationVertexTest.java
@@ -291,14 +291,14 @@ public class MatrixMultiplicationVertexTest {
         UniformVertex inputB = new UniformVertex(new long[]{2, 1}, -10.0, 10.0);
         MatrixMultiplicationVertex mmultVertex = (MatrixMultiplicationVertex)inputA.matrixMultiply(inputB);
 
-//        MultiplicationVertex outputVertex = mmultVertex.times(
-//            new ConstantDoubleVertex(new double[]{1., 2., 3., 4., 5., 6., 7., 8.}, new long[]{2, 2, 2})
-//        );
+        MultiplicationVertex outputVertex = mmultVertex.times(
+            new ConstantDoubleVertex(new double[]{1., 2., 3., 4., 5., 6., 7., 8.}, new long[]{2, 2, 2})
+        );
 
         final double INCREMENT = 10;
         final double DELTA = 1e-10;
 
-        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB), mmultVertex, INCREMENT, DELTA);
+        finiteDifferenceMatchesForwardAndReverseModeGradient(ImmutableList.of(inputA, inputB), outputVertex, INCREMENT, DELTA);
     }
 
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianTest.java
@@ -52,6 +52,17 @@ public class MultivariateGaussianTest {
     }
 
     @Test
+    public void throwsIfMuIsNotRank1() {
+        DoubleVertex mu = new ConstantDoubleVertex(new double[] {0.}, new long[] {1, 1});
+        DoubleVertex covariance = new ConstantDoubleVertex(new double[] {1.}, new long[] {1, 1});
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Mu must be vector but was rank 2");
+
+        new MultivariateGaussianVertex(mu, covariance);
+    }
+
+    @Test
     public void throwsIfCovarianceIsNotRank2() {
         DoubleVertex mu = new ConstantDoubleVertex(new double[]{0.}, new long[]{1});
         DoubleVertex covariance = new ConstantDoubleVertex(new double[]{1.}, new long[]{1});

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianTest.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/MultivariateGaussianTest.java
@@ -4,14 +4,19 @@ import io.improbable.keanu.DeterministicRule;
 import io.improbable.keanu.KeanuRandom;
 import io.improbable.keanu.distributions.ContinuousDistribution;
 import io.improbable.keanu.distributions.continuous.MultivariateGaussian;
+import io.improbable.keanu.network.BayesianNetwork;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import io.improbable.keanu.testcategory.Slow;
 import io.improbable.keanu.vertices.ConstantVertex;
 import io.improbable.keanu.vertices.LogProbGraph;
 import io.improbable.keanu.vertices.LogProbGraphContract;
 import io.improbable.keanu.vertices.LogProbGraphValueFeeder;
+import io.improbable.keanu.vertices.VertexId;
+import io.improbable.keanu.vertices.dbl.Differentiator;
 import io.improbable.keanu.vertices.dbl.DoubleVertex;
 import io.improbable.keanu.vertices.dbl.nonprobabilistic.ConstantDoubleVertex;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.LogProbGradientCalculator;
+import io.improbable.keanu.vertices.dbl.nonprobabilistic.diff.PartialsOf;
 import org.apache.commons.math3.distribution.NormalDistribution;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,8 +24,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
+import java.util.HashSet;
+import java.util.Map;
+
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.sampleMethodMatchesLogProbMethodMultiVariate;
 import static io.improbable.keanu.vertices.dbl.probabilistic.ProbabilisticDoubleTensorContract.sampleUnivariateMethodMatchesLogProbMethod;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 
@@ -52,56 +61,31 @@ public class MultivariateGaussianTest {
     }
 
     @Test
-    public void throwsIfMuIsNotRank2() {
-        DoubleVertex mu = new ConstantDoubleVertex(new double[] {0.}, new long[] {1});
-        DoubleVertex covariance = new ConstantDoubleVertex(new double[] {1.}, new long[] {1, 1});
-
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Ranks of mu and covariance must be 2. Given: 1, 2");
-
-        new MultivariateGaussianVertex(mu, covariance);
-    }
-
-    @Test
     public void throwsIfCovarianceIsNotRank2() {
-        DoubleVertex mu = new ConstantDoubleVertex(new double[] {0.}, new long[] {1, 1});
-        DoubleVertex covariance = new ConstantDoubleVertex(new double[] {1.}, new long[] {1});
+        DoubleVertex mu = new ConstantDoubleVertex(new double[]{0.}, new long[]{1});
+        DoubleVertex covariance = new ConstantDoubleVertex(new double[]{1.}, new long[]{1});
 
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Ranks of mu and covariance must be 2. Given: 2, 1");
 
         new MultivariateGaussianVertex(mu, covariance);
     }
 
     @Test
     public void throwsIfCovarianceFirstDimensionNotEqualToSecond() {
-        DoubleVertex mu = new ConstantDoubleVertex(new double[] {0.}, new long[] {1, 1});
-        DoubleVertex covariance = new ConstantDoubleVertex(new double[] {1., 1.}, new long[] {2, 1});
+        DoubleVertex mu = new ConstantDoubleVertex(new double[]{0.}, new long[]{1, 1});
+        DoubleVertex covariance = new ConstantDoubleVertex(new double[]{1., 1.}, new long[]{2, 1});
 
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Dimensions 0 and 1 of covariance must equal. Given: [2, 1]");
-
-        new MultivariateGaussianVertex(mu, covariance);
-    }
-
-    @Test
-    public void throwsIfFirstDimensionOfMuIsNot1() {
-        DoubleVertex mu = new ConstantDoubleVertex(new double[] {0., 0.}, new long[] {1, 2});
-        DoubleVertex covariance = new ConstantDoubleVertex(new double[] {1.}, new long[] {1, 1});
-
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Dimension 1 of mu must equal 1. Given: 2");
 
         new MultivariateGaussianVertex(mu, covariance);
     }
 
     @Test
     public void throwsIfFirstDimensionOfMuIsNotEqualToFirstDimensionOfCovariance() {
-        DoubleVertex mu = new ConstantDoubleVertex(new double[] {0., 0.}, new long[] {2, 1});
-        DoubleVertex covariance = new ConstantDoubleVertex(new double[] {1.}, new long[] {1, 1});
+        DoubleVertex mu = new ConstantDoubleVertex(new double[]{0., 0.}, new long[]{2});
+        DoubleVertex covariance = new ConstantDoubleVertex(new double[]{1.}, new long[]{1, 1});
 
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Dimension 0 of mu must equal dimension 0 of covariance. Given: 2, 1");
 
         new MultivariateGaussianVertex(mu, covariance);
     }
@@ -133,7 +117,7 @@ public class MultivariateGaussianTest {
 
     @Test
     public void bivariateGaussianLogProbMatchesLogDensityOfVector() {
-        DoubleVertex mu = ConstantVertex.of(new double[]{2, 3}, 2, 1);
+        DoubleVertex mu = ConstantVertex.of(new double[]{2, 3});
 
         MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, 1);
 
@@ -141,21 +125,21 @@ public class MultivariateGaussianTest {
         double expectedDensity2 = new NormalDistribution(3, 1).logDensity(10);
         double expectedDensity = expectedDensity1 + expectedDensity2;
 
-        double density = mvg.logPdf(DoubleTensor.create(new double[]{8, 10}, 2, 1));
+        double density = mvg.logPdf(DoubleTensor.create(new double[]{8, 10}, 2));
 
         assertEquals(expectedDensity, density, 0.0001);
     }
 
     @Test
     public void bivariateGaussianLogProbGraphMatchesLogDensityOfVector() {
-        DoubleVertex mu = ConstantVertex.of(new double[]{2, 3}, 2, 1);
+        DoubleVertex mu = ConstantVertex.of(new double[]{2, 3});
         MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, 1.);
         DoubleVertex covariance = mvg.getCovariance();
         LogProbGraph logProbGraph = mvg.logProbGraph();
 
         LogProbGraphValueFeeder.feedValue(logProbGraph, mu, mu.getValue());
         LogProbGraphValueFeeder.feedValue(logProbGraph, covariance, covariance.getValue());
-        LogProbGraphValueFeeder.feedValue(logProbGraph, mvg, DoubleTensor.create(new double[] {8., 10.}, 2, 1));
+        LogProbGraphValueFeeder.feedValue(logProbGraph, mvg, DoubleTensor.create(new double[]{8., 10.}, 2));
 
         double expectedDensity1 = new NormalDistribution(2, 1).logDensity(8);
         double expectedDensity2 = new NormalDistribution(3, 1).logDensity(10);
@@ -166,11 +150,11 @@ public class MultivariateGaussianTest {
 
     @Test
     public void bivariateGaussianLogProbMatchesLogDensityOfScipy() {
-        DoubleVertex mu = ConstantVertex.of(new double[]{1, 2}, 2, 1);
+        DoubleVertex mu = ConstantVertex.of(new double[]{1, 2});
         DoubleVertex covarianceMatrix = ConstantVertex.of(new double[]{1, 0.3, 0.3, 0.6}, 2, 2);
 
         MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, covarianceMatrix);
-        double density = mvg.logPdf(DoubleTensor.create(new double[]{0.5, 0.4}, 2, 1));
+        double density = mvg.logPdf(DoubleTensor.create(new double[]{0.5, 0.4}, 2));
         double expected = -3.6874792995813834;
 
         assertEquals(expected, density, 0.001);
@@ -178,14 +162,14 @@ public class MultivariateGaussianTest {
 
     @Test
     public void bivariateGaussianLogProbGraphMatchesLogDensityOfScipy() {
-        DoubleVertex mu = ConstantVertex.of(new double[]{1, 2}, 2, 1);
+        DoubleVertex mu = ConstantVertex.of(new double[]{1, 2});
         DoubleVertex covarianceMatrix = ConstantVertex.of(new double[]{1, 0.3, 0.3, 0.6}, 2, 2);
         MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, covarianceMatrix);
         LogProbGraph logProbGraph = mvg.logProbGraph();
 
         LogProbGraphValueFeeder.feedValue(logProbGraph, mu, mu.getValue());
         LogProbGraphValueFeeder.feedValue(logProbGraph, covarianceMatrix, covarianceMatrix.getValue());
-        LogProbGraphValueFeeder.feedValue(logProbGraph, mvg, DoubleTensor.create(new double[] {0.5, 0.4}, 2, 1));
+        LogProbGraphValueFeeder.feedValue(logProbGraph, mvg, DoubleTensor.create(new double[]{0.5, 0.4}, 2));
 
         double expected = -3.6874792995813834;
         LogProbGraphContract.matchesKnownLogDensity(logProbGraph, expected);
@@ -193,7 +177,7 @@ public class MultivariateGaussianTest {
 
     @Test
     public void multivariateGaussianLogProbMatchesLogDensityOfScipy() {
-        DoubleVertex mu = ConstantVertex.of(new double[]{1, 2, 3}, 3, 1);
+        DoubleVertex mu = ConstantVertex.of(new double[]{1, 2, 3});
 
         DoubleVertex covarianceMatrix = ConstantVertex.of(
             new double[]{
@@ -204,7 +188,7 @@ public class MultivariateGaussianTest {
             3, 3);
 
         MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, covarianceMatrix);
-        double density = mvg.logPdf(DoubleTensor.create(new double[]{0.2, 0.3, 0.4}, 3, 1));
+        double density = mvg.logPdf(DoubleTensor.create(new double[]{0.2, 0.3, 0.4}, 3));
         double expected = -8.155504532016181;
 
         assertEquals(expected, density, 0.001);
@@ -212,7 +196,7 @@ public class MultivariateGaussianTest {
 
     @Test
     public void multivariateGaussianLogProbGraphMatchesLogDensityOfScipy() {
-        DoubleVertex mu = ConstantVertex.of(new double[]{1, 2, 3}, 3, 1);
+        DoubleVertex mu = ConstantVertex.of(new double[]{1, 2, 3}, 3);
 
         DoubleVertex covarianceMatrix = ConstantVertex.of(
             new double[]{
@@ -227,7 +211,7 @@ public class MultivariateGaussianTest {
 
         LogProbGraphValueFeeder.feedValue(logProbGraph, mu, mu.getValue());
         LogProbGraphValueFeeder.feedValue(logProbGraph, covarianceMatrix, covarianceMatrix.getValue());
-        LogProbGraphValueFeeder.feedValue(logProbGraph, mvg, DoubleTensor.create(new double[] {0.2, 0.3, 0.4}, 3, 1));
+        LogProbGraphValueFeeder.feedValue(logProbGraph, mvg, DoubleTensor.create(new double[]{0.2, 0.3, 0.4}, 3));
 
         double expected = -8.155504532016181;
 
@@ -237,7 +221,7 @@ public class MultivariateGaussianTest {
     @Category(Slow.class)
     @Test
     public void gaussianSampleMethodMatchesLogProbMethod() {
-        DoubleVertex mu = ConstantVertex.of(new double[]{0, 0}, 2, 1);
+        DoubleVertex mu = ConstantVertex.of(new double[]{0, 0}, 2);
 
         MultivariateGaussianVertex mvg = new MultivariateGaussianVertex(mu, 1);
 
@@ -255,5 +239,37 @@ public class MultivariateGaussianTest {
 
         ContinuousDistribution mvg = MultivariateGaussian.withParameters(mu, sigma);
         mvg.sample(new long[]{2, 2}, KeanuRandom.getDefaultRandom());
+    }
+
+    @Test
+    public void autoDiffOfLogProbGraphEqualsDlogProb() {
+        DoubleVertex mu = ConstantVertex.of(DoubleTensor.create(1, 2));
+        ConstantDoubleVertex cov = ConstantVertex.of(DoubleTensor.create(1, 0, 0, 2).reshape(2, 2));
+        MultivariateGaussianVertex A = new MultivariateGaussianVertex(mu, cov);
+        A.setValue(DoubleTensor.create(1, 3));
+
+        BayesianNetwork bayesianNetwork = new BayesianNetwork(A.getConnectedGraph());
+        LogProbGradientCalculator logProbGradientCalculator = new LogProbGradientCalculator(
+            bayesianNetwork.getContinuousLatentVertices(),
+            bayesianNetwork.getContinuousLatentVertices()
+        );
+
+        LogProbGraph logProbGraph = A.logProbGraph();
+
+        logProbGraph.getInput(A).setValue(A.getValue());
+        logProbGraph.getInput(mu).setValue(mu.getValue());
+        logProbGraph.getInput(cov).setValue(cov.getValue());
+
+        PartialsOf partialsOf = Differentiator.reverseModeAutoDiff(
+            logProbGraph.getLogProbOutput(),
+            new HashSet<>(logProbGraph.getInputs().values())
+        );
+
+        DoubleTensor expected = partialsOf.withRespectTo(A);
+
+        Map<VertexId, DoubleTensor> gradient = logProbGradientCalculator.getJointLogProbGradientWrtLatents();
+        DoubleTensor actual = gradient.get(A.getId());
+
+        assertArrayEquals(expected.asFlatDoubleArray(), actual.asFlatDoubleArray(), 1e-8);
     }
 }

--- a/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
+++ b/keanu-project/src/test/java/io/improbable/keanu/vertices/dbl/probabilistic/ProbabilisticDoubleTensorContract.java
@@ -327,7 +327,7 @@ public class ProbabilisticDoubleTensorContract {
             }
         }
 
-        long[] shape = isVector ? new long[]{1, 2} : new long[]{2, 1};
+        long[] shape = new long[]{2};
 
         for (Map.Entry<Pair<Double, Double>, Long> entry : sampleBucket.entrySet()) {
             double percentage = (double) entry.getValue() / sampleCount;

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 ### Common
 
 * `DoubleVertex#matrixMultiply` now performs dot product when given two vectors, and matrix-vector product when given a matrix and a vector.
+* `MultivariateGaussianVertex` now requires that mu is a vector instead of a matrix.
 
 ### Python
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,8 @@
 
 * `DoubleVertex#matrixMultiply` now performs dot product when given two vectors, and matrix-vector product when given a matrix and a vector.
 * `MultivariateGaussianVertex` now requires that mu is a vector instead of a matrix.
+* `DoubleTensor.scalar` will throw an exception if the DoubleTensor is not actually a scalar. Please use .getValue(0) if you just
+want the first element in a DoubleTensor.
 
 ### Python
 


### PR DESCRIPTION
This PR:

- The multivariate gaussian mu is a vector now. Doesn't need to be a matrix and in fact shouldn't be.
- Cleaned up the multivariate gaussian log prob graph to allow transpose() and remove the unnecessary slice.
- The ScalarDoubleTensor was not doing tensor multiply. This has been implemented and is needed for when the result of a matrix multiply is a (1,1)
- Forward mode auto-diff correct for broadcasting didn't work with (1,1) -> (2,2,2). This now works. 