### PR TITLE
Fix/type of proxy vertices

### DIFF
--- a/keanu-python/keanu/vertex/base.py
+++ b/keanu-python/keanu/vertex/base.py
@@ -4,7 +4,7 @@ from typing import cast as typing_cast
 
 import numpy as np
 from py4j.java_collections import JavaList, JavaArray
-from py4j.java_gateway import JavaObject, JavaMember
+from py4j.java_gateway import JavaObject, JavaMember, is_instance_of
 
 import keanu as kn
 from keanu.base import JavaObjectWrapper
@@ -223,7 +223,16 @@ class Vertex(JavaObjectWrapper, SupportsRound['Vertex']):
 
     @staticmethod
     def _from_java_vertex(java_vertex: JavaObject) -> 'Vertex':
-        return Vertex(java_vertex, None)
+        ctor = Vertex
+
+        if is_instance_of(k._gateway, java_vertex, "io.improbable.keanu.vertices.dbl.DoubleVertex"):
+            ctor = Double
+        elif is_instance_of(k._gateway, java_vertex, "io.improbable.keanu.vertices.intgr.IntegerVertex"):
+            ctor = Integer
+        elif is_instance_of(k._gateway, java_vertex, "io.improbable.keanu.vertices.bool.BooleanVertex"):
+            ctor = Boolean
+
+        return ctor(java_vertex, None)
 
     @staticmethod
     def _to_generator(java_vertices: Union[JavaList, JavaArray]) -> Iterator['Vertex']:

--- a/keanu-python/tests/test_vertex.py
+++ b/keanu-python/tests/test_vertex.py
@@ -8,7 +8,7 @@ from py4j.java_gateway import JVMView
 from keanu import set_deterministic_state
 from keanu.context import KeanuContext
 from keanu.vartypes import tensor_arg_types, primitive_types, numpy_types, pandas_types
-from keanu.vertex import Gaussian, Const, UniformInt, Bernoulli, IntegerProxy
+from keanu.vertex import Gaussian, Const, UniformInt, Bernoulli, IntegerProxy, Double
 from keanu.vertex.base import Vertex
 
 
@@ -182,7 +182,7 @@ def test_java_collections_to_generator() -> None:
     java_vertex_ids = [Vertex._get_python_id(java_vertex) for java_vertex in java_collections]
 
     assert java_collections.size() == len(python_list)
-    assert all(type(element) == Vertex and element.get_id() in java_vertex_ids for element in python_list)
+    assert all(type(element) == Double and element.get_id() in java_vertex_ids for element in python_list)
 
 
 def test_get_vertex_id() -> None:


### PR DESCRIPTION
Bug raised by Katie: 

In Python, proxy vertices were of type "Vertex" rather than a child class e.g. "Double". Consequently they could not be used as parents of other vertices, e.g. an AdditionVertex.