### PR TITLE
Update BK platform/linux/builder queue to HEAD for updates rollup

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -20,13 +20,15 @@ linux: &linux
     - "capable_of_building=graphos-eng"
     - "environment=production"
     - "permission_set=builder"
-    - "queue=${CI_LINUX_BUILDER_QUEUE:-v2-1550668667-a9410887d4b815dd-------z}"
+    - "platform=linux"
+    - "queue=${CI_LINUX_BUILDER_QUEUE:-v2-1552399688-f84f3666421d190b-------z}"
 
 windows: &windows
   agents:
     - "capable_of_building=graphos-eng"
     - "environment=production"
     - "permission_set=builder"
+    - "platform=windows"
     - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v2-1550748015-b6a7d7f9ae5dbf04-------z}"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.


### PR DESCRIPTION
Bakery run: https://buildkite.com/improbable/platform-bakery/builds/654#8c35cb0c-73b8-42aa-9193-192562c61f5c

Changes within packer/improbable.io/buildkite:
----------------------

* Update imp-tool-bootstrap version to the one that includes `subscribe --tools`. (improbable/platform#8932)
* Update imp-tool bootstrap version to 20190311.101729.57b4634585. (improbable/platform#8903)
* Update imp-tool-bootstrap version in platform.git docs. (improbable/platform#8854)
* Eng fix buildkite ansible (improbable/platform#8852)
* Add more quotes and fix the one-shot service installation (improbable/platform#8846)
* Tweaks to fix the local-ssd mount script in some cases. (improbable/platform#8843)
* Upgrade to golang 1.11.5 from 1.10.something (improbable/platform#8671)
* fixing staleness, works on macstadium (improbable/platform#8770)
* Update unreal agents to latest toolbelt version (improbable/platform#8738)
* ENG-1296: Adjust buildkite-agent process management to use --spawn (improbable/platform#8630)
* Make build-cloud able to deploy terraform without a human present. (improbable/platform#8729)
* Fix goss test. (improbable/platform#8730)
* Fix environment hook on Windows (improbable/platform#8720)
* Fix baking with a local SSD (improbable/platform#8680)
* Fix trigger-pipelines queue with if, not elif (improbable/platform#8677)
* ENG-1259: Fix missing var (improbable/platform#8674)
* ENG-1259: Add Linux support for local SSDs (improbable/platform#8534)
* BK drive-by: latest agent version (improbable/platform#8628)
* ENG-1275: Link to a new CI Health dashboard (improbable/platform#8605)
* ENG-1287: Add an isolated temp dir in the BuildKite agent environment hook (improbable/platform#8568)
* BK git: dammit. (improbable/platform#8626)
* BK driveby - new git. (improbable/platform#8624)
* Update imp-tool-bootstrap version. (improbable/platform#8588)
* set folder to staff (improbable/platform#8422)
* dont sleep and brew install vault (improbable/platform#8533)

Changes within go/src/improbable.io/cmd/imp-ci:
----------------------

* ENG-1281: imp-ci steps upload --from <paths/globs> (improbable/platform#8902)
* Expand ownership to EV team (improbable/platform#8905)
* FYS: improve logging in BK wrapper (improbable/platform#8885)
* ENG-1296: Reflect agent-count into the labels for scaler (improbable/platform#8741)
* COMP-549 Set up the sim node bake pipeline (improbable/platform#8433)
* ENG-1274: time BK step durations for later analysis (improbable/platform#8580)
* ENG-1275: Link to a new CI Health dashboard (improbable/platform#8605)

Changes within go/src/improbable.io/cmd/imp-vault:
----------------------

No changes in go/src/improbable.io/cmd/imp-vault