### PR TITLE
New buildkite queue since Feb 2019

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -29,7 +29,7 @@ windows: &windows
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v2-1550748015-b6a7d7f9ae5dbf04-------z}"
+    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v3-1561705708-f00efba34de7ca20-------z}"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.


### PR DESCRIPTION
The following are the PRs that have caused changes between queue "b6a7d7f9ae5dbf04" and "HEAD".

**If you're unfamiliar** with buildkite/build-capabilities/queues, please see:

* [Concept: build-capability](https://github.com/improbable/platform/blob/master/docs/product-groups/dev-workflow/buildkite/concept-build-capability.md)
* [Concept: queue](https://github.com/improbable/platform/blob/master/docs/product-groups/dev-workflow/buildkite/concept-queue.md)

## Changes within "packer/improbable.io/buildkite":

* ENG-1804: FastBuild regional managed instance group  https://github.com/improbable/platform/pull/11811
* Suppress MBs of ngen output from logs  https://github.com/improbable/platform/pull/11783
* ENG-1772 imp-vault works within anka!   https://github.com/improbable/platform/pull/11767
* gsutil runs under root  https://github.com/improbable/platform/pull/11724
* Ansible: Run Fastbuild under service acct + fix params  https://github.com/improbable/platform/pull/11761
* Remove rollout hack now we have pipelines for rolling out workloads  https://github.com/improbable/platform/pull/11726
* BK: Read environment from BK metadata since it is specified in all modern steps files  https://github.com/improbable/platform/pull/11632
* ENG-1729: Latest major win32-openssh release. WCPGW?  https://github.com/improbable/platform/pull/11710
* Update ansible/vagrant readme.md  https://github.com/improbable/platform/pull/11708
* Ansible: Fastbuild role which installs fbuild and fbuildworker service  https://github.com/improbable/platform/pull/11680
* Utility scripts for iterating on Ansible via Vagrant  https://github.com/improbable/platform/pull/11670
* Docs githup force push  https://github.com/improbable/platform/pull/11664
* Ansible: Add sysinternals to System PATH  https://github.com/improbable/platform/pull/11655
* ENG-1729: Swap over to using win32-openssh for baking  https://github.com/improbable/platform/pull/11613
* New buildkite-agent 3.13.0  https://github.com/improbable/platform/pull/11624
* ENG-1783: Fix ssh-agent failure to restart after exiting  https://github.com/improbable/platform/pull/11623
* ENG-1729: Set up win32-openssh on Windows ahead of swapping to it.  https://github.com/improbable/platform/pull/11600
* ENG-683 BK: Turn windows-updates and ngen back on.  https://github.com/improbable/platform/pull/11553
* Add agent_count=8 variable to osx bake.  https://github.com/improbable/platform/pull/11579
* ENG-1677: spawn parameter is now pulled from meta-data  https://github.com/improbable/platform/pull/11241
* run-3382 add fabric build capability  https://github.com/improbable/platform/pull/11476
* Drive by changes and improvements to macos  https://github.com/improbable/platform/pull/11486
* NWX: Install additional required dependencies  https://github.com/improbable/platform/pull/11526
* BK: Ubuntu 16.04 LTS released git 2.22, removing old package  https://github.com/improbable/platform/pull/11532
* ENG-1694: Take care of ansible 2.8 deprecations  https://github.com/improbable/platform/pull/11422
* ENG-1768: Create the temp dir on Windows correctly  https://github.com/improbable/platform/pull/11487
* ENG-1455: Bring forward the bakery pipeline changes of Windows 2019  https://github.com/improbable/platform/pull/10573
* Bakery: Packer logs have timestamps and less redundant color  https://github.com/improbable/platform/pull/11433
* Windows Bakery: improve powershell startup time, ansible benefits dramatically  https://github.com/improbable/platform/pull/11432
* ENG-1328: Pre-factor of the bakery pipeline to better support per-pipeline defaults  https://github.com/improbable/platform/pull/11424
* Ansible: Install newer version of clang in gdk build capability  https://github.com/improbable/platform/pull/11339
* Ansible: Improve performance of buildkite-agent/hooks role  https://github.com/improbable/platform/pull/11335
* ENG-1734: Set up stackdriver metrics + logs  https://github.com/improbable/platform/pull/11347
* UNR-1492: Unreal needs .NET 4.6.2 SDK.  https://github.com/improbable/platform/pull/11334
* BAU: Remove ansible GCE plugin since I think I was the only person to ever use it.  https://github.com/improbable/platform/pull/11307
* BK: BAU update ansible to latest release  https://github.com/improbable/platform/pull/11298
* Ansible: Faster baseline role chocolatey installation  https://github.com/improbable/platform/pull/11285
* Local iteration scripts for building a base image and canary  https://github.com/improbable/platform/pull/10914
* MacOS agents are builder perm set  https://github.com/improbable/platform/pull/10910
* Share 'unreal_download_clang' role between NWX and Unreal GDK build capability  https://github.com/improbable/platform/pull/11129
* Ansible: Consolidate buildkite-agent hook creation tasks  https://github.com/improbable/platform/pull/11112
* Ansible: Consolidate tasks in baseline role  https://github.com/improbable/platform/pull/11114
* BK: Fix trailing whitespace to fix ansible-lint  https://github.com/improbable/platform/pull/11096
* Add Windows Online Services capability  https://github.com/improbable/platform/pull/10813
* ENG-1637: Extract all the operability stuff to its own role  https://github.com/improbable/platform/pull/10389
* Driveby: get back onto unpinned chocolatey for windows bakes  https://github.com/improbable/platform/pull/11057
* Driveby - noticed we're no longer using this build output  https://github.com/improbable/platform/pull/11052
* ENG-1677: set BUILDKITE_AGENT_SPAWN environment variable on buildkite linux from metadata.  https://github.com/improbable/platform/pull/10866
* BK, ansible-lint - Make the pip packages be installed within the container for 1m speed improvement  https://github.com/improbable/platform/pull/10967
* EF-919: FYS docs for reusable ansible roles  https://github.com/improbable/platform/pull/10937
* Decouple ansible-lint from infra-ci container.  https://github.com/improbable/platform/pull/10870
* Ansible: Add callback plugin to profile playbooks  https://github.com/improbable/platform/pull/10889
* Ansible: Actually use ansible.cfg on Windows  https://github.com/improbable/platform/pull/10906
* BK: Lint the ansible roles too.  https://github.com/improbable/platform/pull/10864
* Update imp-tool version to 20190528.135640.233fbf467c.  https://github.com/improbable/platform/pull/10827
* Annotate bakes with vars used  https://github.com/improbable/platform/pull/10810
* NWX build-capability: include 7zip  https://github.com/improbable/platform/pull/10754
* Latest docker for platform build capability  https://github.com/improbable/platform/pull/10785
* ENG-1618: Update to ansible 2.8.0 so we can move toward windows openssh for remote connection  https://github.com/improbable/platform/pull/10727
* Remove non-ascii characters  https://github.com/improbable/platform/pull/10767
* Strip Worker SDK capability of all requirements but docker.  https://github.com/improbable/platform/pull/10743
* ENG-1645 Use agent_count from image labels to make scaling decisions  https://github.com/improbable/platform/pull/10687
* Pin a new version of imp-tool-bootstrap  https://github.com/improbable/platform/pull/10714
* Remove now redundant clusters.git simlink in packer  https://github.com/improbable/platform/pull/10652
* Pin new imp-tool bootstrap  https://github.com/improbable/platform/pull/10619
* SSd conditional failed to run on mac  https://github.com/improbable/platform/pull/10615
* ENG-1362: Use windows environment variable when fetching robot-at-improbable-io from vault.  https://github.com/improbable/platform/pull/10618
* Upgrade unity dependency to 2019.1.3f1  https://github.com/improbable/platform/pull/10608
* ENG-1362: Remove environment_name from ansible completely.  https://github.com/improbable/platform/pull/10592
* ENG-1362: Remove deprecated environment_name (in favour of $CI_ENVIRONMENT) from unity and unreal ansible playbooks.  https://github.com/improbable/platform/pull/10575
* ENG-1362: Remove environment_name from ansible roles that do not need it.  https://github.com/improbable/platform/pull/10571
* ENG-1362: remove environment name from buildkite-agent, source_control_perforce and source_control_git roles.  https://github.com/improbable/platform/pull/10556
* ENG-1362: Do not use environment goss variable in goss tests, because no tests are using that anymore.  https://github.com/improbable/platform/pull/10545
* Do not use baked-in environment in logstash.  https://github.com/improbable/platform/pull/10535
* Release new version of imp-tool-bootstrap.  https://github.com/improbable/platform/pull/10520
* ENG-1375: Make gcs_artifacts_root and proxy_host not be a bake time variable, but depend on $CI_ENVIRONMENT (on linux).  https://github.com/improbable/platform/pull/10450
* ENG-1362: set CI_ENVIRONMENT via windows on-boot task and during the bake time.  https://github.com/improbable/platform/pull/10453
* BK: Be on latest 2.7.x ansible patch release  https://github.com/improbable/platform/pull/10461
* ENG-1472: Every BC _can_ have local-ssds  https://github.com/improbable/platform/pull/10343
* ENG-1652 simplify ansible perforce role  https://github.com/improbable/platform/pull/10445
* ENG-1603 Anka bakery script now uploads VM to registry  https://github.com/improbable/platform/pull/10427
* buildkite agent hooks don't fail vs non-git checkouts  https://github.com/improbable/platform/pull/10419
* ENG-1375: generate goss file with environment via fetch_environment role.  https://github.com/improbable/platform/pull/10418
* Ansible: Add perforce role to NWX build capability  https://github.com/improbable/platform/pull/10407
* Ansible: Run oneshot service to retrieve perforce credentials  https://github.com/improbable/platform/pull/10372
* Ansible: Perforce role fix p4ticket.txt encoding  https://github.com/improbable/platform/pull/10409
* ENG-1362: modify /etc/environment via systemd using imp-ci fetch-metadata.  https://github.com/improbable/platform/pull/10260
* Pin new imp-tool  https://github.com/improbable/platform/pull/10379
* Ansible: Explicitly install python/pip on debian for perforce role  https://github.com/improbable/platform/pull/10366
* Fix logstash goss test  https://github.com/improbable/platform/pull/10374
* BK: when integration tests fail the buffer fills up when it's only 5k.  https://github.com/improbable/platform/pull/10327
* Use latest BuildKite agent release  https://github.com/improbable/platform/pull/10359
* Fix trigger-pipelines bakes  https://github.com/improbable/platform/pull/10340
* Turn on host labels  https://github.com/improbable/platform/pull/10332
* Ansible galaxy install --force in bakery pipeline.  https://github.com/improbable/platform/pull/10325
* ENG-1365 + ENG-1468 Consistent labelling  https://github.com/improbable/platform/pull/10103
* Ansible: Install p4python dependencies as part of source_control_perforce role  https://github.com/improbable/platform/pull/10301
* Set BUILDKITE_PTY=false for toolshare v1 and v2 pipelines.  https://github.com/improbable/platform/pull/10290
* BK: Driveby update to packer 1.4.0 inside bakery.  https://github.com/improbable/platform/pull/10249
* Add comment explaining the windows docker version and package name formats  https://github.com/improbable/platform/pull/10282
* Ansible: Install libssl-dev as part of source_control_perforce role  https://github.com/improbable/platform/pull/10248
* ENG-1276: New platform/windows/builder  https://github.com/improbable/platform/pull/10242
* ENG-1276: Log _everything_ to ELK, not just command hook.  https://github.com/improbable/platform/pull/10194
* ENG-1609 Ansible: Install perforce cli on Debian and Darwin  https://github.com/improbable/platform/pull/10208
* nwx-services build capability  https://github.com/improbable/platform/pull/10185
* Ansible: Perforce credential provisioning for Debian  https://github.com/improbable/platform/pull/10136
* Ansible: fix perforce credential provisioning on Windows  https://github.com/improbable/platform/pull/10172
* Ansible perforce role: move ps1 script out of templates folder  https://github.com/improbable/platform/pull/10135
* EF-109: Further git issue hunting + docs  https://github.com/improbable/platform/pull/10138
* ENG-1607 Allow plugins in buildkite pipelines  https://github.com/improbable/platform/pull/10096
* WF-586: Fix git cloning on Windows buildkite-agent  https://github.com/improbable/platform/pull/10071
* ENG-1434 BK local pipeline  https://github.com/improbable/platform/pull/9844
* WF-586 add support for windows setup of docker gcr authentication  https://github.com/improbable/platform/pull/9679
* ENG-796: Add a simple MVP goss test to a windows buildkite-agent role.  https://github.com/improbable/platform/pull/9991
* Revert "ENG-796: Add a simple MVP goss test to a windows buildkite-agent role. (#9828)"  https://github.com/improbable/platform/pull/9946
* ENG-796: Add a simple MVP goss test to a windows buildkite-agent role.  https://github.com/improbable/platform/pull/9828
* update imp-tool-bootstrap version  https://github.com/improbable/platform/pull/9928
* WRK-1083 | Create `everything` build capability for Bazel build on Linux  https://github.com/improbable/platform/pull/9739
* bump  https://github.com/improbable/platform/pull/9703
* Update bootstrap version of imp-tool  https://github.com/improbable/platform/pull/9833
* BK: Add some more details to troubleshooting unity license issues  https://github.com/improbable/platform/pull/9824
* I don't know why we this file is being touched  https://github.com/improbable/platform/pull/9778
* ENG-1483: Squash a bash script in favour of golang.  https://github.com/improbable/platform/pull/9343
* WF-586 configure docker and go to be runnable by the buildkite agent user  https://github.com/improbable/platform/pull/9772
* BK: Correct online-services goss tests & document.  https://github.com/improbable/platform/pull/9688
* BK: notice bash logs are using dead function  https://github.com/improbable/platform/pull/9775
* ENG-1434 - Using ansible local run instead of ssh provisioning  https://github.com/improbable/platform/pull/9750
* Cache Ansible (pip) Requirements  https://github.com/improbable/platform/pull/9695
* EF-109: Add git mirror support to the bk agent flags  https://github.com/improbable/platform/pull/9692
* ENG-1155 BuildKite SSH Connectivity Race  https://github.com/improbable/platform/pull/9663
* Update bk agent to 3.10.4  https://github.com/improbable/platform/pull/9686
* Upgrade pinned version of imp-tool  https://github.com/improbable/platform/pull/9657
* WF-586 add windows support to install docker in platform build-capability  https://github.com/improbable/platform/pull/9454
* Draft bakery scripts for local macos bakes using anka  https://github.com/improbable/platform/pull/8979
* Fixes to bk local run in bakery pipeline.  https://github.com/improbable/platform/pull/9578
* Do not download imp-ci in build-image.sh, because it is not necessary.  https://github.com/improbable/platform/pull/9589
* VAL-196: Add build capability for the State Space Explorer  https://github.com/improbable/platform/pull/7660
* More progress in `bk local run` with windows bakery pipeline.  https://github.com/improbable/platform/pull/9047
* WF-586 add windows support for step to install go for platform build-capability  https://github.com/improbable/platform/pull/9401
* BK Un-pin apt-transport-https  https://github.com/improbable/platform/pull/9421
* Docker ci upgrade  https://github.com/improbable/platform/pull/9315
* ENG-1463: Pin to version of chocolatey compatible with our ansible.  https://github.com/improbable/platform/pull/9230
* ENG-1460: Fix buildkite agent double tag inclusion  https://github.com/improbable/platform/pull/9244
* Fix invalid startup of ssh-agent when socket exists because baking leaves it there.  https://github.com/improbable/platform/pull/9234
* Quiet down terraform init in build-cloud.sh  https://github.com/improbable/platform/pull/9214
* ENG-945: Only generate necessary keypairs, and only store the artifact proxy secret in vault.  https://github.com/improbable/platform/pull/9076
* Update imp-tool-bootstrap version to the one that includes `subscribe --tools`.  https://github.com/improbable/platform/pull/8932
* Update imp-tool bootstrap version to 20190311.101729.57b4634585.  https://github.com/improbable/platform/pull/8903
* Update imp-tool-bootstrap version in platform.git docs.  https://github.com/improbable/platform/pull/8854
* Eng fix buildkite ansible  https://github.com/improbable/platform/pull/8852
* Add more quotes and fix the one-shot service installation  https://github.com/improbable/platform/pull/8846
* Tweaks to fix the local-ssd mount script in some cases.  https://github.com/improbable/platform/pull/8843
* Upgrade to golang 1.11.5 from 1.10.something  https://github.com/improbable/platform/pull/8671
* fixing staleness, works on macstadium  https://github.com/improbable/platform/pull/8770
* Update unreal agents to latest toolbelt version  https://github.com/improbable/platform/pull/8738
* ENG-1296: Adjust buildkite-agent process management to use --spawn  https://github.com/improbable/platform/pull/8630
* Make build-cloud able to deploy terraform without a human present.  https://github.com/improbable/platform/pull/8729
* Fix goss test.  https://github.com/improbable/platform/pull/8730
* Fix environment hook on Windows  https://github.com/improbable/platform/pull/8720
* Fix baking with a local SSD  https://github.com/improbable/platform/pull/8680
* Fix trigger-pipelines queue with if, not elif  https://github.com/improbable/platform/pull/8677
* ENG-1259: Fix missing var  https://github.com/improbable/platform/pull/8674
* ENG-1259: Add Linux support for local SSDs  https://github.com/improbable/platform/pull/8534
* BK drive-by: latest agent version  https://github.com/improbable/platform/pull/8628
* ENG-1275: Link to a new CI Health dashboard  https://github.com/improbable/platform/pull/8605
* ENG-1287: Add an isolated temp dir in the BuildKite agent environment hook  https://github.com/improbable/platform/pull/8568
* BK git: dammit.  https://github.com/improbable/platform/pull/8626
* BK driveby - new git.  https://github.com/improbable/platform/pull/8624
* Update imp-tool-bootstrap version.  https://github.com/improbable/platform/pull/8588
* set folder to staff  https://github.com/improbable/platform/pull/8422
* dont sleep and brew install vault  https://github.com/improbable/platform/pull/8533

## Changes within "go/src/improbable.io/cmd/imp-ci":

* Driveby; change how we attempt to release unity licenses  https://github.com/improbable/platform/pull/11674
* ENG-1480: Fix buildkite artifact proxy link generation  https://github.com/improbable/platform/pull/11630
* add fabric bakery post image ownership  https://github.com/improbable/platform/pull/11591
* BK: BAU It's safe to keep a canary's image  https://github.com/improbable/platform/pull/11586
* Improve messaging of promote-without-attribution outcome  https://github.com/improbable/platform/pull/11583
* ENG-1455: Bring forward the bakery pipeline changes of Windows 2019  https://github.com/improbable/platform/pull/10573
* imp-ci wrap: include elapsed_s in log  https://github.com/improbable/platform/pull/11434
* ENG-1734: Set up stackdriver metrics + logs  https://github.com/improbable/platform/pull/11347
* fix attribution  https://github.com/improbable/platform/pull/11367
* Enable buildkite-agent 3.12.0 for our artifact-proxy  https://github.com/improbable/platform/pull/11238
* Unified secrets for alertmanager and its qualifier  https://github.com/improbable/platform/pull/10905
* add dependabot to the imp-ci ensure-authorised security filter  https://github.com/improbable/platform/pull/10913
* ENG-1362: Make environment be a canary property  https://github.com/improbable/platform/pull/10677
* ENG-1362: Remove deprecated environment_name (in favour of $CI_ENVIRONMENT) from unity and unreal ansible playbooks.  https://github.com/improbable/platform/pull/10575
* ENG-1661: fix circle local presubmit hanging on lagre PRs by fixing how imp-ci processes input.  https://github.com/improbable/platform/pull/10548
* Make our buildkite stuff more compatible with `bk local run`.  https://github.com/improbable/platform/pull/10508
* Set image-environment to be production by default in imp-ci bakery post-image.  https://github.com/improbable/platform/pull/10505
* Fix trigger-pipelines bakes  https://github.com/improbable/platform/pull/10340
* ENG-1362 move fetch-metadata command from imp-ci to imp-tool, because we have to fetch metadata before we use imp-ci (imp-tool is now our only option).  https://github.com/improbable/platform/pull/10293
* ENG-1365 + ENG-1468 Consistent labelling  https://github.com/improbable/platform/pull/10103
* ENG-1362: implement imp-ci fetch-metadata command.  https://github.com/improbable/platform/pull/10235
* nwx-services build capability  https://github.com/improbable/platform/pull/10185
* WF-586 add support for windows setup of docker gcr authentication  https://github.com/improbable/platform/pull/9679
* fixed windows annotation template  https://github.com/improbable/platform/pull/9990
* BK: worker-sdk ownership  https://github.com/improbable/platform/pull/9936
* Bakery - Update metadata flag for unity  https://github.com/improbable/platform/pull/9713
* ENG-1470: fix number 3  https://github.com/improbable/platform/pull/9838
* ENG-1470: Update ancient version of gcloud to one that has the command needed in bakery  https://github.com/improbable/platform/pull/9812
* ENG-1483: Squash a bash script in favour of golang.  https://github.com/improbable/platform/pull/9343
* Fix mismatch in role attempted vs actual name  https://github.com/improbable/platform/pull/9781
* ENG-1470: Self-service canary start-up  https://github.com/improbable/platform/pull/9693
* VAL-196: Add build capability for the State Space Explorer  https://github.com/improbable/platform/pull/7660
* [ENG-1418] Fix imp-ci panic when build started without message  https://github.com/improbable/platform/pull/9432
* ENG-1481: Fix value handling with defaults.  https://github.com/improbable/platform/pull/9307
* ENG-1471: Expose BK canary ssh ports globally  https://github.com/improbable/platform/pull/9260
* Pretty logs from imp-ci inside CI  https://github.com/improbable/platform/pull/9155
* ENG-1281: Fix for generated trigger-pipeline  https://github.com/improbable/platform/pull/9153
* Fix BK release process so we don't push all tags indiscriminately again.  https://github.com/improbable/platform/pull/9025
* ENG-1281: imp-ci steps upload --from <paths/globs>  https://github.com/improbable/platform/pull/8902
* Expand ownership to EV team  https://github.com/improbable/platform/pull/8905
* FYS: improve logging in BK wrapper  https://github.com/improbable/platform/pull/8885
* ENG-1296: Reflect agent-count into the labels for scaler  https://github.com/improbable/platform/pull/8741
* COMP-549 Set up the sim node bake pipeline  https://github.com/improbable/platform/pull/8433
* ENG-1274: time BK step durations for later analysis  https://github.com/improbable/platform/pull/8580
* ENG-1275: Link to a new CI Health dashboard  https://github.com/improbable/platform/pull/8605
* ENG-1347: Use the zone function instead of incorrectly calling a region a zone.  https://github.com/improbable/platform/pull/8518

## Changes within "go/src/improbable.io/cmd/imp-vault":

* Unified secrets for alertmanager and its qualifier  https://github.com/improbable/platform/pull/10905
* COMP-1696: modify imp-vault code to use the latest experiment environment - part one  https://github.com/improbable/platform/pull/10749