### PR TITLE
Expose SequenceItem contents

### DIFF
--- a/keanu-project/src/main/java/io/improbable/keanu/templating/SequenceItem.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/templating/SequenceItem.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableMap.copyOf;
+
 public class SequenceItem implements VertexDictionary {
 
     private static final String NAME_PREFIX = "Sequence_Item_";
@@ -61,7 +63,7 @@ public class SequenceItem implements VertexDictionary {
      * added to this sequence item.
      */
     public Map<VertexLabel, Vertex<?>> getContents() {
-        return this.contents;
+        return copyOf(this.contents);
     }
 
     private String getUniqueName() {

--- a/keanu-project/src/main/java/io/improbable/keanu/templating/SequenceItem.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/templating/SequenceItem.java
@@ -56,6 +56,14 @@ public class SequenceItem implements VertexDictionary {
         return v;
     }
 
+    /**
+     * @return Returns a map of vertex labels to vertices, which covers all of the vertices that have been explicitly
+     * added to this sequence item.
+     */
+    public Map<VertexLabel, Vertex<?>> getContents() {
+        return this.contents;
+    }
+
     private String getUniqueName() {
         return NAME_PREFIX + this.hashCode();
     }

--- a/keanu-python/keanu/sequence.py
+++ b/keanu-python/keanu/sequence.py
@@ -31,6 +31,9 @@ class SequenceItem(JavaObjectWrapper):
     def get(self, label: str) -> Vertex:
         return Vertex._from_java_vertex(self.unwrap().get(_VertexLabel(label).unwrap()))
 
+    def get_contents(self) -> Dict[str, Vertex]:
+        return self.unwrap().getContents()
+
 
 class Sequence(JavaObjectWrapper):
     """

--- a/keanu-python/keanu/sequence.py
+++ b/keanu-python/keanu/sequence.py
@@ -32,12 +32,16 @@ class SequenceItem(JavaObjectWrapper):
         return Vertex._from_java_vertex(self.unwrap().get(_VertexLabel(label).unwrap()))
 
     def get_contents(self) -> Dict[str, Vertex]:
+
         def get_unqualified_name_or_proxy_name(key, vertex) -> str:
             if is_instance_of(k._gateway, vertex, "io.improbable.keanu.vertices.ProxyVertex"):
                 return "proxy_for." + key.getUnqualifiedName()
             return key.getUnqualifiedName()
 
-        return {get_unqualified_name_or_proxy_name(k, v): Vertex._from_java_vertex(v) for k, v in self.unwrap().getContents().items()}
+        return {
+            get_unqualified_name_or_proxy_name(k, v): Vertex._from_java_vertex(v)
+            for k, v in self.unwrap().getContents().items()
+        }
 
 
 class Sequence(JavaObjectWrapper):

--- a/keanu-python/keanu/sequence.py
+++ b/keanu-python/keanu/sequence.py
@@ -1,6 +1,6 @@
 from typing import Callable, Generator, Dict, Optional, Any, Iterator, Iterable, Union
 
-from py4j.java_gateway import java_import
+from py4j.java_gateway import java_import, is_instance_of
 from py4j.java_collections import ListConverter
 
 from functools import partial
@@ -32,7 +32,13 @@ class SequenceItem(JavaObjectWrapper):
         return Vertex._from_java_vertex(self.unwrap().get(_VertexLabel(label).unwrap()))
 
     def get_contents(self) -> Dict[str, Vertex]:
-        return {k.getUnqualifiedName(): Vertex._from_java_vertex(v) for k, v in self.unwrap().getContents().items()}
+        def get_unqualified_name_or_proxy_name(key, vertex):
+            if is_instance_of(k._gateway, vertex, "io.improbable.keanu.vertices.ProxyVertex"):
+                print("found a proxy")
+                return "proxy_for." + key.getUnqualifiedName()
+            return key.getUnqualifiedName()
+
+        return {get_unqualified_name_or_proxy_name(k, v): Vertex._from_java_vertex(v) for k, v in self.unwrap().getContents().items()}
 
 
 class Sequence(JavaObjectWrapper):

--- a/keanu-python/keanu/sequence.py
+++ b/keanu-python/keanu/sequence.py
@@ -32,9 +32,8 @@ class SequenceItem(JavaObjectWrapper):
         return Vertex._from_java_vertex(self.unwrap().get(_VertexLabel(label).unwrap()))
 
     def get_contents(self) -> Dict[str, Vertex]:
-        def get_unqualified_name_or_proxy_name(key, vertex):
+        def get_unqualified_name_or_proxy_name(key, vertex) -> str:
             if is_instance_of(k._gateway, vertex, "io.improbable.keanu.vertices.ProxyVertex"):
-                print("found a proxy")
                 return "proxy_for." + key.getUnqualifiedName()
             return key.getUnqualifiedName()
 

--- a/keanu-python/keanu/sequence.py
+++ b/keanu-python/keanu/sequence.py
@@ -32,7 +32,7 @@ class SequenceItem(JavaObjectWrapper):
         return Vertex._from_java_vertex(self.unwrap().get(_VertexLabel(label).unwrap()))
 
     def get_contents(self) -> Dict[str, Vertex]:
-        return self.unwrap().getContents()
+        return {k.getUnqualifiedName(): Vertex._from_java_vertex(v) for k, v in self.unwrap().getContents().items()}
 
 
 class Sequence(JavaObjectWrapper):
@@ -94,6 +94,9 @@ class Sequence(JavaObjectWrapper):
 
     def size(self) -> int:
         return self.unwrap().size()
+
+    def get_last_item(self) -> SequenceItem:
+        return SequenceItem(self.unwrap().getLastItem())
 
     @staticmethod
     def proxy_for(label: str) -> str:

--- a/keanu-python/tests/test_sequence.py
+++ b/keanu-python/tests/test_sequence.py
@@ -207,9 +207,7 @@ def test_last_item_retrieved_correctly() -> None:
         sequence_item.add(x)
 
     x_start = ConstantDouble(1.0)
-    initial_state = {
-      x_label: x_start
-    }
+    initial_state = {x_label: x_start}
 
     sequence = Sequence(count=2, factories=factory, initial_state=initial_state)
 

--- a/keanu-python/tests/test_sequence.py
+++ b/keanu-python/tests/test_sequence.py
@@ -195,7 +195,7 @@ def test_you_can_use_multiple_factories_to_build_sequences() -> None:
     __check_output_equals(sequence, x4_label, 0.125)
 
 
-def test_last_item_retrieved_correctly():
+def test_last_item_retrieved_correctly() -> None:
     x_label = "xx"
     x_input_label = Sequence.proxy_for(x_label)
 

--- a/keanu-python/tests/test_sequence.py
+++ b/keanu-python/tests/test_sequence.py
@@ -2,10 +2,8 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from keanu import BayesNet
-from keanu.network_io import DotSaver
 from keanu.sequence import Sequence, SequenceItem
-from keanu.vertex import Bernoulli, DoubleProxy, Exponential, Poisson, Const, KeanuContext, ConstantDouble, Vertex, \
+from keanu.vertex import Bernoulli, DoubleProxy, Exponential, Poisson, Const, ConstantDouble, \
     vertex_constructor_param_types
 from keanu.vertex.label import _VertexLabel
 
@@ -213,6 +211,9 @@ def test_last_item_retrieved_correctly() -> None:
 
     sequence_item_contents = sequence.get_last_item().get_contents()
     x_output = sequence_item_contents.get(x_label)
+    x_proxy = sequence_item_contents.get(Sequence.proxy_for(x_label))
 
     assert x_output is not None
+    assert x_proxy is not None
     assert x_output.get_value() == 4
+    assert x_proxy.get_value() == 2

--- a/keanu-python/tests/test_sequence.py
+++ b/keanu-python/tests/test_sequence.py
@@ -196,7 +196,7 @@ def test_you_can_use_multiple_factories_to_build_sequences() -> None:
 
 
 def test_last_item_retrieved_correctly() -> None:
-    x_label = "xx"
+    x_label = "x"
     x_input_label = Sequence.proxy_for(x_label)
 
     def factory(sequence_item):
@@ -213,5 +213,6 @@ def test_last_item_retrieved_correctly() -> None:
 
     sequence_item_contents = sequence.get_last_item().get_contents()
     x_output = sequence_item_contents.get(x_label)
+
     assert x_output is not None
     assert x_output.get_value() == 4

--- a/keanu-python/tests/test_sequence.py
+++ b/keanu-python/tests/test_sequence.py
@@ -207,10 +207,11 @@ def test_last_item_retrieved_correctly() -> None:
         sequence_item.add(x)
 
     x_start = ConstantDouble(1.0)
-    initial_state = {x_label: x_start}
+    initial_state: Optional[Dict[str, vertex_constructor_param_types]] = {x_label: x_start}
 
     sequence = Sequence(count=2, factories=factory, initial_state=initial_state)
 
     sequence_item_contents = sequence.get_last_item().get_contents()
     x_output = sequence_item_contents.get(x_label)
+    assert x_output is not None
     assert x_output.get_value() == 4


### PR DESCRIPTION
Exposes a `getContents()` method on `SequenceItem` which I have found useful for the purposes of debugging.
It allows a narrower view into the graph than `vertex.getConnectedGraph()` because it only shows vertices that have been explicitly added and only vertices from this sequence item.

This PR also adds the `get_last_item()` method to the python `Sequence` API to match the Java API