### PR TITLE
SonarQube - Iterating on entrySet() instead of keySet() when key and value are needed

### DIFF
--- a/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
+++ b/codegen/src/main/java/io/improbable/keanu/codegen/python/DocString.java
@@ -1,8 +1,8 @@
 package io.improbable.keanu.codegen.python;
 
 import org.apache.commons.lang3.StringUtils;
-
 import java.util.Map;
+import java.util.Map.Entry;
 
 public class DocString {
     private static final String THREE_QUOTES = "\"\"\"";
@@ -32,12 +32,12 @@ public class DocString {
         stringBuilder.append(NEW_LINE_TAB);
         stringBuilder.append(methodDescription.replaceAll("\n ", NEW_LINE_TAB));
         stringBuilder.append(NEW_LINE_TAB);
-        for (String param : parameterNameToDescriptionMap.keySet()) {
+        for (Entry<String, String> entry : parameterNameToDescriptionMap.entrySet()) {
             stringBuilder.append(NEW_LINE_TAB);
             stringBuilder.append(":param ");
-            stringBuilder.append(param);
+            stringBuilder.append(entry.getKey());
             stringBuilder.append(": ");
-            stringBuilder.append(parameterNameToDescriptionMap.get(param));
+            stringBuilder.append(entry.getValue());
         }
         stringBuilder.append(NEW_LINE_TAB);
         stringBuilder.append(THREE_QUOTES);

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/AdaptiveQuadraticPotential.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/AdaptiveQuadraticPotential.java
@@ -5,15 +5,14 @@ import io.improbable.keanu.KeanuRandom;
 import io.improbable.keanu.algorithms.VariableReference;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import lombok.Getter;
-
 import java.util.HashMap;
 import java.util.Map;
-
 import static io.improbable.keanu.algorithms.mcmc.nuts.VariableValues.dotProduct;
 import static io.improbable.keanu.algorithms.mcmc.nuts.VariableValues.pow;
 import static io.improbable.keanu.algorithms.mcmc.nuts.VariableValues.times;
 import static io.improbable.keanu.algorithms.mcmc.nuts.VariableValues.withShape;
 import static io.improbable.keanu.algorithms.mcmc.nuts.VariableValues.zeros;
+import java.util.Map.Entry;
 
 
 public class AdaptiveQuadraticPotential implements Potential {
@@ -82,15 +81,15 @@ public class AdaptiveQuadraticPotential implements Potential {
     public Map<VariableReference, DoubleTensor> randomMomentum(KeanuRandom random) {
 
         Map<VariableReference, DoubleTensor> result = new HashMap<>();
-        for (VariableReference variable : standardDeviation.keySet()) {
+        for (Entry<VariableReference, DoubleTensor> entry : standardDeviation.entrySet()) {
 
-            DoubleTensor standardDeviationForVariable = standardDeviation.get(variable);
+            DoubleTensor standardDeviationForVariable = entry.getValue();
 
             DoubleTensor randomForVariable = random
                 .nextGaussian(standardDeviationForVariable.getShape())
                 .divInPlace(standardDeviationForVariable);
 
-            result.put(variable, randomForVariable);
+            result.put(entry.getKey(), randomForVariable);
         }
 
         return result;

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/LeapfrogIntegrator.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/LeapfrogIntegrator.java
@@ -4,9 +4,9 @@ import io.improbable.keanu.algorithms.ProbabilisticModelWithGradient;
 import io.improbable.keanu.algorithms.VariableReference;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import lombok.AllArgsConstructor;
-
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 @AllArgsConstructor
 public class LeapfrogIntegrator {
@@ -45,14 +45,14 @@ public class LeapfrogIntegrator {
 
         Map<VariableReference, DoubleTensor> nextPosition = new HashMap<>();
 
-        for (VariableReference variableReference : position.keySet()) {
+        for (Entry<VariableReference, DoubleTensor> entry : position.entrySet()) {
 
-            final DoubleTensor variablePosition = position.get(variableReference);
-            final DoubleTensor variableVelocity = velocity.get(variableReference);
+            final DoubleTensor variablePosition = entry.getValue();
+            final DoubleTensor variableVelocity = velocity.get(entry.getKey());
 
             final DoubleTensor nextPositionForLatent = variableVelocity.times(dt).plusInPlace(variablePosition);
 
-            nextPosition.put(variableReference, nextPositionForLatent);
+            nextPosition.put(entry.getKey(), nextPositionForLatent);
         }
 
         return nextPosition;

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/Tree.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/Tree.java
@@ -9,12 +9,11 @@ import io.improbable.keanu.tensor.dbl.DoubleTensor;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
-
 import java.util.List;
 import java.util.Map;
-
 import static io.improbable.keanu.algorithms.mcmc.SamplingAlgorithm.takeSample;
 import static io.improbable.keanu.algorithms.mcmc.nuts.VariableValues.add;
+import java.util.Map.Entry;
 
 
 /**
@@ -336,11 +335,11 @@ class Tree {
         double forward = 0.0;
         double backward = 0.0;
 
-        for (VariableReference latentId : velocityForward.keySet()) {
+        for (Entry<VariableReference, DoubleTensor> entry : velocityForward.entrySet()) {
 
-            final DoubleTensor vForward = velocityForward.get(latentId);
-            final DoubleTensor vBackward = velocityBackward.get(latentId);
-            final DoubleTensor rhoForLatent = rho.get(latentId);
+            final DoubleTensor vForward = entry.getValue();
+            final DoubleTensor vBackward = velocityBackward.get(entry.getKey());
+            final DoubleTensor rhoForLatent = rho.get(entry.getKey());
 
             forward += vForward.times(rhoForLatent).sum();
             backward += vBackward.times(rhoForLatent).sum();

--- a/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/VariableValues.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/algorithms/mcmc/nuts/VariableValues.java
@@ -2,9 +2,9 @@ package io.improbable.keanu.algorithms.mcmc.nuts;
 
 import io.improbable.keanu.algorithms.VariableReference;
 import io.improbable.keanu.tensor.dbl.DoubleTensor;
-
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 public class VariableValues {
 
@@ -13,56 +13,56 @@ public class VariableValues {
 
     public static double dotProduct(Map<? extends VariableReference, DoubleTensor> left, Map<? extends VariableReference, DoubleTensor> right) {
         double dotProduct = 0.0;
-        for (VariableReference v : left.keySet()) {
-            dotProduct += left.get(v).times(right.get(v)).sum();
+        for (Entry<? extends VariableReference, DoubleTensor> entry : left.entrySet()) {
+            dotProduct += entry.getValue().times(right.get(entry.getKey())).sum();
         }
         return dotProduct;
     }
 
     public static Map<VariableReference, DoubleTensor> pow(Map<VariableReference, DoubleTensor> values, double exponent) {
         Map<VariableReference, DoubleTensor> result = new HashMap<>();
-        for (VariableReference v : values.keySet()) {
-            result.put(v, values.get(v).pow(exponent));
+        for (Entry<VariableReference, DoubleTensor> entry : values.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().pow(exponent));
         }
         return result;
     }
 
     public static Map<VariableReference, DoubleTensor> divide(Map<VariableReference, DoubleTensor> left, double right) {
         Map<VariableReference, DoubleTensor> result = new HashMap<>();
-        for (VariableReference v : left.keySet()) {
-            result.put(v, left.get(v).div(right));
+        for (Entry<VariableReference, DoubleTensor> entry : left.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().div(right));
         }
         return result;
     }
 
     public static Map<VariableReference, DoubleTensor> times(Map<VariableReference, DoubleTensor> left, double right) {
         Map<VariableReference, DoubleTensor> result = new HashMap<>();
-        for (VariableReference v : left.keySet()) {
-            result.put(v, left.get(v).times(right));
+        for (Entry<VariableReference, DoubleTensor> entry : left.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().times(right));
         }
         return result;
     }
 
     public static Map<VariableReference, DoubleTensor> times(Map<VariableReference, DoubleTensor> left, Map<VariableReference, DoubleTensor> right) {
         Map<VariableReference, DoubleTensor> result = new HashMap<>();
-        for (VariableReference v : left.keySet()) {
-            result.put(v, left.get(v).times(right.get(v)));
+        for (Entry<VariableReference, DoubleTensor> entry : left.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().times(right.get(entry.getKey())));
         }
         return result;
     }
 
     public static Map<VariableReference, DoubleTensor> add(Map<VariableReference, DoubleTensor> left, Map<VariableReference, DoubleTensor> right) {
         Map<VariableReference, DoubleTensor> result = new HashMap<>();
-        for (VariableReference v : left.keySet()) {
-            result.put(v, left.get(v).plus(right.get(v)));
+        for (Entry<VariableReference, DoubleTensor> entry : left.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().plus(right.get(entry.getKey())));
         }
         return result;
     }
 
     public static Map<VariableReference, DoubleTensor> withShape(double value, Map<VariableReference, DoubleTensor> shapeLike) {
         Map<VariableReference, DoubleTensor> result = new HashMap<>();
-        for (VariableReference v : shapeLike.keySet()) {
-            result.put(v, DoubleTensor.create(value, shapeLike.get(v).getShape()));
+        for (Entry<VariableReference, DoubleTensor> entry : shapeLike.entrySet()) {
+            result.put(entry.getKey(), DoubleTensor.create(value, entry.getValue().getShape()));
         }
         return result;
     }

--- a/keanu-project/src/main/java/io/improbable/keanu/network/NetworkSnapshot.java
+++ b/keanu-project/src/main/java/io/improbable/keanu/network/NetworkSnapshot.java
@@ -2,11 +2,11 @@ package io.improbable.keanu.network;
 
 import io.improbable.keanu.vertices.Vertex;
 import io.improbable.keanu.vertices.VertexState;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.Map.Entry;
 
 /**
  * Saves the state (value and observed) of a specified collection of variables.
@@ -30,8 +30,8 @@ public class NetworkSnapshot {
      * Revert the state of the network to the previously saved state
      */
     public void apply() {
-        for (Vertex v : vertexStates.keySet()) {
-            v.setState(vertexStates.get(v));
+        for (Entry<Vertex, VertexState> entry : vertexStates.entrySet()) {
+            v.setState(entry.getValue());
         }
     }
 


### PR DESCRIPTION
Iterating on a Map using `entrySet()`, when both key and value are needed, is more performant.

Fixes SonarQube violations of the rule: ["entrySet()" should be iterated when both the key and value are needed](https://rules.sonarsource.com/java/RSPEC-2864)