### PR TITLE
Fix incorrect pipeline permissions

### DIFF
--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -7,5 +7,5 @@ github:
 teams:
 - name: Everyone
   permission: BUILD_AND_READ
-- name: ebu/graphos-engineering
+- name: ior/simx
   permission: MANAGE_BUILD_AND_READ

--- a/.buildkite/release-python.definition.yaml
+++ b/.buildkite/release-python.definition.yaml
@@ -8,5 +8,5 @@ github:
 teams:
 - name: Everyone
   permission: BUILD_AND_READ
-- name: ebu/graphos-engineering
+- name: ior/simx
   permission: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
Updating the pipeline definition to match the perms set in the BuildKite pipeline.

This was manually changed in the BK UI.  Please don't do that.

See [here](https://docs.improbable.io/internal/platform/product-groups/dev-workflow/buildkite/how-to-create-a-new-pipeline#update-a-pipeline) for the correct way to do this.